### PR TITLE
feat(harnesses): Pass run context to agent factories

### DIFF
--- a/packages/harness-ai-sdk/README.md
+++ b/packages/harness-ai-sdk/README.md
@@ -68,6 +68,23 @@ const harness = aiSdkHarness({
 });
 ```
 
+If your app exposes an agent object instead, `agent` can be either that object
+or a per-run factory. Factories receive the eval input and harness context so
+input-dependent instructions, metadata, or seeded state do not require
+side-channel setup:
+
+```ts
+const harness = aiSdkHarness({
+  tools,
+  prompt: sharedJudgePrompt,
+  agent: ({ input, context }) =>
+    createRefundAgent({
+      instructions: buildInstructions(input),
+      metadata: context.metadata,
+    }),
+});
+```
+
 The required `prompt` callback is passed to harness-backed judges as
 `JudgeContext.harness.prompt`, which lets rubric or factuality judges share the
 same provider/model configuration as the suite harness.

--- a/packages/harness-ai-sdk/src/index.test.ts
+++ b/packages/harness-ai-sdk/src/index.test.ts
@@ -3,6 +3,7 @@ import { join } from "node:path";
 import type { ToolExecutionOptions } from "ai";
 import { afterEach, expect, test, vi } from "vitest";
 import { describeEval, getHarnessRunFromError, toolCalls } from "vitest-evals";
+import type { HarnessContext } from "vitest-evals/harness";
 import { z } from "zod";
 import { aiSdkHarness, type AiSdkToolset } from "./index";
 
@@ -903,6 +904,62 @@ test("creates a fresh agent for each explicit run", async () => {
 
   expect(createAgent).toHaveBeenCalledTimes(2);
   expect(run).toHaveBeenCalledTimes(2);
+});
+
+test("passes run input and context to agent factories", async () => {
+  const createAgent = vi.fn(
+    ({
+      input,
+      context,
+    }: {
+      input: string;
+      context: HarnessContext<DemoMetadata>;
+    }) => {
+      context.setArtifact("preparedInput", input);
+      const scenario = context.metadata.scenario ?? "unknown";
+
+      return {
+        run: async (runInput: string) => ({
+          object: {
+            status: "approved",
+            input: runInput,
+            preparedInput: input,
+            scenario,
+          },
+        }),
+      };
+    },
+  );
+  const harness = aiSdkHarness({
+    prompt: judgePrompt,
+    agent: createAgent,
+  });
+  const context = createHarnessContext({
+    scenario: "refund",
+  });
+
+  const result = await harness.run("Refund invoice inv_123", context);
+
+  expect(createAgent).toHaveBeenCalledWith(
+    expect.objectContaining({
+      input: "Refund invoice inv_123",
+      context: expect.objectContaining({
+        metadata: {
+          scenario: "refund",
+        },
+      }),
+    }),
+  );
+  expect(context.setArtifact).toHaveBeenCalledWith(
+    "preparedInput",
+    "Refund invoice inv_123",
+  );
+  expect(result.output).toEqual({
+    status: "approved",
+    input: "Refund invoice inv_123",
+    preparedInput: "Refund invoice inv_123",
+    scenario: "refund",
+  });
 });
 
 test("normalizes domain results that resemble harness runs", async () => {

--- a/packages/harness-ai-sdk/src/index.ts
+++ b/packages/harness-ai-sdk/src/index.ts
@@ -46,7 +46,13 @@ import type {
 } from "ai";
 
 type MaybePromise<T> = T | Promise<T>;
-type AgentSource<TAgent> = TAgent | (() => MaybePromise<TAgent>);
+type AgentSource<
+  TAgent,
+  TInput = string,
+  TMetadata extends HarnessMetadata = HarnessMetadata,
+> =
+  | TAgent
+  | ((args: AiSdkCreateAgentArgs<TInput, TMetadata>) => MaybePromise<TAgent>);
 type AnyAiSdkToolset<
   TInput = string,
   TMetadata extends HarnessMetadata = HarnessMetadata,
@@ -150,6 +156,14 @@ export interface AiSdkRuntime<
   signal?: AbortSignal;
 }
 
+export interface AiSdkCreateAgentArgs<
+  TInput = string,
+  TMetadata extends HarnessMetadata = HarnessMetadata,
+> {
+  input: TInput;
+  context: HarnessContext<TMetadata>;
+}
+
 export interface AiSdkHarnessRunArgs<
   TAgent,
   TInput,
@@ -185,7 +199,7 @@ export type AiSdkHarnessOptions<
 > = AiSdkHarnessBaseOptions<TAgent, TInput, TMetadata, TResult, TTools> &
   (
     | {
-        agent: AgentSource<TAgent>;
+        agent: AgentSource<TAgent, TInput, TMetadata>;
         task?: never;
       }
     | {
@@ -280,7 +294,10 @@ export function aiSdkHarness<
     name: options.name ?? "ai-sdk",
     prompt: options.prompt,
     run: async (input, context) => {
-      const agent = await resolveAgent(options);
+      const agent = await resolveAgent(options, {
+        input,
+        context,
+      });
       return runAiSdkHarness(options, agent, input, context);
     },
   };
@@ -420,9 +437,12 @@ async function resolveAgent<
   TMetadata extends HarnessMetadata,
   TResult,
   TTools extends AiSdkToolset<TInput, TMetadata>,
->(options: AiSdkHarnessOptions<TAgent, TInput, TMetadata, TResult, TTools>) {
+>(
+  options: AiSdkHarnessOptions<TAgent, TInput, TMetadata, TResult, TTools>,
+  args: AiSdkCreateAgentArgs<TInput, TMetadata>,
+) {
   return hasAgentSource(options)
-    ? await resolveAgentSource(options.agent)
+    ? await resolveAgentSource(options.agent, args)
     : undefined;
 }
 
@@ -490,15 +510,20 @@ function hasAgentSource<
   TMetadata,
   TResult,
   TTools
-> & { agent: AgentSource<TAgent> } {
+> & { agent: AgentSource<TAgent, TInput, TMetadata> } {
   return "agent" in options && options.agent !== undefined;
 }
 
-async function resolveAgentSource<TAgent>(
-  agent: AgentSource<TAgent>,
+async function resolveAgentSource<
+  TAgent,
+  TInput,
+  TMetadata extends HarnessMetadata,
+>(
+  agent: AgentSource<TAgent, TInput, TMetadata>,
+  args: AiSdkCreateAgentArgs<TInput, TMetadata>,
 ): Promise<TAgent> {
   if (isAgentFactory(agent)) {
-    return agent();
+    return agent(args);
   }
 
   return agent;
@@ -526,9 +551,11 @@ function hasAiSdkGenerateMethod<
   return hasCallableMethod(agent, "generate");
 }
 
-function isAgentFactory<TAgent>(
-  agent: AgentSource<TAgent>,
-): agent is () => MaybePromise<TAgent> {
+function isAgentFactory<TAgent, TInput, TMetadata extends HarnessMetadata>(
+  agent: AgentSource<TAgent, TInput, TMetadata>,
+): agent is (
+  args: AiSdkCreateAgentArgs<TInput, TMetadata>,
+) => MaybePromise<TAgent> {
   return (
     typeof agent === "function" &&
     !hasCallableMethod(agent, "run") &&

--- a/packages/harness-openai-agents/README.md
+++ b/packages/harness-openai-agents/README.md
@@ -60,6 +60,27 @@ const harness = openaiAgentsHarness({
 });
 ```
 
