### PR TITLE
fix: postinstall should not contain dev env setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "lint": "biome lint",
     "lint:fix": "biome lint --fix",
     "prepare": "npm run build && simple-git-hooks",
-    "postinstall": "simple-git-hooks",
     "test": "dotenv -e .env -e .env.local -- vitest --reporter=./src/reporter.ts",
     "test:ci": "dotenv -e .env -e .env.local -- vitest run --coverage --reporter=./src/reporter.ts --reporter=junit --outputFile=tests.junit.xml"
   },


### PR DESCRIPTION
`postinstall` runs after the user installs the package causing issues since `simple-git-hooks` is not installed:

![CleanShot 2025-06-27 at 16 32 50](https://github.com/user-attachments/assets/f75526fb-8535-4095-97f0-8441653e7fb0)

You already have `prepare` which runs when you run `pnpm install` inside the repo that accomplishes what you want:

![CleanShot 2025-06-27 at 16 35 31](https://github.com/user-attachments/assets/937a0e06-e2fa-4a76-b9f9-b28b7b4ae3aa)
