### PR TITLE
fix: Move `simple-git-hooks` to prepare hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,8 +18,7 @@
     "format": "biome format --write",
     "lint": "biome lint",
     "lint:fix": "biome lint --fix",
-    "prepare": "build",
-    "postinstall": "simple-git-hooks",
+    "prepare": "npm run build && simple-git-hooks",
     "test": "vitest"
   },
   "repository": {


### PR DESCRIPTION
When installing vitest-evals in project without `simple-git-hooks` installed as a dependency, the installation fails:

```sh
npm ERR! code 127
npm ERR! path /Users/csparks/test/node_modules/vitest-evals
npm ERR! command failed
npm ERR! command sh -c simple-git-hooks
npm ERR! sh: simple-git-hooks: command not found

npm ERR! A complete log of this run can be found in: /Users/csparks/.npm/_logs/2025-04-14T18_36_25_966Z-debug-0.log
```

To fix:
* Moved `simple-git-hooks` to the prepare lifecycle hook 
* Fixed an issue that I ran into in local dev (`build` isn't a valid command, changed to `npm run build`) in the prepare hook 

I'm not an expert in publishing npm packages, but I validated by installing the tarball from `npm pack` in an node project without `simple-git-hooks` installed, so this should work.