+`createAgent` receives the per-run input and harness context before the
+adapter instruments local function tools. Use that when an agent needs
+scenario-specific tool closures, instructions, seeded artifacts, or metadata
+while staying on the native replay path:
+
+```ts
+const harness = openaiAgentsHarness({
+  createAgent: ({ input, context }) =>
+    createClassifierAgent({
+      bottleId: parseBottleId(input),
+      metadata: context.metadata,
+      setArtifact: context.setArtifact,
+    }),
+  createRunner: () => new Runner({ modelProvider, tracingDisabled: true }),
+  prompt: sharedJudgePrompt,
+  toolReplay: {
+    lookup_bottle: true,
+  },
+});
+```
+
 The required `prompt` callback is passed to harness-backed judges as
 `JudgeContext.harness.prompt`, so rubric or factuality judges can share the
 same provider/model setup as the suite harness.
@@ -67,7 +88,8 @@ same provider/model setup as the suite harness.
 The adapter provides:
 
 - native `Runner.run(agent, input, options)` execution
-- support for existing agents or per-test `createAgent()` factories
+- support for existing agents or per-run `createAgent({ input, context })`
+  factories
 - a `run` escape hatch for app-specific entrypoints
 - normalized assistant output, messages, tool calls, tool results, usage,
   timings, errors, and replay-friendly metadata

