### PR TITLE
ci(release): Prevent command injection in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,11 +51,13 @@ jobs:
 
     - name: Calculate version
       id: version
+      env:
+        BUMP: ${{ inputs.bump }}
       run: |
         CURRENT=$(node -p "require('./package.json').version")
-        NEW=$(npx semver -i ${{ inputs.bump }} $CURRENT)
-        echo "current=$CURRENT" >> $GITHUB_OUTPUT
-        echo "new=$NEW" >> $GITHUB_OUTPUT
+        NEW=$(npx semver -i "$BUMP" "$CURRENT")
+        echo "current=$CURRENT" >> "$GITHUB_OUTPUT"
+        echo "new=$NEW" >> "$GITHUB_OUTPUT"
 
     - name: Prepare release
       uses: getsentry/action-prepare-release@v1


### PR DESCRIPTION
Move the release workflow's `workflow_dispatch` bump input into an environment variable before using it in the shell script. This prevents direct GitHub expression interpolation from turning an input value into executable shell syntax.

Refs https://github.com/getsentry/warden/pull/277