--- a/packages/harness-openai-agents/src/index.test.ts
+++ b/packages/harness-openai-agents/src/index.test.ts
@@ -3,7 +3,7 @@ import { join } from "node:path";
 import { Agent, tool } from "@openai/agents";
 import { afterEach, expect, test, vi } from "vitest";
 import { describeEval, getHarnessRunFromError, toolCalls } from "vitest-evals";
-import type { JsonValue } from "vitest-evals/harness";
+import type { HarnessContext, JsonValue } from "vitest-evals/harness";
 import { openaiAgentsHarness, type OpenAiAgentsTool } from "./index";
 
 type DemoMetadata = {
@@ -258,6 +258,118 @@ test("exposes prompt and supports custom app output mapping", async () => {
   expect(result.artifacts).toEqual({
     entrypoint: "custom",
   });
+});
+
+test("passes run input and context to createAgent before tool instrumentation", async () => {
+  replayDir = mkdtempSync(join(process.cwd(), ".tmp-openai-agents-replay-"));
+  vi.stubEnv("VITEST_EVALS_REPLAY_MODE", "auto");
+  vi.stubEnv("VITEST_EVALS_REPLAY_DIR", replayDir);
+
+  let createdTool: OpenAiAgentsTool<string, DemoMetadata> | undefined;
+  const createAgent = vi.fn(
+    ({
+      input,
+      context,
+    }: {
+      input: string;
+      context: HarnessContext<DemoMetadata>;
+    }) => {
+      context.setArtifact("preparedInput", input);
+      const scenario = context.metadata.scenario ?? "unknown";
+      const lookupBottle = {
+        type: "function",
+        name: "lookupBottle",
+        invoke: vi.fn(async (_runContext: unknown, rawInput: unknown) => {
+          if (typeof rawInput !== "string") {
+            throw new Error("Expected JSON tool input");
+          }
+
+          const parsed = JSON.parse(rawInput) as { bottleId: string };
+          return {
+            bottleId: parsed.bottleId,
+            preparedInput: input,
+            scenario,
+          };
+        }),
+      } satisfies OpenAiAgentsTool<string, DemoMetadata>;
+
+      createdTool = lookupBottle;
+      return {
+        name: "classifier",
+        model: "gpt-4.1-mini",
+        tools: [lookupBottle],
+      } satisfies DemoAgent;
+    },
+  );
+  const runner = {
+    run: vi.fn(async (runAgent: DemoAgent, _input: string, runOptions) => {
+      expect(runAgent.tools?.[0]).not.toBe(createdTool);
+
+      const evidence = await runAgent.tools?.[0].invoke?.(
+        runOptions?.context,
+        JSON.stringify({
+          bottleId: "bt_123",
+        }),
+        {
+          toolCallId: "call_lookup",
+        },
+      );
+
+      return {
+        finalOutput: evidence,
+      };
+    }),
+  };
+  const harness = openaiAgentsHarness({
+    prompt: judgePrompt,
+    createAgent,
+    runner,
+    toolReplay: {
+      lookupBottle: true,
+    },
+  });
+
+  const result = await harness.run(
+    "Classify bottle bt_123",
+    createHarnessContext({
+      scenario: "peated",
+    }),
+  );
+
+  expect(createAgent).toHaveBeenCalledWith(
+    expect.objectContaining({
+      input: "Classify bottle bt_123",
+      context: expect.objectContaining({
+        metadata: {
+          scenario: "peated",
+        },
+      }),
+    }),
+  );
+  expect(result.artifacts).toEqual({
+    preparedInput: "Classify bottle bt_123",
+  });
+  expect(result.output).toEqual({
+    bottleId: "bt_123",
+    preparedInput: "Classify bottle bt_123",
+    scenario: "peated",
+  });
+  expect(toolCalls(result.session)).toMatchObject([
+    {
+      id: "call_lookup",
+      name: "lookupBottle",
+      result: {
+        bottleId: "bt_123",
+        preparedInput: "Classify bottle bt_123",
+        scenario: "peated",
+      },
+      metadata: {
+        replay: {
+          status: "recorded",
+        },
+      },
+    },
+  ]);
 });
 
 test("wraps OpenAI Agents function tools with replay metadata", async () => {

--- a/packages/harness-openai-agents/src/index.ts
+++ b/packages/harness-openai-agents/src/index.ts
@@ -74,6 +74,14 @@ export interface OpenAiAgentsRuntime<
   tools: OpenAiAgentsTool<TInput, TMetadata>[];
 }
 
+export interface OpenAiAgentsCreateAgentArgs<
+  TInput = string,
+  TMetadata extends HarnessMetadata = HarnessMetadata,
+> {
+  input: TInput;
+  context: HarnessContext<TMetadata>;
+}
+
 export interface OpenAiAgentsHarnessRunArgs<
   TAgent,
   TInput,
@@ -249,7 +257,9 @@ export interface OpenAiAgentsHarnessOptions<
   TContext = OpenAiAgentsRuntimeContext<TMetadata>,
 > {
   agent?: TAgent;
-  createAgent?: () => MaybePromise<TAgent>;
+  createAgent?: (
+    args: OpenAiAgentsCreateAgentArgs<TInput, TMetadata>,
+  ) => MaybePromise<TAgent>;
   runner?: TRunner;
   createRunner?: (
     args: Omit<
@@ -335,7 +345,10 @@ export function openaiAgentsHarness<
     name: options.name ?? "openai-agents",
     prompt: options.prompt,
     run: async (input, context) => {
-      const agent = await resolveAgent(options);
+      const agent = await resolveAgent(options, {
+        input,
+        context,
+      });
       return executeOpenAiAgentsHarness(options, agent, input, context);
     },
   };
@@ -586,9 +599,10 @@ async function resolveAgent<
     TResult,
     TContext
   >,
+  args: OpenAiAgentsCreateAgentArgs<TInput, TMetadata>,
 ) {
   if (options.createAgent) {
-    return options.createAgent();
+    return options.createAgent(args);
   }
 
   if (options.agent !== undefined) {

--- a/packages/harness-pi-ai/README.md
+++ b/packages/harness-pi-ai/README.md
@@ -57,6 +57,26 @@ const harness = piAiHarness({
 If the agent already implements `run(input, runtime)`, you can omit `run` and
 the harness will call that method automatically.
 
+`createAgent` receives the per-run input and harness context before the adapter
+infers and instruments native agent tools. Use that for scenario-specific
+instructions, tool closures, metadata, or seeded artifacts without leaving the
+default replay path:
+
+```ts
+const harness = piAiHarness({
+  createAgent: ({ input, context }) =>
+    createRefundAgent({
+      instructions: buildInstructions(input),
+      metadata: context.metadata,
+      setArtifact: context.setArtifact,
+    }),
+  toolReplay: {
+    lookupInvoice: true,
+  },
+  prompt: sharedJudgePrompt,
+});
+```
+
 You should not need to configure output/session/usage basics for the normal Pi
 path. Pass your agent and let the adapter infer both the toolset and the
 normalized result from common Pi-style return values such as `decision` or

--- a/packages/harness-pi-ai/src/index.test.ts
+++ b/packages/harness-pi-ai/src/index.test.ts
@@ -2,9 +2,12 @@ import { mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { afterEach, expect, test, vi } from "vitest";
 import { describeEval, getHarnessRunFromError, toolCalls } from "vitest-evals";
+import type { HarnessContext, JsonValue } from "vitest-evals/harness";
 import { piAiHarness, type PiAiRuntime, type PiAiToolset } from "./index";
 
-type DemoMetadata = Record<string, never>;
+type DemoMetadata = {
+  scenario?: string;
+};
 
 const createAgent = vi.fn(() => ({
   id: "refund-agent",
@@ -1147,6 +1150,123 @@ test("does not opt native agent tools into replay from tool objects", async () =
 
   expect(execute).toHaveBeenCalledTimes(1);
   expect(toolCalls(run.session)[0].metadata?.replay).toBeUndefined();
+});
+
+test("passes run input and context to createAgent before native tool instrumentation", async () => {
+  replayDir = mkdtempSync(join(process.cwd(), ".tmp-pi-native-replay-"));
+  vi.stubEnv("VITEST_EVALS_REPLAY_MODE", "auto");
+  vi.stubEnv("VITEST_EVALS_REPLAY_DIR", replayDir);
+
+  const createContextualAgent = vi.fn(
+    ({
+      input,
+      context,
+    }: {
+      input: string;
+      context: HarnessContext<DemoMetadata>;
+    }) => {
+      context.setArtifact("preparedInput", input);
+      const scenario = context.metadata.scenario ?? "unknown";
+      const nativeTools = [
+        {
+          name: "lookupInvoice",
+          execute: vi.fn(
+            async (_toolCallId: string, args: { invoiceId: string }) => ({
+              content: [
+                {
+                  type: "text",
+                  text: JSON.stringify({
+                    invoiceId: args.invoiceId,
+                    scenario,
+                  }),
+                },
+              ],
+              details: {
+                invoiceId: args.invoiceId,
+                preparedInput: input,
+                scenario,
+              },
+            }),
+          ),
+        },
+      ];
+
+      return {
+        agent: {
+          state: {
+            tools: nativeTools,
+          },
+        },
+        async run(_input: string, runtime: { events: DemoRuntime["events"] }) {
+          const toolResult = await nativeTools[0].execute("call_lookup", {
+            invoiceId: "inv_123",
+          });
+
+          runtime.events.assistant(toolResult.content[0].text);
+
+          return {
+            decision: toolResult.details,
+          };
+        },
+      };
+    },
+  );
+  const harness = piAiHarness({
+    prompt: judgePrompt,
+    createAgent: createContextualAgent,
+    toolReplay: {
+      lookupInvoice: true,
+    },
+  });
+  const artifacts: Record<string, JsonValue> = {};
+  const context: HarnessContext<DemoMetadata> = {
+    metadata: {
+      scenario: "refund",
+    },
+    task: {
+      meta: {},
+    },
+    artifacts,
+    setArtifact: vi.fn((name: string, value: JsonValue) => {
+      artifacts[name] = value;
+    }),
+  };
+
+  const result = await harness.run("Refund invoice inv_123", context);
+
+  expect(createContextualAgent).toHaveBeenCalledWith(
+    expect.objectContaining({
+      input: "Refund invoice inv_123",
+      context: expect.objectContaining({
+        metadata: {
+          scenario: "refund",
+        },
+      }),
+    }),
+  );
+  expect(result.artifacts).toEqual({
+    preparedInput: "Refund invoice inv_123",
+  });
+  expect(result.output).toEqual({
+    invoiceId: "inv_123",
+    preparedInput: "Refund invoice inv_123",
+    scenario: "refund",
+  });
+  expect(toolCalls(result.session)).toMatchObject([
+    {
+      name: "lookupInvoice",
+      result: {
+        invoiceId: "inv_123",
+        preparedInput: "Refund invoice inv_123",
+        scenario: "refund",
+      },
+      metadata: {
+        replay: {
+          status: "recorded",
+        },
+      },
+    },
+  ]);
 });
 
 test("records and replays opt-in tools in auto mode", async () => {

--- a/packages/harness-pi-ai/src/index.ts
+++ b/packages/harness-pi-ai/src/index.ts
@@ -186,6 +186,14 @@ export interface PiAiHarnessResultArgs<
   result: TResult;
 }
 
+export interface PiAiCreateAgentArgs<
+  TInput = string,
+  TMetadata extends HarnessMetadata = HarnessMetadata,
+> {
+  input: TInput;
+  context: HarnessContext<TMetadata>;
+}
+
 interface PiAiHarnessBaseOptions<
   TAgent,
   TInput = string,
@@ -197,7 +205,9 @@ interface PiAiHarnessBaseOptions<
   >,
 > {
   agent?: TAgent;
-  createAgent?: () => MaybePromise<TAgent>;
+  createAgent?: (
+    args: PiAiCreateAgentArgs<TInput, TMetadata>,
+  ) => MaybePromise<TAgent>;
   toolReplay?: PiAiToolReplayPolicies<TInput, TMetadata>;
   normalize?: PiAiHarnessNormalizeOptions<
     TAgent,
@@ -365,7 +375,10 @@ export function piAiHarness<
     name: options.name ?? "pi-ai",
     prompt: options.prompt,
     run: async (input, context) => {
-      const agent = await resolveAgent(options);
+      const agent = await resolveAgent(options, {
+        input,
+        context,
+      });
       const messages: NormalizedMessage[] = [
         {
           role: "user",
@@ -517,13 +530,16 @@ async function resolveAgent<
   TMetadata extends HarnessMetadata,
   TResult,
   TTools extends PiAiToolset<TInput, TMetadata>,
->(options: PiAiHarnessOptions<TAgent, TInput, TMetadata, TResult, TTools>) {
+>(
+  options: PiAiHarnessOptions<TAgent, TInput, TMetadata, TResult, TTools>,
+  args: PiAiCreateAgentArgs<TInput, TMetadata>,
+) {
   if (options.agent !== undefined) {
     return options.agent;
   }
 
   if (options.createAgent) {
-    return options.createAgent();
+    return options.createAgent(args);
   }
 
   throw new Error(

--- a/policies/api-design.md
+++ b/policies/api-design.md
@@ -15,6 +15,9 @@ hatches for advanced cases.
 - Put capabilities on the object that owns their configuration. Avoid parallel
   context objects with overlapping lifecycle names such as `harness` and
   `runtime`.
+- Per-run factories should receive one contextual args object with the run
+  input and harness context when the harness owns later instrumentation or
+  execution.
 - Infer context from fixtures, registered runs, or the current test when that
   removes repetitive parameters and avoids caller mistakes.
 - Keep explicit overrides for values that cannot be inferred reliably.

--- a/skills/vitest-evals/references/harness-ai-sdk.md
+++ b/skills/vitest-evals/references/harness-ai-sdk.md
@@ -44,12 +44,15 @@ const harness = aiSdkHarness({
 |--------|-------------|
 | `prompt` | Required prompt seam for judges. |
 | `task` | Use for custom execution such as `generateText(...)`; mutually exclusive with `agent`. |
-| `agent` | Use for objects or factories exposing `run(input, runtime)` or `generate(input, runtime)`; mutually exclusive with `task`. |
+| `agent` | Use for objects or per-run factories exposing `run(input, runtime)` or `generate(input, runtime)`; mutually exclusive with `task`. |
 | `tools` | Optional AI SDK toolset; wrapped before being passed to the task or agent. |
 | `output` | Optional domain output selector; defaults to `output`, `object`, `experimental_output`, `result`, then `text`. |
 | `session` | Optional override when inferred steps or traces are insufficient. |
 | `usage`, `timings`, `errors` | Optional diagnostic overrides. |
 | `name` | Optional reporter label; defaults to `ai-sdk`. |
+
+Agent factories receive `{ input, context }` before execution so apps can
+derive instructions, metadata, or seeded state without side-channel setup.
 
 ## Normalization Behavior
 

--- a/skills/vitest-evals/references/harness-pi-ai.md
+++ b/skills/vitest-evals/references/harness-pi-ai.md
@@ -21,6 +21,9 @@ const harness = piAiHarness({
 });
 ```
 
+`createAgent` receives `{ input, context }` when per-run instructions, native
+tool closures, metadata, or seeded artifacts are needed before instrumentation.
+
 If the agent needs a custom entrypoint:
 
 ```ts
@@ -39,7 +42,7 @@ const harness = piAiHarness({
 | Option | Requirement |
 |--------|-------------|
 | `agent` | Existing instance used for runs. |
-| `createAgent` | Factory for a fresh agent; prefer for per-test isolation. |
+| `createAgent` | Factory for a fresh per-run agent; receives `{ input, context }`. |
 | `prompt` | Required prompt seam for judges. |
 | `run` | Optional custom execution; omitted when the agent exposes `run(input, runtime)`. |
 | `tools` | Optional explicit `PiAiToolset`; use when the agent hides its tool surface. |


### PR DESCRIPTION
Agent factories in the first-party harnesses now receive the eval input and harness context before the harness instruments tools or executes the run. This lets per-run agents derive instructions, tool closures, metadata, and artifacts without AsyncLocalStorage or other side-channel setup.

**Contextual Factories**

OpenAI Agents and Pi AI create their agents before native tool instrumentation, so createAgent now receives { input, context } in both harnesses. AI SDK agent factories receive the same shape for consistency and lower boilerplate.

**Docs And Policy**

Update harness READMEs, skill references, and the API design policy so future harness surfaces prefer one contextual per-run factory object.

Validated with pnpm exec biome lint, pnpm exec vitest run for the three harness test files, pnpm run typecheck, and pnpm run build.

Fixes #54