### PR TITLE
feat(github-reporter): Add GitHub eval report publisher

### DIFF
--- a/.github/workflows/github-reporter-smoke.yml
+++ b/.github/workflows/github-reporter-smoke.yml
@@ -1,0 +1,171 @@
+name: GitHub Reporter Smoke
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/github-reporter-smoke.yml"
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
+      - "packages/github-reporter/**"
+  pull_request:
+    paths:
+      - ".github/workflows/github-reporter-smoke.yml"
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
+      - "packages/github-reporter/**"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  smoke:
+    name: Smoke test GitHub reporter CLI
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: "20"
+
+      # pnpm/action-setup@v4
+      - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda
+        name: Install pnpm
+        with:
+          version: 10.33.0
+          run_install: false
+
+      - name: Get pnpm store directory
+        shell: bash
+        run: |
+          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+
+      - uses: actions/cache@v4
+        name: Setup pnpm cache
+        with:
+          path: ${{ env.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Build reporter
+        run: pnpm --filter @vitest-evals/github-reporter run build
+
+      - name: Create fake Vitest JSON report
+        run: |
+          mkdir -p tmp/github-reporter-smoke
+          cat > tmp/github-reporter-smoke/vitest-results.json <<JSON
+          {
+            "numFailedTests": 1,
+            "numPassedTests": 0,
+            "numPendingTests": 0,
+            "numTodoTests": 0,
+            "numTotalTests": 1,
+            "startTime": 1000,
+            "success": false,
+            "testResults": [
+              {
+                "name": "$GITHUB_WORKSPACE/apps/demo/evals/smoke.eval.ts",
+                "status": "failed",
+                "message": "",
+                "startTime": 1000,
+                "endTime": 2500,
+                "assertionResults": [
+                  {
+                    "ancestorTitles": ["smoke eval"],
+                    "fullName": "smoke eval reports a failed judge",
+                    "title": "reports a failed judge",
+                    "status": "failed",
+                    "duration": 1500,
+                    "failureMessages": ["Score: 0.10 below threshold: 1.00"],
+                    "location": {
+                      "line": 12,
+                      "column": 5
+                    },
+                    "tags": [],
+                    "meta": {
+                      "eval": {
+                        "avgScore": 0.1,
+                        "thresholdFailed": true,
+                        "output": {
+                          "status": "denied"
+                        },
+                        "scores": [
+                          {
+                            "name": "SmokeJudge",
+                            "score": 0.1,
+                            "metadata": {
+                              "rationale": "expected approved but got denied"
+                            }
+                          }
+                        ]
+                      },
+                      "harness": {
+                        "name": "smoke-harness",
+                        "run": {
+                          "output": {
+                            "status": "denied"
+                          },
+                          "usage": {
+                            "totalTokens": 42,
+                            "toolCalls": 1
+                          },
+                          "timings": {
+                            "totalMs": 1200
+                          },
+                          "session": {
+                            "messages": [
+                              {
+                                "role": "assistant",
+                                "toolCalls": [
+                                  {
+                                    "name": "lookupInvoice",
+                                    "durationMs": 7
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          "errors": []
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+          JSON
+
+      - name: Run and assert reporter in GitHub Actions mode
+        run: |
+          set -euo pipefail
+          node packages/github-reporter/dist/cli.js \
+            tmp/github-reporter-smoke/vitest-results.json \
+            --annotations \
+            --check-run \
+            --repo getsentry/vitest-evals \
+            --sha "$GITHUB_SHA" \
+            --workspace "$GITHUB_WORKSPACE" \
+            > tmp/github-reporter-smoke/stdout.txt \
+            2> tmp/github-reporter-smoke/stderr.txt
+
+          grep -F "## vitest-evals" "$GITHUB_STEP_SUMMARY"
+          grep -F "Status: failed" "$GITHUB_STEP_SUMMARY"
+          grep -F "Score: avg 0.10, min 0.10" "$GITHUB_STEP_SUMMARY"
+          grep -F "Usage: 42 tokens, 1 tool" "$GITHUB_STEP_SUMMARY"
+          grep -F "smoke eval > reports a failed judge" "$GITHUB_STEP_SUMMARY"
+          grep -F "::error file=apps/demo/evals/smoke.eval.ts,line=12,col=5,title=vitest-evals::smoke eval > reports a failed judge - score 0.10 - SmokeJudge - expected approved but got denied" tmp/github-reporter-smoke/stdout.txt
+          grep -F "::warning::GitHub Check Run skipped: missing GITHUB_TOKEN" tmp/github-reporter-smoke/stdout.txt
+          if grep -F "::warning::" tmp/github-reporter-smoke/stderr.txt; then
+            echo "warning workflow command was emitted on stderr"
+            exit 1
+          fi

--- a/.github/workflows/github-reporter-smoke.yml
+++ b/.github/workflows/github-reporter-smoke.yml
@@ -62,88 +62,227 @@ jobs:
       - name: Create fake Vitest JSON report
         run: |
           mkdir -p tmp/github-reporter-smoke
-          cat > tmp/github-reporter-smoke/vitest-results.json <<JSON
-          {
-            "numFailedTests": 1,
-            "numPassedTests": 0,
-            "numPendingTests": 0,
-            "numTodoTests": 0,
-            "numTotalTests": 1,
-            "startTime": 1000,
-            "success": false,
-            "testResults": [
-              {
-                "name": "$GITHUB_WORKSPACE/apps/demo/evals/smoke.eval.ts",
-                "status": "failed",
-                "message": "",
-                "startTime": 1000,
-                "endTime": 2500,
-                "assertionResults": [
+          node <<'NODE'
+          const { writeFileSync } = require("node:fs");
+
+          const workspace = process.env.GITHUB_WORKSPACE ?? process.cwd();
+          const file = `${workspace}/apps/demo/evals/smoke.eval.ts`;
+          const cases = [
+            {
+              title: "rejects fraud",
+              status: "failed",
+              line: 12,
+              duration: 1500,
+              score: 0.1,
+              judge: "SmokeJudge",
+              rationale: "expected approved but got denied",
+              output: { status: "denied" },
+              usage: { totalTokens: 42, toolCalls: 1, estimatedCost: 0.0011 },
+              timingMs: 1200,
+              toolCalls: [{ name: "lookupInvoice", durationMs: 7 }],
+            },
+            {
+              title: "returns wrong refund amount",
+              status: "failed",
+              line: 28,
+              duration: 900,
+              score: 0.35,
+              judge: "AmountJudge",
+              rationale: "expected amount=5000, got amount=499",
+              output: { status: "approved", amount: 499 },
+              usage: { totalTokens: 120, toolCalls: 2, estimatedCost: 0.0042 },
+              timingMs: 1800,
+              toolCalls: [
+                { name: "lookupInvoice", durationMs: 9 },
+                {
+                  name: "createRefund",
+                  durationMs: 31,
+                  error: { message: "amount mismatch" },
+                },
+              ],
+              errors: [{ message: "refund ledger rejected amount" }],
+              extraScores: [{ name: "JsonShapeJudge", score: 1 }],
+            },
+            {
+              title: "flags missing receipt",
+              status: "passed",
+              line: 44,
+              duration: 320,
+              score: 0.22,
+              judge: "PolicyJudge",
+              output: { status: "needs_review" },
+              usage: { totalTokens: 80, estimatedCost: 0.0018 },
+              timingMs: 610,
+            },
+            {
+              title: "keeps customer tone",
+              status: "passed",
+              line: 61,
+              duration: 480,
+              score: 0.45,
+              judge: "ToneJudge",
+              output: { tone: "calm" },
+              usage: { totalTokens: 95, toolCalls: 1, estimatedCost: 0.002 },
+              timingMs: 740,
+              toolCalls: [{ name: "loadCustomer", durationMs: 11 }],
+            },
+            {
+              title: "explains partial refund",
+              status: "passed",
+              line: 78,
+              duration: 510,
+              score: 0.58,
+              judge: "ExplanationJudge",
+              output: { status: "approved", amount: 2500 },
+              usage: { totalTokens: 110, estimatedCost: 0.0024 },
+              timingMs: 860,
+            },
+            {
+              title: "asks for clarification",
+              status: "passed",
+              line: 95,
+              duration: 430,
+              score: 0.62,
+              judge: "ClarificationJudge",
+              output: { status: "needs_more_info" },
+              usage: { totalTokens: 130, toolCalls: 1, estimatedCost: 0.003 },
+              timingMs: 920,
+              toolCalls: [{ name: "readPolicy", durationMs: 5 }],
+            },
+            {
+              title: "uses order lookup",
+              status: "passed",
+              line: 112,
+              duration: 700,
+              score: 0.74,
+              judge: "ToolUseJudge",
+              output: { status: "approved", amount: 1800 },
+              usage: { totalTokens: 155, toolCalls: 2, estimatedCost: 0.0037 },
+              timingMs: 1100,
+              toolCalls: [
+                { name: "lookupOrder", durationMs: 8 },
+                { name: "lookupPayment", durationMs: 14 },
+              ],
+            },
+            {
+              title: "approves standard refund",
+              status: "passed",
+              line: 129,
+              duration: 360,
+              score: 0.86,
+              judge: "RefundJudge",
+              output: { status: "approved", amount: 1200 },
+              usage: { totalTokens: 170, toolCalls: 1, estimatedCost: 0.004 },
+              timingMs: 990,
+              toolCalls: [{ name: "createRefund", durationMs: 22 }],
+            },
+            {
+              title: "denies expired claim",
+              status: "passed",
+              line: 146,
+              duration: 390,
+              score: 0.95,
+              judge: "PolicyJudge",
+              output: { status: "denied" },
+              usage: { totalTokens: 190, toolCalls: 1, estimatedCost: 0.0045 },
+              timingMs: 1040,
+              toolCalls: [{ name: "readPolicy", durationMs: 6 }],
+            },
+            {
+              title: "handles duplicate request",
+              status: "passed",
+              line: 163,
+              duration: 410,
+              score: 1,
+              judge: "DuplicateJudge",
+              output: { status: "denied", reason: "duplicate" },
+              usage: { totalTokens: 210, estimatedCost: 0.005 },
+              timingMs: 1150,
+            },
+          ];
+
+          const assertionResults = cases.map((testCase) => ({
+            ancestorTitles: ["refund eval"],
+            fullName: `refund eval ${testCase.title}`,
+            title: testCase.title,
+            status: testCase.status,
+            duration: testCase.duration,
+            failureMessages:
+              testCase.status === "failed"
+                ? [`Score: ${testCase.score.toFixed(2)} below threshold: 1.00`]
+                : [],
+            location: {
+              line: testCase.line,
+              column: 5,
+            },
+            tags: [],
+            meta: {
+              eval: {
+                avgScore: testCase.score,
+                thresholdFailed: testCase.status === "failed",
+                output: testCase.output,
+                scores: [
                   {
-                    "ancestorTitles": ["smoke eval"],
-                    "fullName": "smoke eval reports a failed judge",
-                    "title": "reports a failed judge",
-                    "status": "failed",
-                    "duration": 1500,
-                    "failureMessages": ["Score: 0.10 below threshold: 1.00"],
-                    "location": {
-                      "line": 12,
-                      "column": 5
-                    },
-                    "tags": [],
-                    "meta": {
-                      "eval": {
-                        "avgScore": 0.1,
-                        "thresholdFailed": true,
-                        "output": {
-                          "status": "denied"
-                        },
-                        "scores": [
-                          {
-                            "name": "SmokeJudge",
-                            "score": 0.1,
-                            "metadata": {
-                              "rationale": "expected approved but got denied"
-                            }
-                          }
-                        ]
+                    name: testCase.judge,
+                    score: testCase.score,
+                    metadata: testCase.rationale
+                      ? { rationale: testCase.rationale }
+                      : undefined,
+                  },
+                  ...(testCase.extraScores ?? []),
+                ],
+              },
+              harness: {
+                name: "smoke-harness",
+                run: {
+                  output: testCase.output,
+                  usage: testCase.usage,
+                  timings: {
+                    totalMs: testCase.timingMs,
+                  },
+                  session: {
+                    messages: [
+                      {
+                        role: "assistant",
+                        toolCalls: testCase.toolCalls ?? [],
                       },
-                      "harness": {
-                        "name": "smoke-harness",
-                        "run": {
-                          "output": {
-                            "status": "denied"
-                          },
-                          "usage": {
-                            "totalTokens": 42,
-                            "toolCalls": 1
-                          },
-                          "timings": {
-                            "totalMs": 1200
-                          },
-                          "session": {
-                            "messages": [
-                              {
-                                "role": "assistant",
-                                "toolCalls": [
-                                  {
-                                    "name": "lookupInvoice",
-                                    "durationMs": 7
-                                  }
-                                ]
-                              }
-                            ]
-                          },
-                          "errors": []
-                        }
-                      }
-                    }
-                  }
-                ]
-              }
-            ]
-          }
-          JSON
+                    ],
+                  },
+                  errors: testCase.errors ?? [],
+                },
+              },
+            },
+          }));
+          const failedCount = cases.filter(
+            (testCase) => testCase.status === "failed",
+          ).length;
+          const passedCount = cases.length - failedCount;
+
+          const report = {
+            numFailedTests: failedCount,
+            numPassedTests: passedCount,
+            numPendingTests: 0,
+            numTodoTests: 0,
+            numTotalTests: cases.length,
+            startTime: 1000,
+            success: false,
+            testResults: [
+              {
+                name: file,
+                status: "failed",
+                message: "",
+                startTime: 1000,
+                endTime: 8000,
+                assertionResults,
+              },
+            ],
+          };
+
+          writeFileSync(
+            "tmp/github-reporter-smoke/vitest-results.json",
+            `${JSON.stringify(report, null, 2)}\n`,
+          );
+          NODE
 
       - name: Run and assert reporter in GitHub Actions mode
         run: |
@@ -158,12 +297,37 @@ jobs:
             > tmp/github-reporter-smoke/stdout.txt \
             2> tmp/github-reporter-smoke/stderr.txt
 
-          grep -F "## vitest-evals" "$GITHUB_STEP_SUMMARY"
-          grep -F "Status: failed" "$GITHUB_STEP_SUMMARY"
-          grep -F "Score: avg 0.10, min 0.10" "$GITHUB_STEP_SUMMARY"
-          grep -F "Usage: 42 tokens, 1 tool" "$GITHUB_STEP_SUMMARY"
-          grep -F "smoke eval > reports a failed judge" "$GITHUB_STEP_SUMMARY"
-          grep -F "::error file=apps/demo/evals/smoke.eval.ts,line=12,col=5,title=vitest-evals::smoke eval > reports a failed judge - score 0.10 - SmokeJudge - expected approved but got denied" tmp/github-reporter-smoke/stdout.txt
+          grep -F "# vitest-evals" "$GITHUB_STEP_SUMMARY"
+          grep -F "| Metric | Value |" "$GITHUB_STEP_SUMMARY"
+          grep -F "Score distribution" "$GITHUB_STEP_SUMMARY"
+          grep -F "0-19%   | #######              1" "$GITHUB_STEP_SUMMARY"
+          grep -F "20-39%  | #############        2" "$GITHUB_STEP_SUMMARY"
+          grep -F "40-59%  | #############        2" "$GITHUB_STEP_SUMMARY"
+          grep -F "60-79%  | #############        2" "$GITHUB_STEP_SUMMARY"
+          grep -F "80-100% | #################### 3" "$GITHUB_STEP_SUMMARY"
+          grep -F "## Results" "$GITHUB_STEP_SUMMARY"
+          grep -F "### Failures" "$GITHUB_STEP_SUMMARY"
+          grep -F "refund eval &gt; rejects fraud" "$GITHUB_STEP_SUMMARY"
+          grep -F "refund eval &gt; returns wrong refund amount" "$GITHUB_STEP_SUMMARY"
+          grep -F "Result" "$GITHUB_STEP_SUMMARY"
+          grep -F "Reason" "$GITHUB_STEP_SUMMARY"
+          grep -F "expected approved but got denied" "$GITHUB_STEP_SUMMARY"
+          grep -F "expected amount=5000, got amount=499" "$GITHUB_STEP_SUMMARY"
+          grep -F "Judge       Score" "$GITHUB_STEP_SUMMARY"
+          grep -F "SmokeJudge  0.10" "$GITHUB_STEP_SUMMARY"
+          grep -F "AmountJudge     0.35" "$GITHUB_STEP_SUMMARY"
+          grep -F "Harness Errors" "$GITHUB_STEP_SUMMARY"
+          grep -F "refund ledger rejected amount" "$GITHUB_STEP_SUMMARY"
+          grep -F "Final Output" "$GITHUB_STEP_SUMMARY"
+          grep -F "Tool           Status  Duration" "$GITHUB_STEP_SUMMARY"
+          grep -F "lookupInvoice  ok      7ms" "$GITHUB_STEP_SUMMARY"
+          grep -F "| Status | failed |" "$GITHUB_STEP_SUMMARY"
+          grep -F "| Tests | 8 passed, 2 failed, 10 total |" "$GITHUB_STEP_SUMMARY"
+          grep -F "| Evals | 8 passed, 2 failed, 10 total |" "$GITHUB_STEP_SUMMARY"
+          grep -F "| Score | avg 0.59, min 0.10 |" "$GITHUB_STEP_SUMMARY"
+          grep -F '| Usage | 1,302 tokens, 9 tools, $0.0317 |' "$GITHUB_STEP_SUMMARY"
+          grep -F "::error file=apps/demo/evals/smoke.eval.ts,line=12,col=5,title=vitest-evals::refund eval > rejects fraud - score 0.10 - SmokeJudge - expected approved but got denied" tmp/github-reporter-smoke/stdout.txt
+          grep -F "::error file=apps/demo/evals/smoke.eval.ts,line=28,col=5,title=vitest-evals::refund eval > returns wrong refund amount - score 0.35 - AmountJudge - expected amount=5000, got amount=499" tmp/github-reporter-smoke/stdout.txt
           grep -F "::warning::GitHub Check Run skipped: missing GITHUB_TOKEN" tmp/github-reporter-smoke/stdout.txt
           if grep -F "::warning::" tmp/github-reporter-smoke/stderr.txt; then
             echo "warning workflow command was emitted on stderr"

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ Monorepo for the explicit-run `vitest-evals` shape:
 - `packages/harness-ai-sdk`: `ai-sdk`-focused harness adapter
 - `packages/harness-openai-agents`: `@openai/agents`-focused harness adapter
 - `packages/harness-pi-ai`: `pi-ai`-focused harness adapter with tool replay
+- `packages/github-reporter`: GitHub Actions summary, annotation, and optional
+  Check Run publishing from Vitest JSON output
 - `apps/demo-pi`: end-to-end Pi Mono demo evals with an app-local refund agent
 - `apps/demo-ai-sdk`: end-to-end AI SDK demo evals with app-local refund tools
 - `apps/demo-openai-agents`: end-to-end OpenAI Agents demo evals with
@@ -20,6 +22,7 @@ packages/
   harness-ai-sdk/
   harness-openai-agents/
   harness-pi-ai/
+  github-reporter/
 apps/
   demo-ai-sdk/
   demo-openai-agents/
@@ -55,6 +58,29 @@ tables.
 
 Pull request CI runs the same core safety checks: release config validation,
 lint, typecheck, the CI test suite, and the workspace build.
+
+## GitHub Reporting
+
+For GitHub Actions, emit Vitest JSON and let the GitHub reporter read that file.
+The JSON report preserves `task.meta`, including eval scores, harness runs,
+usage, and tool calls. JUnit can still be emitted alongside it for CI systems
+that expect XML.
+
+```sh
+pnpm exec vitest run apps packages \
+  --config=./vitest.config.ts \
+  --reporter=vitest-evals/reporter \
+  --reporter=json \
+  --outputFile.json=vitest-results.json
+
+pnpm exec vitest-evals-github-report --check-run
+```
+
+The reporter writes a plain ASCII job summary through `GITHUB_STEP_SUMMARY`,
+emits terse annotations for failed evals, and publishes a separate Check Run
+only when `--check-run` is set, `GITHUB_TOKEN` is available, and `checks: write`
+permission is configured.
+See [docs/github-actions.md](docs/github-actions.md) for the minimal workflow.
 
 ## Releases
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -29,6 +29,7 @@ packages/
   harness-ai-sdk/
   harness-openai-agents/
   harness-pi-ai/
+  github-reporter/
 apps/
   demo-ai-sdk/
   demo-openai-agents/
@@ -102,6 +103,25 @@ Provides the custom Vitest reporter that reads normalized run metadata from
 - tool activity
 - judge sub-results
 - richer failure diagnostics
+
+## GitHub Reporting
+
+`packages/github-reporter` is a post-run reporter for GitHub Actions. It reads
+Vitest's built-in JSON output instead of attaching directly to the Vitest
+reporter lifecycle. That JSON output includes each assertion's `meta` field, so
+it preserves the normalized eval and harness metadata recorded by core.
+
+This split keeps the terminal reporter focused on local output and gives CI a
+stable artifact to process:
+
+1. Vitest runs evals and writes `--reporter=json` to `vitest-results.json`.
+2. The GitHub reporter reads that JSON.
+3. It writes an ASCII job summary to `GITHUB_STEP_SUMMARY`.
+4. It emits terse workflow-command annotations for failed evals.
+5. When explicitly configured, it publishes a separate GitHub Check Run.
+
+JUnit XML can be emitted alongside JSON, but it is not used as the source of
+truth for eval reporting because it does not carry the full harness metadata.
 
 ## Harness Lifecycle
 

--- a/docs/development-guide.md
+++ b/docs/development-guide.md
@@ -33,6 +33,7 @@ When changing behavior, decide first which surface you are touching:
 
 - root harness/judge API
 - reporter output
+- GitHub JSON post-processing output
 - a first-party harness package
 - legacy scorer compatibility
 
@@ -80,6 +81,19 @@ Owns:
 - adapting `pi-ai` style agents into `HarnessRun`
 - wrapped tool runtime injection
 - tool replay/VCR behavior
+
+### `packages/github-reporter`
+
+Owns:
+
+- reading Vitest JSON reports that include eval task metadata
+- rendering GitHub Actions job summaries
+- rendering workflow-command annotations
+- optional GitHub Check Run publishing
+
+Keep this package file/artifact based. Do not make it depend on Vitest's live
+reporter lifecycle unless the JSON contract stops carrying the metadata core
+needs.
 
 ## Demo Apps
 
@@ -152,6 +166,7 @@ pnpm evals
 For targeted work, prefer narrow verification:
 
 - reporter changes: run reporter tests
+- GitHub reporter changes: run `packages/github-reporter/src/report.test.ts`
 - harness changes: run the relevant harness package tests
 - demo app changes: run `pnpm evals` or a filtered app eval command
 - legacy changes: run the moved tests under `packages/vitest-evals/src/legacy`

--- a/docs/github-actions.md
+++ b/docs/github-actions.md
@@ -1,0 +1,76 @@
+# GitHub Actions Reporting
+
+`@vitest-evals/github-reporter` reads Vitest JSON output and publishes the
+GitHub-facing report. Use JSON as the eval artifact because it preserves
+`task.meta.eval` and `task.meta.harness`; JUnit XML does not carry the full eval
+metadata.
+
+## Install
+
+```sh
+pnpm add -D @vitest-evals/github-reporter
+```
+
+## Minimal Workflow
+
+```yaml
+jobs:
+  evals:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+      - run: pnpm install
+
+      - name: Run evals
+        run: |
+          pnpm exec vitest run evals \
+            --reporter=vitest-evals/reporter \
+            --reporter=json \
+            --outputFile.json=vitest-results.json
+
+      - name: Publish eval report
+        if: always()
+        run: pnpm exec vitest-evals-github-report
+```
+
+The publish step still runs after failed evals because of `if: always()`. The
+job remains failed when the eval step fails.
+
+## Optional Check Run
+
+Add `checks: write`, pass the GitHub token as an environment variable, and opt
+in with `--check-run`.
+
+```yaml
+permissions:
+  contents: read
+  checks: write
+
+steps:
+  - name: Publish eval report
+    if: always()
+    env:
+      GITHUB_TOKEN: ${{ github.token }}
+    run: pnpm exec vitest-evals-github-report --check-run
+```
+
+If the token or permission is missing, the command keeps the job summary and
+workflow annotations and warns instead of failing the job.
+
+## JUnit
+
+Emit JUnit only when another CI tool needs XML:
+
+```sh
+pnpm exec vitest run evals \
+  --reporter=vitest-evals/reporter \
+  --reporter=json \
+  --reporter=junit \
+  --outputFile.json=vitest-results.json \
+  --outputFile.junit=tests.junit.xml
+```

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -27,6 +27,8 @@ packages/harness-openai-agents/src/
   index.test.ts
 packages/harness-pi-ai/src/
   index.test.ts
+packages/github-reporter/src/
+  report.test.ts
 apps/demo-pi/src/
   refundAgent.test.ts
 apps/demo-openai-agents/src/
@@ -61,6 +63,16 @@ Cover:
 - judge sub-results
 - failure formatting
 - replay/tool metadata when relevant
+
+### GitHub Reporter Changes
+
+Cover:
+
+- Vitest JSON metadata collection
+- ASCII job summary rendering
+- long judge rationale handling without tables
+- workflow-command escaping
+- optional Check Run payloads and missing-configuration fallback
 
 ### Harness Package Changes
 

--- a/packages/github-reporter/README.md
+++ b/packages/github-reporter/README.md
@@ -1,0 +1,86 @@
+# @vitest-evals/github-reporter
+
+GitHub Actions reporting for `vitest-evals` runs.
+
+This package reads Vitest's built-in JSON report. Vitest JSON includes each
+test's `meta` field, which is where `vitest-evals` records harness runs,
+scores, judge rationales, usage, and tool calls.
+
+JUnit XML can still be emitted for CI systems that expect it, but it is not the
+source of truth for eval reporting.
+
+## Usage
+
+```sh
+pnpm exec vitest run apps packages \
+  --config=./vitest.config.ts \
+  --reporter=vitest-evals/reporter \
+  --reporter=json \
+  --outputFile.json=vitest-results.json
+
+pnpm exec vitest-evals-github-report
+```
+
+In GitHub Actions, the reporter writes to `GITHUB_STEP_SUMMARY` when available
+and emits terse workflow-command annotations for failed evals.
+
+## Check Run
+
+To publish a separate `vitest-evals` Check Run, opt in explicitly:
+
+```sh
+GITHUB_TOKEN=... pnpm exec vitest-evals-github-report --check-run
+```
+
+The Check Run path requires the normal GitHub Actions environment plus a token
+with `checks: write`. If configuration or permission is missing, the command
+keeps the job summary and workflow annotations and warns instead of failing.
+
+```yaml
+permissions:
+  contents: read
+  checks: write
+```
+
+## Recommended Workflow
+
+```yaml
+jobs:
+  evals:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+      - run: pnpm install
+
+      - name: Run evals
+        run: |
+          pnpm exec vitest run apps packages \
+            --config=./vitest.config.ts \
+            --reporter=vitest-evals/reporter \
+            --reporter=json \
+            --outputFile.json=vitest-results.json
+
+      - name: Publish eval report
+        if: always()
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          pnpm exec vitest-evals-github-report --check-run
+```
+
+## Output Rules
+
+- Job summary is the primary human-readable report.
+- Failure lists use numbered key/value blocks, not wide tables.
+- Long judge reasons live inside `<details>` blocks and fenced text.
+- Workflow annotations include only the first useful failure line.
+- Check Run annotations include richer `raw_details` when available.
+- Output is plain ASCII markdown.

--- a/packages/github-reporter/package.json
+++ b/packages/github-reporter/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@vitest-evals/github-reporter",
+  "version": "0.9.0-beta.3",
+  "sideEffects": false,
+  "types": "./dist/index.d.ts",
+  "main": "./dist/index.js",
+  "module": "./dist/index.mjs",
+  "bin": {
+    "vitest-evals-github-report": "./dist/cli.js"
+  },
+  "files": ["dist"],
+  "publishConfig": {
+    "access": "public"
+  },
+  "exports": {
+    ".": {
+      "source": "./src/index.ts",
+      "types": "./dist/index.d.ts",
+      "require": "./dist/index.js",
+      "import": "./dist/index.mjs"
+    }
+  },
+  "scripts": {
+    "build": "tsup --config ./tsup.config.ts"
+  },
+  "peerDependencies": {
+    "vitest": ">=4 <5"
+  },
+  "devDependencies": {
+    "vitest": "^4.1.2"
+  }
+}

--- a/packages/github-reporter/src/annotations.ts
+++ b/packages/github-reporter/src/annotations.ts
@@ -47,7 +47,7 @@ export function renderWorkflowCommands(
         properties: {
           file: testCase.displayFile,
           line: String(testCase.location.line),
-          column: String(testCase.location.column),
+          col: String(testCase.location.column),
           title: "vitest-evals",
         },
         message: formatWorkflowMessage(testCase),

--- a/packages/github-reporter/src/annotations.ts
+++ b/packages/github-reporter/src/annotations.ts
@@ -3,6 +3,7 @@ import {
   compactLine,
   escapeCommandData,
   escapeCommandProperty,
+  formatScore,
   stringifyValue,
   truncate,
 } from "./utils";
@@ -24,6 +25,10 @@ export type CheckAnnotation = {
 const DEFAULT_MAX_WORKFLOW_ANNOTATIONS = 10;
 const DEFAULT_MAX_CHECK_ANNOTATIONS = 50;
 const MAX_CHECK_FIELD_LENGTH = 64_000;
+
+type AnnotatedEvalCase = EvalCase & {
+  location: { line: number; column: number };
+};
 
 /** Renders GitHub workflow-command annotations for failed eval cases. */
 export function renderWorkflowCommands(
@@ -80,7 +85,7 @@ export function buildCheckAnnotations(
 
 function hasAnnotationLocation(
   testCase: EvalCase,
-): testCase is EvalCase & { location: { line: number; column: number } } {
+): testCase is AnnotatedEvalCase {
   return Boolean(testCase.location);
 }
 
@@ -88,7 +93,7 @@ function formatWorkflowMessage(testCase: EvalCase) {
   const failure = testCase.primaryFailure;
   const parts = [
     testCase.displayName,
-    `score ${formatAnnotationScore(failure?.score ?? testCase.eval?.avgScore)}`,
+    `score ${formatScore(failure?.score ?? testCase.eval?.avgScore)}`,
   ];
 
   if (failure?.judgeName) {
@@ -103,16 +108,12 @@ function formatWorkflowMessage(testCase: EvalCase) {
   return parts.join(" - ");
 }
 
-function formatAnnotationScore(value: number | undefined) {
-  return value === undefined ? "n/a" : value.toFixed(2);
-}
-
-function formatRawDetails(testCase: EvalCase) {
+function formatRawDetails(testCase: AnnotatedEvalCase) {
   const lines = [
     `Test: ${testCase.displayName}`,
-    `Location: ${testCase.displayFile}:${testCase.location?.line ?? 0}`,
+    `Location: ${testCase.displayFile}:${testCase.location.line}`,
     `Harness: ${testCase.harness?.name ?? "n/a"}`,
-    `Score: ${formatAnnotationScore(testCase.primaryFailure?.score ?? testCase.eval?.avgScore)}`,
+    `Score: ${formatScore(testCase.primaryFailure?.score ?? testCase.eval?.avgScore)}`,
     `Judge: ${testCase.primaryFailure?.judgeName ?? "n/a"}`,
     "",
     "Reason:",

--- a/packages/github-reporter/src/annotations.ts
+++ b/packages/github-reporter/src/annotations.ts
@@ -1,0 +1,152 @@
+import type { EvalCase, EvalReport } from "./types";
+import {
+  compactLine,
+  escapeCommandData,
+  escapeCommandProperty,
+  stringifyValue,
+  truncate,
+} from "./utils";
+
+export type AnnotationOptions = {
+  maxAnnotations?: number;
+};
+
+export type CheckAnnotation = {
+  path: string;
+  start_line: number;
+  end_line: number;
+  annotation_level: "failure" | "warning" | "notice";
+  message: string;
+  title?: string;
+  raw_details?: string;
+};
+
+const DEFAULT_MAX_WORKFLOW_ANNOTATIONS = 10;
+const DEFAULT_MAX_CHECK_ANNOTATIONS = 50;
+const MAX_CHECK_FIELD_LENGTH = 64_000;
+
+/** Renders GitHub workflow-command annotations for failed eval cases. */
+export function renderWorkflowCommands(
+  report: EvalReport,
+  options: AnnotationOptions = {},
+) {
+  const maxAnnotations =
+    options.maxAnnotations ?? DEFAULT_MAX_WORKFLOW_ANNOTATIONS;
+
+  return report.failures
+    .filter(hasAnnotationLocation)
+    .slice(0, maxAnnotations)
+    .map((testCase) =>
+      formatWorkflowCommand({
+        command: "error",
+        properties: {
+          file: testCase.displayFile,
+          line: String(testCase.location.line),
+          column: String(testCase.location.column),
+          title: "vitest-evals",
+        },
+        message: formatWorkflowMessage(testCase),
+      }),
+    );
+}
+
+/** Builds Check Run annotations for failed eval cases. */
+export function buildCheckAnnotations(
+  report: EvalReport,
+  options: AnnotationOptions = {},
+): CheckAnnotation[] {
+  const maxAnnotations =
+    options.maxAnnotations ?? DEFAULT_MAX_CHECK_ANNOTATIONS;
+
+  return report.failures
+    .filter(hasAnnotationLocation)
+    .slice(0, maxAnnotations)
+    .map((testCase) => ({
+      path: testCase.displayFile,
+      start_line: testCase.location.line,
+      end_line: testCase.location.line,
+      annotation_level: "failure",
+      title: truncate(
+        `${testCase.primaryFailure?.judgeName ?? "vitest-evals"} - ${testCase.displayName}`,
+        255,
+      ),
+      message: truncate(
+        formatWorkflowMessage(testCase),
+        MAX_CHECK_FIELD_LENGTH,
+      ),
+      raw_details: truncate(formatRawDetails(testCase), MAX_CHECK_FIELD_LENGTH),
+    }));
+}
+
+function hasAnnotationLocation(
+  testCase: EvalCase,
+): testCase is EvalCase & { location: { line: number; column: number } } {
+  return Boolean(testCase.location);
+}
+
+function formatWorkflowMessage(testCase: EvalCase) {
+  const failure = testCase.primaryFailure;
+  const parts = [
+    testCase.displayName,
+    `score ${formatAnnotationScore(failure?.score ?? testCase.eval?.avgScore)}`,
+  ];
+
+  if (failure?.judgeName) {
+    parts.push(failure.judgeName);
+  }
+
+  const reason = compactLine(failure?.reason ?? "", 320);
+  if (reason) {
+    parts.push(reason);
+  }
+
+  return parts.join(" - ");
+}
+
+function formatAnnotationScore(value: number | undefined) {
+  return value === undefined ? "n/a" : value.toFixed(2);
+}
+
+function formatRawDetails(testCase: EvalCase) {
+  const lines = [
+    `Test: ${testCase.displayName}`,
+    `Location: ${testCase.displayFile}:${testCase.location?.line ?? 0}`,
+    `Harness: ${testCase.harness?.name ?? "n/a"}`,
+    `Score: ${formatAnnotationScore(testCase.primaryFailure?.score ?? testCase.eval?.avgScore)}`,
+    `Judge: ${testCase.primaryFailure?.judgeName ?? "n/a"}`,
+    "",
+    "Reason:",
+    testCase.primaryFailure?.reason ?? "n/a",
+  ];
+
+  const finalOutput = testCase.eval?.output ?? testCase.harness?.output;
+  if (finalOutput !== undefined) {
+    lines.push("", "Final:", stringifyValue(finalOutput, 8000));
+  }
+
+  if (testCase.harness?.toolCalls.length) {
+    lines.push("", "Tools:");
+    for (const toolCall of testCase.harness.toolCalls) {
+      lines.push(
+        `- ${toolCall.name}: ${toolCall.error ? `error: ${toolCall.error}` : "ok"}`,
+      );
+    }
+  }
+
+  return lines.join("\n");
+}
+
+function formatWorkflowCommand({
+  command,
+  properties,
+  message,
+}: {
+  command: "error" | "warning" | "notice";
+  properties: Record<string, string>;
+  message: string;
+}) {
+  const renderedProperties = Object.entries(properties)
+    .map(([key, value]) => `${key}=${escapeCommandProperty(value)}`)
+    .join(",");
+  return `::${command} ${renderedProperties}::${escapeCommandData(message)}`;
+}

--- a/packages/github-reporter/src/cli-options.ts
+++ b/packages/github-reporter/src/cli-options.ts
@@ -1,0 +1,115 @@
+export type CliOptions = {
+  jsonPath?: string;
+  summaryPath?: string;
+  summaryEnabled: boolean;
+  annotations: boolean;
+  checkRun: boolean;
+  failOnCheckError: boolean;
+  maxAnnotations?: number;
+  maxFailures?: number;
+  checkRunId?: number;
+  checkName?: string;
+  token?: string;
+  repository?: string;
+  sha?: string;
+  workspace?: string;
+  help: boolean;
+};
+
+/** Parses GitHub reporter CLI arguments, with explicit arguments taking precedence over environment defaults. */
+export function parseCliArgs(
+  args: string[],
+  env: NodeJS.ProcessEnv = process.env,
+): CliOptions {
+  const options: CliOptions = {
+    summaryPath: env.GITHUB_STEP_SUMMARY,
+    summaryEnabled: true,
+    annotations: env.GITHUB_ACTIONS === "true",
+    checkRun: false,
+    failOnCheckError: false,
+    help: false,
+  };
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    switch (arg) {
+      case "--json":
+        options.jsonPath = readValue(args, ++index, arg);
+        break;
+      case "--summary":
+        options.summaryPath = readValue(args, ++index, arg);
+        options.summaryEnabled = true;
+        break;
+      case "--no-summary":
+        options.summaryEnabled = false;
+        break;
+      case "--annotations":
+        options.annotations = true;
+        break;
+      case "--no-annotations":
+        options.annotations = false;
+        break;
+      case "--check-run":
+        options.checkRun = true;
+        break;
+      case "--fail-on-check-error":
+        options.failOnCheckError = true;
+        break;
+      case "--max-annotations":
+        options.maxAnnotations = readInteger(args, ++index, arg);
+        break;
+      case "--max-failures":
+        options.maxFailures = readInteger(args, ++index, arg);
+        break;
+      case "--check-run-id":
+        options.checkRunId = readInteger(args, ++index, arg);
+        options.checkRun = true;
+        break;
+      case "--check-name":
+        options.checkName = readValue(args, ++index, arg);
+        break;
+      case "--token":
+        options.token = readValue(args, ++index, arg);
+        break;
+      case "--repo":
+        options.repository = readValue(args, ++index, arg);
+        break;
+      case "--sha":
+        options.sha = readValue(args, ++index, arg);
+        break;
+      case "--workspace":
+        options.workspace = readValue(args, ++index, arg);
+        break;
+      case "--help":
+      case "-h":
+        options.help = true;
+        break;
+      default:
+        if (!arg.startsWith("-") && !options.jsonPath) {
+          options.jsonPath = arg;
+          break;
+        }
+        throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  options.jsonPath ??= env.VITEST_EVALS_JSON_REPORT ?? "vitest-results.json";
+
+  return options;
+}
+
+function readValue(args: string[], index: number, flag: string) {
+  const value = args[index];
+  if (!value) {
+    throw new Error(`Missing value for ${flag}`);
+  }
+  return value;
+}
+
+function readInteger(args: string[], index: number, flag: string) {
+  const value = Number.parseInt(readValue(args, index, flag), 10);
+  if (!Number.isFinite(value) || value < 0) {
+    throw new Error(`Invalid integer for ${flag}`);
+  }
+  return value;
+}

--- a/packages/github-reporter/src/cli-options.ts
+++ b/packages/github-reporter/src/cli-options.ts
@@ -1,5 +1,5 @@
 export type CliOptions = {
-  jsonPath?: string;
+  jsonPath: string;
   summaryPath?: string;
   summaryEnabled: boolean;
   annotations: boolean;
@@ -16,12 +16,16 @@ export type CliOptions = {
   help: boolean;
 };
 
+type MutableCliOptions = Omit<CliOptions, "jsonPath"> & {
+  jsonPath?: string;
+};
+
 /** Parses GitHub reporter CLI arguments, with explicit arguments taking precedence over environment defaults. */
 export function parseCliArgs(
   args: string[],
   env: NodeJS.ProcessEnv = process.env,
 ): CliOptions {
-  const options: CliOptions = {
+  const options: MutableCliOptions = {
     summaryPath: env.GITHUB_STEP_SUMMARY,
     summaryEnabled: true,
     annotations: env.GITHUB_ACTIONS === "true",
@@ -83,7 +87,7 @@ export function parseCliArgs(
       case "--help":
       case "-h":
         options.help = true;
-        break;
+        return withDefaultJsonPath(options, env);
       default:
         if (!arg.startsWith("-") && !options.jsonPath) {
           options.jsonPath = arg;
@@ -93,9 +97,18 @@ export function parseCliArgs(
     }
   }
 
-  options.jsonPath ??= env.VITEST_EVALS_JSON_REPORT ?? "vitest-results.json";
+  return withDefaultJsonPath(options, env);
+}
 
-  return options;
+function withDefaultJsonPath(
+  options: MutableCliOptions,
+  env: NodeJS.ProcessEnv,
+): CliOptions {
+  return {
+    ...options,
+    jsonPath:
+      options.jsonPath || env.VITEST_EVALS_JSON_REPORT || "vitest-results.json",
+  };
 }
 
 function readValue(args: string[], index: number, flag: string) {

--- a/packages/github-reporter/src/cli.ts
+++ b/packages/github-reporter/src/cli.ts
@@ -74,7 +74,7 @@ async function main() {
 
 function warn(message: string) {
   if (process.env.GITHUB_ACTIONS === "true") {
-    console.error(`::warning::${escapeCommandData(message)}`);
+    console.log(`::warning::${escapeCommandData(message)}`);
     return;
   }
   console.error(`Warning: ${message}`);

--- a/packages/github-reporter/src/cli.ts
+++ b/packages/github-reporter/src/cli.ts
@@ -1,0 +1,208 @@
+#!/usr/bin/env node
+import { appendFile, readFile } from "node:fs/promises";
+import { collectEvalReport } from "./collect";
+import { publishCheckRun } from "./github";
+import { renderWorkflowCommands } from "./annotations";
+import { renderJobSummary } from "./summary";
+import type { VitestJsonReport } from "./types";
+import { escapeCommandData } from "./utils";
+
+type CliOptions = {
+  jsonPath?: string;
+  summaryPath?: string;
+  summaryEnabled: boolean;
+  annotations: boolean;
+  checkRun: boolean;
+  failOnCheckError: boolean;
+  maxAnnotations?: number;
+  maxFailures?: number;
+  checkRunId?: number;
+  checkName?: string;
+  token?: string;
+  repository?: string;
+  sha?: string;
+  workspace?: string;
+};
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+});
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  if (!options.jsonPath) {
+    console.error(usage());
+    process.exitCode = 1;
+    return;
+  }
+
+  const json = JSON.parse(
+    await readFile(options.jsonPath, "utf8"),
+  ) as VitestJsonReport;
+  const report = collectEvalReport(json, {
+    workspace:
+      options.workspace ?? process.env.GITHUB_WORKSPACE ?? process.cwd(),
+  });
+  const summary = renderJobSummary(report, {
+    maxFailures: options.maxFailures,
+  });
+
+  if (options.summaryEnabled) {
+    if (options.summaryPath) {
+      await appendFile(options.summaryPath, `${summary}\n`);
+    } else {
+      console.log(summary);
+    }
+  }
+
+  if (options.annotations) {
+    for (const command of renderWorkflowCommands(report, {
+      maxAnnotations: options.maxAnnotations,
+    })) {
+      console.log(command);
+    }
+  }
+
+  if (options.checkRun) {
+    try {
+      const result = await publishCheckRun(report, {
+        checkRunId: options.checkRunId,
+        maxAnnotations: options.maxAnnotations,
+        maxFailures: options.maxFailures,
+        name: options.checkName,
+        repository: options.repository,
+        sha: options.sha,
+        token: options.token,
+      });
+
+      if (result.status === "skipped") {
+        warn(`GitHub Check Run skipped: ${result.reason}`);
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      if (options.failOnCheckError) {
+        throw error;
+      }
+      warn(message);
+    }
+  }
+}
+
+function parseArgs(args: string[]): CliOptions {
+  const options: CliOptions = {
+    jsonPath: process.env.VITEST_EVALS_JSON_REPORT ?? "vitest-results.json",
+    summaryPath: process.env.GITHUB_STEP_SUMMARY,
+    summaryEnabled: true,
+    annotations: process.env.GITHUB_ACTIONS === "true",
+    checkRun: false,
+    failOnCheckError: false,
+  };
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    switch (arg) {
+      case "--json":
+        options.jsonPath = readValue(args, ++index, arg);
+        break;
+      case "--summary":
+        options.summaryPath = readValue(args, ++index, arg);
+        options.summaryEnabled = true;
+        break;
+      case "--no-summary":
+        options.summaryEnabled = false;
+        break;
+      case "--annotations":
+        options.annotations = true;
+        break;
+      case "--no-annotations":
+        options.annotations = false;
+        break;
+      case "--check-run":
+        options.checkRun = true;
+        break;
+      case "--fail-on-check-error":
+        options.failOnCheckError = true;
+        break;
+      case "--max-annotations":
+        options.maxAnnotations = readInteger(args, ++index, arg);
+        break;
+      case "--max-failures":
+        options.maxFailures = readInteger(args, ++index, arg);
+        break;
+      case "--check-run-id":
+        options.checkRunId = readInteger(args, ++index, arg);
+        options.checkRun = true;
+        break;
+      case "--check-name":
+        options.checkName = readValue(args, ++index, arg);
+        break;
+      case "--token":
+        options.token = readValue(args, ++index, arg);
+        break;
+      case "--repo":
+        options.repository = readValue(args, ++index, arg);
+        break;
+      case "--sha":
+        options.sha = readValue(args, ++index, arg);
+        break;
+      case "--workspace":
+        options.workspace = readValue(args, ++index, arg);
+        break;
+      case "--help":
+      case "-h":
+        console.log(usage());
+        process.exit(0);
+        return options;
+      default:
+        if (!arg.startsWith("-") && !options.jsonPath) {
+          options.jsonPath = arg;
+          break;
+        }
+        throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  return options;
+}
+
+function readValue(args: string[], index: number, flag: string) {
+  const value = args[index];
+  if (!value) {
+    throw new Error(`Missing value for ${flag}`);
+  }
+  return value;
+}
+
+function readInteger(args: string[], index: number, flag: string) {
+  const value = Number.parseInt(readValue(args, index, flag), 10);
+  if (!Number.isFinite(value) || value < 0) {
+    throw new Error(`Invalid integer for ${flag}`);
+  }
+  return value;
+}
+
+function warn(message: string) {
+  if (process.env.GITHUB_ACTIONS === "true") {
+    console.error(`::warning::${escapeCommandData(message)}`);
+    return;
+  }
+  console.error(`Warning: ${message}`);
+}
+
+function usage() {
+  return [
+    "Usage: vitest-evals-github-report [--json <vitest-results.json>]",
+    "",
+    "Options:",
+    "  --summary <path>          Write job summary markdown to this path",
+    "  --no-summary             Disable summary output",
+    "  --annotations            Emit GitHub workflow-command annotations",
+    "  --no-annotations         Disable workflow-command annotations",
+    "  --check-run              Publish a GitHub Check Run when configured",
+    "  --check-run-id <id>      Update an existing Check Run",
+    "  --check-name <name>      Check Run name (default: vitest-evals)",
+    "  --max-annotations <n>    Maximum annotations to emit",
+    "  --max-failures <n>       Maximum failures to include in details",
+  ].join("\n");
+}

--- a/packages/github-reporter/src/cli.ts
+++ b/packages/github-reporter/src/cli.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import { appendFile, readFile } from "node:fs/promises";
+import { parseCliArgs } from "./cli-options";
 import { collectEvalReport } from "./collect";
 import { publishCheckRun } from "./github";
 import { renderWorkflowCommands } from "./annotations";
@@ -7,30 +8,17 @@ import { renderJobSummary } from "./summary";
 import type { VitestJsonReport } from "./types";
 import { escapeCommandData } from "./utils";
 
-type CliOptions = {
-  jsonPath?: string;
-  summaryPath?: string;
-  summaryEnabled: boolean;
-  annotations: boolean;
-  checkRun: boolean;
-  failOnCheckError: boolean;
-  maxAnnotations?: number;
-  maxFailures?: number;
-  checkRunId?: number;
-  checkName?: string;
-  token?: string;
-  repository?: string;
-  sha?: string;
-  workspace?: string;
-};
-
 main().catch((error) => {
   console.error(error instanceof Error ? error.message : String(error));
   process.exitCode = 1;
 });
 
 async function main() {
-  const options = parseArgs(process.argv.slice(2));
+  const options = parseCliArgs(process.argv.slice(2));
+  if (options.help) {
+    console.log(usage());
+    return;
+  }
   if (!options.jsonPath) {
     console.error(usage());
     process.exitCode = 1;
@@ -89,99 +77,6 @@ async function main() {
   }
 }
 
-function parseArgs(args: string[]): CliOptions {
-  const options: CliOptions = {
-    jsonPath: process.env.VITEST_EVALS_JSON_REPORT ?? "vitest-results.json",
-    summaryPath: process.env.GITHUB_STEP_SUMMARY,
-    summaryEnabled: true,
-    annotations: process.env.GITHUB_ACTIONS === "true",
-    checkRun: false,
-    failOnCheckError: false,
-  };
-
-  for (let index = 0; index < args.length; index += 1) {
-    const arg = args[index];
-    switch (arg) {
-      case "--json":
-        options.jsonPath = readValue(args, ++index, arg);
-        break;
-      case "--summary":
-        options.summaryPath = readValue(args, ++index, arg);
-        options.summaryEnabled = true;
-        break;
-      case "--no-summary":
-        options.summaryEnabled = false;
-        break;
-      case "--annotations":
-        options.annotations = true;
-        break;
-      case "--no-annotations":
-        options.annotations = false;
-        break;
-      case "--check-run":
-        options.checkRun = true;
-        break;
-      case "--fail-on-check-error":
-        options.failOnCheckError = true;
-        break;
-      case "--max-annotations":
-        options.maxAnnotations = readInteger(args, ++index, arg);
-        break;
-      case "--max-failures":
-        options.maxFailures = readInteger(args, ++index, arg);
-        break;
-      case "--check-run-id":
-        options.checkRunId = readInteger(args, ++index, arg);
-        options.checkRun = true;
-        break;
-      case "--check-name":
-        options.checkName = readValue(args, ++index, arg);
-        break;
-      case "--token":
-        options.token = readValue(args, ++index, arg);
-        break;
-      case "--repo":
-        options.repository = readValue(args, ++index, arg);
-        break;
-      case "--sha":
-        options.sha = readValue(args, ++index, arg);
-        break;
-      case "--workspace":
-        options.workspace = readValue(args, ++index, arg);
-        break;
-      case "--help":
-      case "-h":
-        console.log(usage());
-        process.exit(0);
-        return options;
-      default:
-        if (!arg.startsWith("-") && !options.jsonPath) {
-          options.jsonPath = arg;
-          break;
-        }
-        throw new Error(`Unknown argument: ${arg}`);
-    }
-  }
-
-  return options;
-}
-
-function readValue(args: string[], index: number, flag: string) {
-  const value = args[index];
-  if (!value) {
-    throw new Error(`Missing value for ${flag}`);
-  }
-  return value;
-}
-
-function readInteger(args: string[], index: number, flag: string) {
-  const value = Number.parseInt(readValue(args, index, flag), 10);
-  if (!Number.isFinite(value) || value < 0) {
-    throw new Error(`Invalid integer for ${flag}`);
-  }
-  return value;
-}
-
 function warn(message: string) {
   if (process.env.GITHUB_ACTIONS === "true") {
     console.error(`::warning::${escapeCommandData(message)}`);
@@ -192,7 +87,7 @@ function warn(message: string) {
 
 function usage() {
   return [
-    "Usage: vitest-evals-github-report [--json <vitest-results.json>]",
+    "Usage: vitest-evals-github-report [vitest-results.json] [--json <path>]",
     "",
     "Options:",
     "  --summary <path>          Write job summary markdown to this path",

--- a/packages/github-reporter/src/cli.ts
+++ b/packages/github-reporter/src/cli.ts
@@ -19,11 +19,6 @@ async function main() {
     console.log(usage());
     return;
   }
-  if (!options.jsonPath) {
-    console.error(usage());
-    process.exitCode = 1;
-    return;
-  }
 
   const json = JSON.parse(
     await readFile(options.jsonPath, "utf8"),
@@ -90,13 +85,19 @@ function usage() {
     "Usage: vitest-evals-github-report [vitest-results.json] [--json <path>]",
     "",
     "Options:",
+    "  --json <path>             Read Vitest JSON report from this path",
     "  --summary <path>          Write job summary markdown to this path",
     "  --no-summary             Disable summary output",
     "  --annotations            Emit GitHub workflow-command annotations",
     "  --no-annotations         Disable workflow-command annotations",
     "  --check-run              Publish a GitHub Check Run when configured",
+    "  --fail-on-check-error    Fail when Check Run publishing fails",
     "  --check-run-id <id>      Update an existing Check Run",
     "  --check-name <name>      Check Run name (default: vitest-evals)",
+    "  --token <token>          GitHub token (default: GITHUB_TOKEN)",
+    "  --repo <owner/repo>      GitHub repository (default: GITHUB_REPOSITORY)",
+    "  --sha <sha>              Git commit SHA (default: GITHUB_SHA)",
+    "  --workspace <path>       Workspace path for relative annotation files",
     "  --max-annotations <n>    Maximum annotations to emit",
     "  --max-failures <n>       Maximum failures to include in details",
   ].join("\n");

--- a/packages/github-reporter/src/collect.ts
+++ b/packages/github-reporter/src/collect.ts
@@ -1,0 +1,344 @@
+import type {
+  CollectOptions,
+  EvalCase,
+  EvalFailure,
+  EvalReport,
+  EvalScore,
+  ToolCallSummary,
+  UsageSummary,
+  VitestJsonAssertion,
+  VitestJsonFile,
+  VitestJsonReport,
+} from "./types";
+import {
+  compactLine,
+  isRecord,
+  normalizePathForGitHub,
+  stringifyValue,
+} from "./utils";
+
+type EvalMeta = {
+  scores?: EvalScore[];
+  avgScore?: number;
+  output?: unknown;
+  thresholdFailed?: boolean;
+};
+
+type HarnessMeta = {
+  name?: string;
+  run?: {
+    output?: unknown;
+    usage?: UsageSummary;
+    timings?: {
+      totalMs?: number;
+    };
+    session?: {
+      messages?: Array<{
+        toolCalls?: unknown[];
+      }>;
+    };
+    errors?: unknown[];
+  };
+};
+
+type HarnessRunMeta = NonNullable<HarnessMeta["run"]>;
+
+/** Converts a Vitest JSON report into the compact eval report model. */
+export function collectEvalReport(
+  input: VitestJsonReport,
+  options: CollectOptions = {},
+): EvalReport {
+  const cases = input.testResults.flatMap((file) =>
+    file.assertionResults.flatMap((assertion) => {
+      const evalCase = collectEvalCase(file, assertion, options);
+      return evalCase ? [evalCase] : [];
+    }),
+  );
+  const failures = cases.filter((testCase) => testCase.status === "failed");
+  const evalScores = cases
+    .map((testCase) => testCase.eval?.avgScore)
+    .filter((score): score is number => typeof score === "number");
+  const usage = sumUsage(cases);
+  const durationMs = resolveRunDuration(input);
+
+  return {
+    status: input.success && failures.length === 0 ? "passed" : "failed",
+    startedAt: input.startTime,
+    durationMs,
+    totals: {
+      total: input.numTotalTests,
+      passed: input.numPassedTests,
+      failed: input.numFailedTests,
+      skipped: input.numPendingTests + input.numTodoTests,
+      evalTotal: cases.length,
+      evalPassed: cases.filter((testCase) => testCase.status === "passed")
+        .length,
+      evalFailed: failures.length,
+    },
+    score:
+      evalScores.length > 0
+        ? {
+            average:
+              evalScores.reduce((total, score) => total + score, 0) /
+              evalScores.length,
+            minimum: Math.min(...evalScores),
+          }
+        : undefined,
+    usage,
+    cases,
+    failures,
+  };
+}
+
+function collectEvalCase(
+  file: VitestJsonFile,
+  assertion: VitestJsonAssertion,
+  options: CollectOptions,
+): EvalCase | null {
+  const meta = isRecord(assertion.meta) ? assertion.meta : {};
+  const evalMeta = getEvalMeta(meta.eval);
+  const harnessMeta = getHarnessMeta(meta.harness);
+
+  if (!evalMeta && !harnessMeta) {
+    return null;
+  }
+
+  const displayFile = normalizePathForGitHub(file.name, options.workspace);
+  const scores = evalMeta?.scores ?? [];
+  const harnessRun = harnessMeta?.run;
+  const toolCalls = collectToolCalls(harnessRun?.session);
+  const evalCase: EvalCase = {
+    id: `${file.name}:${assertion.location?.line ?? 0}:${assertion.fullName}`,
+    file: file.name,
+    displayFile,
+    title: assertion.title,
+    displayName: formatDisplayName(assertion),
+    status: assertion.status,
+    durationMs:
+      typeof assertion.duration === "number" ? assertion.duration : undefined,
+    location: assertion.location ?? undefined,
+    failureMessages: assertion.failureMessages ?? [],
+    eval: evalMeta
+      ? {
+          avgScore: evalMeta.avgScore,
+          thresholdFailed: evalMeta.thresholdFailed,
+          output: evalMeta.output,
+          scores,
+        }
+      : undefined,
+    harness: harnessMeta
+      ? {
+          name: harnessMeta.name,
+          output: harnessRun?.output,
+          usage: harnessRun?.usage,
+          timingMs: harnessRun?.timings?.totalMs,
+          toolCalls,
+          errors: harnessRun?.errors ?? [],
+        }
+      : undefined,
+  };
+
+  evalCase.primaryFailure = getPrimaryFailure(evalCase);
+  return evalCase;
+}
+
+function getEvalMeta(value: unknown): EvalMeta | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+
+  return {
+    scores: Array.isArray(value.scores)
+      ? value.scores.filter(isRecord).map(normalizeScore)
+      : undefined,
+    avgScore: typeof value.avgScore === "number" ? value.avgScore : undefined,
+    output: value.output,
+    thresholdFailed:
+      typeof value.thresholdFailed === "boolean"
+        ? value.thresholdFailed
+        : undefined,
+  };
+}
+
+function normalizeScore(score: Record<string, unknown>): EvalScore {
+  const metadata = isRecord(score.metadata) ? score.metadata : undefined;
+  return {
+    name: typeof score.name === "string" ? score.name : undefined,
+    score: typeof score.score === "number" ? score.score : null,
+    metadata: metadata
+      ? {
+          ...metadata,
+          rationale: metadata.rationale,
+          output: metadata.output,
+        }
+      : undefined,
+  };
+}
+
+function getHarnessMeta(value: unknown): HarnessMeta | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+  const run = isRecord(value.run) ? value.run : undefined;
+  const usage = isRecord(run?.usage) ? getUsage(run.usage) : undefined;
+  const timings = isRecord(run?.timings) ? run.timings : undefined;
+
+  return {
+    name: typeof value.name === "string" ? value.name : undefined,
+    run: run
+      ? {
+          output: run.output,
+          usage,
+          timings: {
+            totalMs:
+              typeof timings?.totalMs === "number"
+                ? timings.totalMs
+                : undefined,
+          },
+          session: isRecord(run.session)
+            ? {
+                messages: Array.isArray(run.session.messages)
+                  ? (run.session.messages as Array<{ toolCalls?: unknown[] }>)
+                  : undefined,
+              }
+            : undefined,
+          errors: Array.isArray(run.errors) ? run.errors : undefined,
+        }
+      : undefined,
+  };
+}
+
+function getUsage(value: Record<string, unknown>): UsageSummary {
+  return {
+    inputTokens: numberField(value.inputTokens),
+    outputTokens: numberField(value.outputTokens),
+    reasoningTokens: numberField(value.reasoningTokens),
+    totalTokens: numberField(value.totalTokens),
+    estimatedCost: numberField(value.estimatedCost),
+    toolCalls: numberField(value.toolCalls),
+  };
+}
+
+function numberField(value: unknown) {
+  return typeof value === "number" && Number.isFinite(value)
+    ? value
+    : undefined;
+}
+
+function collectToolCalls(session: HarnessRunMeta["session"] | undefined) {
+  const messages = session?.messages ?? [];
+  const toolCalls: ToolCallSummary[] = [];
+
+  for (const message of messages) {
+    if (!Array.isArray(message.toolCalls)) {
+      continue;
+    }
+
+    for (const call of message.toolCalls) {
+      if (!isRecord(call) || typeof call.name !== "string") {
+        continue;
+      }
+
+      toolCalls.push({
+        name: call.name,
+        error: getToolCallError(call.error),
+        durationMs: numberField(call.durationMs),
+      });
+    }
+  }
+
+  return toolCalls;
+}
+
+function getToolCallError(value: unknown) {
+  if (isRecord(value) && typeof value.message === "string") {
+    return value.message;
+  }
+  if (value !== undefined) {
+    return stringifyValue(value, 240);
+  }
+  return undefined;
+}
+
+function getPrimaryFailure(testCase: EvalCase): EvalFailure | undefined {
+  const failingScores = [...(testCase.eval?.scores ?? [])]
+    .filter(
+      (score) =>
+        (score.score ?? 0) < 1 ||
+        score.metadata?.rationale !== undefined ||
+        score.metadata?.output !== undefined,
+    )
+    .sort((left, right) => (left.score ?? 0) - (right.score ?? 0));
+  const primary = failingScores[0];
+  const score =
+    typeof primary?.score === "number"
+      ? primary.score
+      : testCase.eval?.avgScore;
+  const reason =
+    stringifyReason(primary?.metadata?.rationale) ??
+    compactLine(testCase.failureMessages.join("\n"), 500);
+
+  if (!primary && !reason && score === undefined) {
+    return undefined;
+  }
+
+  return {
+    judgeName: primary?.name,
+    score,
+    reason: reason || undefined,
+  };
+}
+
+function stringifyReason(value: unknown) {
+  if (value === undefined) {
+    return undefined;
+  }
+  return typeof value === "string" ? value : stringifyValue(value, 4000);
+}
+
+function formatDisplayName(assertion: VitestJsonAssertion) {
+  return [...assertion.ancestorTitles, assertion.title]
+    .filter((part) => part.length > 0)
+    .join(" > ");
+}
+
+function sumUsage(cases: EvalCase[]) {
+  const usage: Required<UsageSummary> = {
+    inputTokens: 0,
+    outputTokens: 0,
+    reasoningTokens: 0,
+    totalTokens: 0,
+    estimatedCost: 0,
+    toolCalls: 0,
+  };
+
+  for (const testCase of cases) {
+    const caseUsage = testCase.harness?.usage;
+    usage.inputTokens += caseUsage?.inputTokens ?? 0;
+    usage.outputTokens += caseUsage?.outputTokens ?? 0;
+    usage.reasoningTokens += caseUsage?.reasoningTokens ?? 0;
+    usage.totalTokens +=
+      caseUsage?.totalTokens ??
+      (caseUsage?.inputTokens ?? 0) +
+        (caseUsage?.outputTokens ?? 0) +
+        (caseUsage?.reasoningTokens ?? 0);
+    usage.estimatedCost += caseUsage?.estimatedCost ?? 0;
+    usage.toolCalls +=
+      caseUsage?.toolCalls ?? testCase.harness?.toolCalls.length ?? 0;
+  }
+
+  return usage;
+}
+
+function resolveRunDuration(input: VitestJsonReport) {
+  const startTimes = input.testResults
+    .map((file) => file.startTime)
+    .filter((time) => Number.isFinite(time));
+  const endTimes = input.testResults
+    .map((file) => file.endTime)
+    .filter((time) => Number.isFinite(time));
+  if (startTimes.length === 0 || endTimes.length === 0) {
+    return undefined;
+  }
+  return Math.max(...endTimes) - Math.min(...startTimes);
+}

--- a/packages/github-reporter/src/collect.ts
+++ b/packages/github-reporter/src/collect.ts
@@ -165,13 +165,7 @@ function normalizeScore(score: Record<string, unknown>): EvalScore {
   return {
     name: typeof score.name === "string" ? score.name : undefined,
     score: typeof score.score === "number" ? score.score : null,
-    metadata: metadata
-      ? {
-          ...metadata,
-          rationale: metadata.rationale,
-          output: metadata.output,
-        }
-      : undefined,
+    metadata,
   };
 }
 

--- a/packages/github-reporter/src/collect.ts
+++ b/packages/github-reporter/src/collect.ts
@@ -57,7 +57,7 @@ export function collectEvalReport(
   const failures = cases.filter((testCase) => testCase.status === "failed");
   const evalScores = cases
     .map((testCase) => testCase.eval?.avgScore)
-    .filter((score): score is number => typeof score === "number");
+    .filter((score): score is number => isFiniteNumber(score));
   const usage = sumUsage(cases);
   const durationMs = resolveRunDuration(input);
 
@@ -151,7 +151,7 @@ function getEvalMeta(value: unknown): EvalMeta | undefined {
     scores: Array.isArray(value.scores)
       ? value.scores.filter(isRecord).map(normalizeScore)
       : undefined,
-    avgScore: typeof value.avgScore === "number" ? value.avgScore : undefined,
+    avgScore: numberField(value.avgScore),
     output: value.output,
     thresholdFailed:
       typeof value.thresholdFailed === "boolean"
@@ -164,7 +164,7 @@ function normalizeScore(score: Record<string, unknown>): EvalScore {
   const metadata = isRecord(score.metadata) ? score.metadata : undefined;
   return {
     name: typeof score.name === "string" ? score.name : undefined,
-    score: typeof score.score === "number" ? score.score : null,
+    score: numberField(score.score) ?? null,
     metadata,
   };
 }
@@ -214,9 +214,11 @@ function getUsage(value: Record<string, unknown>): UsageSummary {
 }
 
 function numberField(value: unknown) {
-  return typeof value === "number" && Number.isFinite(value)
-    ? value
-    : undefined;
+  return isFiniteNumber(value) ? value : undefined;
+}
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value);
 }
 
 function collectToolCalls(session: HarnessRunMeta["session"] | undefined) {

--- a/packages/github-reporter/src/github.ts
+++ b/packages/github-reporter/src/github.ts
@@ -25,6 +25,8 @@ export type PublishCheckRunResult =
 
 const DEFAULT_CHECK_NAME = "vitest-evals";
 const MAX_CHECK_SUMMARY_LENGTH = 64_000;
+const CHECK_SUMMARY_TRUNCATION_SUFFIX =
+  "\n\n[truncated for GitHub Check Run]\n";
 
 /** Publishes the eval report to a GitHub Check Run when configuration allows it. */
 export async function publishCheckRun(
@@ -139,5 +141,7 @@ function truncateCheckSummary(summary: string) {
     return summary;
   }
 
-  return `${summary.slice(0, MAX_CHECK_SUMMARY_LENGTH - 34).trimEnd()}\n\n[truncated for GitHub Check Run]\n`;
+  return `${summary
+    .slice(0, MAX_CHECK_SUMMARY_LENGTH - CHECK_SUMMARY_TRUNCATION_SUFFIX.length)
+    .trimEnd()}${CHECK_SUMMARY_TRUNCATION_SUFFIX}`;
 }

--- a/packages/github-reporter/src/github.ts
+++ b/packages/github-reporter/src/github.ts
@@ -1,0 +1,143 @@
+import { buildCheckAnnotations } from "./annotations";
+import { renderJobSummary, type SummaryOptions } from "./summary";
+import type { EvalReport } from "./types";
+
+export type PublishCheckRunOptions = SummaryOptions & {
+  token?: string;
+  repository?: string;
+  sha?: string;
+  name?: string;
+  apiUrl?: string;
+  checkRunId?: number;
+  maxAnnotations?: number;
+};
+
+export type PublishCheckRunResult =
+  | {
+      status: "skipped";
+      reason: string;
+    }
+  | {
+      status: "created" | "updated";
+      id?: number;
+      htmlUrl?: string;
+    };
+
+const DEFAULT_CHECK_NAME = "vitest-evals";
+const MAX_CHECK_SUMMARY_LENGTH = 64_000;
+
+/** Publishes the eval report to a GitHub Check Run when configuration allows it. */
+export async function publishCheckRun(
+  report: EvalReport,
+  options: PublishCheckRunOptions = {},
+): Promise<PublishCheckRunResult> {
+  const token = options.token ?? process.env.GITHUB_TOKEN;
+  const repository = options.repository ?? process.env.GITHUB_REPOSITORY;
+  const sha = options.sha ?? process.env.GITHUB_SHA;
+
+  if (!token) {
+    return { status: "skipped", reason: "missing GITHUB_TOKEN" };
+  }
+  if (!repository) {
+    return { status: "skipped", reason: "missing GITHUB_REPOSITORY" };
+  }
+  if (!sha && options.checkRunId === undefined) {
+    return { status: "skipped", reason: "missing GITHUB_SHA" };
+  }
+
+  const [owner, repo] = repository.split("/");
+  if (!owner || !repo) {
+    return {
+      status: "skipped",
+      reason: `invalid GitHub repository: ${repository}`,
+    };
+  }
+
+  const payload = buildCheckRunPayload(report, options);
+  const apiUrl =
+    options.apiUrl ?? process.env.GITHUB_API_URL ?? "https://api.github.com";
+  const requestUrl =
+    options.checkRunId === undefined
+      ? `${apiUrl}/repos/${owner}/${repo}/check-runs`
+      : `${apiUrl}/repos/${owner}/${repo}/check-runs/${options.checkRunId}`;
+  const response = await fetch(requestUrl, {
+    method: options.checkRunId === undefined ? "POST" : "PATCH",
+    headers: {
+      accept: "application/vnd.github+json",
+      authorization: `Bearer ${token}`,
+      "content-type": "application/json",
+      "x-github-api-version": "2022-11-28",
+    },
+    body: JSON.stringify(
+      options.checkRunId === undefined
+        ? {
+            name: options.name ?? DEFAULT_CHECK_NAME,
+            head_sha: sha,
+            ...payload,
+          }
+        : payload,
+    ),
+  });
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(
+      `GitHub Check Run request failed: ${response.status} ${response.statusText} ${text}`.trim(),
+    );
+  }
+
+  const data = (await response.json()) as {
+    id?: number;
+    html_url?: string;
+  };
+
+  return {
+    status: options.checkRunId === undefined ? "created" : "updated",
+    id: data.id,
+    htmlUrl: data.html_url,
+  };
+}
+
+function buildCheckRunPayload(
+  report: EvalReport,
+  options: PublishCheckRunOptions,
+) {
+  const annotations = buildCheckAnnotations(report, {
+    maxAnnotations: options.maxAnnotations,
+  });
+  const title =
+    report.failures.length === 0 && report.status === "passed"
+      ? "No eval failures"
+      : report.failures.length === 0
+        ? "Vitest run failed"
+        : `${report.failures.length} eval failure${
+            report.failures.length === 1 ? "" : "s"
+          }`;
+
+  return {
+    status: "completed",
+    conclusion: report.status === "passed" ? "success" : "failure",
+    completed_at: new Date().toISOString(),
+    output: {
+      title,
+      summary: truncateCheckSummary(
+        renderJobSummary(report, {
+          ...options,
+          maxFailures: options.maxFailures ?? 5,
+          maxReasonChars: options.maxReasonChars ?? 4000,
+          maxOutputChars: options.maxOutputChars ?? 2000,
+          maxToolCalls: options.maxToolCalls ?? 10,
+        }),
+      ),
+      annotations,
+    },
+  };
+}
+
+function truncateCheckSummary(summary: string) {
+  if (summary.length <= MAX_CHECK_SUMMARY_LENGTH) {
+    return summary;
+  }
+
+  return `${summary.slice(0, MAX_CHECK_SUMMARY_LENGTH - 34).trimEnd()}\n\n[truncated for GitHub Check Run]\n`;
+}

--- a/packages/github-reporter/src/index.ts
+++ b/packages/github-reporter/src/index.ts
@@ -1,0 +1,20 @@
+export { collectEvalReport } from "./collect";
+export {
+  buildCheckAnnotations,
+  renderWorkflowCommands,
+  type AnnotationOptions,
+  type CheckAnnotation,
+} from "./annotations";
+export {
+  publishCheckRun,
+  type PublishCheckRunOptions,
+  type PublishCheckRunResult,
+} from "./github";
+export { renderJobSummary, type SummaryOptions } from "./summary";
+export type {
+  EvalCase,
+  EvalFailure,
+  EvalReport,
+  EvalScore,
+  VitestJsonReport,
+} from "./types";

--- a/packages/github-reporter/src/report.test.ts
+++ b/packages/github-reporter/src/report.test.ts
@@ -272,7 +272,7 @@ describe("renderWorkflowCommands", () => {
     });
 
     expect(renderWorkflowCommands(report)).toEqual([
-      "::error file=apps/demo/evals/refund.eval.ts,line=42,column=3,title=vitest-evals::refund agent > rejects fraud - score 0.20 - StructuredOutputJudge - bad value: expected, got 20%25",
+      "::error file=apps/demo/evals/refund.eval.ts,line=42,col=3,title=vitest-evals::refund agent > rejects fraud - score 0.20 - StructuredOutputJudge - bad value: expected, got 20%25",
     ]);
   });
 

--- a/packages/github-reporter/src/report.test.ts
+++ b/packages/github-reporter/src/report.test.ts
@@ -1,10 +1,11 @@
 import { afterEach, describe, expect, test, vi } from "vitest";
 import { renderWorkflowCommands } from "./annotations";
+import { parseCliArgs } from "./cli-options";
 import { collectEvalReport } from "./collect";
 import { publishCheckRun } from "./github";
 import { renderJobSummary } from "./summary";
 import type { VitestJsonReport } from "./types";
-import { normalizePathForGitHub } from "./utils";
+import { formatDuration, normalizePathForGitHub } from "./utils";
 
 const sampleJson: VitestJsonReport = {
   numFailedTests: 1,
@@ -159,6 +160,36 @@ describe("normalizePathForGitHub", () => {
   });
 });
 
+describe("parseCliArgs", () => {
+  test("accepts a positional JSON report path", () => {
+    expect(parseCliArgs(["custom-results.json"], {})).toMatchObject({
+      jsonPath: "custom-results.json",
+    });
+  });
+
+  test("uses the default JSON report path when no path is provided", () => {
+    expect(parseCliArgs([], {})).toMatchObject({
+      jsonPath: "vitest-results.json",
+    });
+  });
+
+  test("lets CLI paths override environment defaults", () => {
+    expect(
+      parseCliArgs(["custom-results.json"], {
+        VITEST_EVALS_JSON_REPORT: "env-results.json",
+      }),
+    ).toMatchObject({
+      jsonPath: "custom-results.json",
+    });
+  });
+});
+
+describe("formatDuration", () => {
+  test("carries rounded seconds into minutes", () => {
+    expect(formatDuration(119_500)).toBe("2m 0s");
+  });
+});
+
 describe("renderJobSummary", () => {
   test("renders compact ASCII markdown without failure tables", () => {
     const report = collectEvalReport(sampleJson, {
@@ -299,6 +330,42 @@ describe("publishCheckRun", () => {
         ],
       },
     });
+  });
+
+  test("caps Check Run summary at GitHub's summary length limit", async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({
+        id: 125,
+      }),
+      text: async () => "",
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const report = collectEvalReport(sampleJson, {
+      workspace: "/repo",
+    });
+    report.failures[0]!.primaryFailure = {
+      ...report.failures[0]!.primaryFailure,
+      reason: "x".repeat(70_000),
+    };
+
+    await publishCheckRun(report, {
+      token: "token",
+      repository: "getsentry/vitest-evals",
+      sha: "abc123",
+      maxReasonChars: 70_000,
+    });
+
+    const [, request] = fetchMock.mock.calls[0] as unknown as [
+      string,
+      { body: string },
+    ];
+    const body = JSON.parse(request.body);
+    expect(body.output.summary).toHaveLength(64_000);
+    expect(
+      body.output.summary.endsWith("\n\n[truncated for GitHub Check Run]\n"),
+    ).toBe(true);
   });
 
   test("uses a non-eval failure title for failed runs without eval failures", async () => {

--- a/packages/github-reporter/src/report.test.ts
+++ b/packages/github-reporter/src/report.test.ts
@@ -147,6 +147,24 @@ describe("collectEvalReport", () => {
       },
     });
   });
+
+  test("ignores non-finite eval scores", () => {
+    const json = structuredClone(sampleJson);
+    const evalMeta = (json.testResults[0]?.assertionResults[0]?.meta as any)
+      .eval;
+    evalMeta.avgScore = Number.POSITIVE_INFINITY;
+    evalMeta.scores[0].score = Number.POSITIVE_INFINITY;
+
+    const report = collectEvalReport(json, {
+      workspace: "/repo",
+    });
+
+    expect(report.score).toBeUndefined();
+    expect(report.failures[0]?.eval?.avgScore).toBeUndefined();
+    expect(report.failures[0]?.eval?.scores[0]?.score).toBeNull();
+    expect(renderJobSummary(report)).not.toContain("Infinity");
+    expect(renderWorkflowCommands(report)[0]).toContain("score n/a");
+  });
 });
 
 describe("normalizePathForGitHub", () => {
@@ -198,19 +216,55 @@ describe("formatDuration", () => {
 });
 
 describe("renderJobSummary", () => {
-  test("renders compact ASCII markdown without failure tables", () => {
+  test("renders the summary table before result details", () => {
     const report = collectEvalReport(sampleJson, {
       workspace: "/repo",
     });
     const summary = renderJobSummary(report);
 
-    expect(summary).toContain("## vitest-evals");
-    expect(summary).toContain("Status: failed");
-    expect(summary).toContain("Score: avg 0.20, min 0.20");
-    expect(summary).toContain("1. refund agent > rejects fraud");
-    expect(summary).toContain("Reason:");
-    expect(summary).toContain("```text");
+    expect(summary).toContain("# vitest-evals");
+    expect(summary).toContain("## Results");
+    expect(summary.indexOf("| Metric | Value |")).toBeLessThan(
+      summary.indexOf("## Results"),
+    );
+    expect(summary).toContain("### Failures");
+    expect(summary).toContain("<details>");
+    expect(summary).toContain(
+      "<summary>1. refund agent &gt; rejects fraud - StructuredOutputJudge - 0.20</summary>",
+    );
+    expect(summary).toContain("| Metric | Value |");
+    expect(summary).toContain("| Status | failed |");
+    expect(summary).toContain("| Tests | 1 passed, 1 failed, 2 total |");
+    expect(summary).toContain("| Evals | 0 passed, 1 failed, 1 total |");
+    expect(summary).toContain("| Score | avg 0.20, min 0.20 |");
+    expect(summary).toContain("Score distribution");
+    expect(summary.indexOf("Score distribution")).toBeLessThan(
+      summary.indexOf("## Results"),
+    );
+    expect(summary).toContain("20-39%  | #################### 1");
+    expect(summary).not.toContain("### Details");
     expect(summary).not.toContain("| Test |");
+
+    const details = summary.match(/<details>[\s\S]*?<\/details>/)?.[0] ?? "";
+    expect(details.match(/```/g)).toHaveLength(2);
+    expect(details).toContain("```text\nResult\n------");
+    expect(details).toContain("Case      1. refund agent > rejects fraud");
+    expect(details).toContain("Location  apps/demo/evals/refund.eval.ts:42");
+    expect(details).toContain("Usage     1,220 tokens, 2 tools, 4.1s");
+    expect(details).toContain("Reason\n------");
+    expect(details).toContain("Expected status=approved, got status=denied");
+    expect(details).toContain("Judge                  Score");
+    expect(details).toContain("StructuredOutputJudge  0.20");
+    expect(details).toContain("Final Output\n------------");
+    expect(details).toContain('"reason": "invoice is not refundable"');
+    expect(details).toContain("Tool           Status");
+    expect(details).toContain(
+      "createRefund   error: skipped: invoice not refundable",
+    );
+    expect(details).not.toContain("Scores\n------");
+    expect(details).not.toContain("Tool Calls\n----------");
+    expect(details).not.toContain("Reason:\n\n```text");
+    expect(details).not.toContain("Final:\n\n```text");
   });
 
   test("surfaces non-eval failures without pretending the run passed", () => {
@@ -253,10 +307,22 @@ describe("renderJobSummary", () => {
       }),
     );
 
-    expect(summary).toContain("Status: failed");
-    expect(summary).toContain("Evals: 0 passed, 0 failed, 0 total");
-    expect(summary).toContain("Other Failures: 1 non-eval test failure");
+    expect(summary).toContain("| Status | failed |");
+    expect(summary).toContain("| Evals | 0 passed, 0 failed, 0 total |");
+    expect(summary).toContain("| Other Failures | 1 non-eval test failure |");
+    expect(summary).toContain("## Results");
     expect(summary).toContain("No eval metadata was found");
+  });
+
+  test("escapes table cell control characters", () => {
+    const report = collectEvalReport(sampleJson, {
+      workspace: "/repo",
+    });
+    report.status = "failed \\ | escaped" as typeof report.status;
+
+    expect(renderJobSummary(report)).toContain(
+      String.raw`| Status | failed \\ \| escaped |`,
+    );
   });
 });
 

--- a/packages/github-reporter/src/report.test.ts
+++ b/packages/github-reporter/src/report.test.ts
@@ -1,0 +1,362 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { renderWorkflowCommands } from "./annotations";
+import { collectEvalReport } from "./collect";
+import { publishCheckRun } from "./github";
+import { renderJobSummary } from "./summary";
+import type { VitestJsonReport } from "./types";
+import { normalizePathForGitHub } from "./utils";
+
+const sampleJson: VitestJsonReport = {
+  numFailedTests: 1,
+  numPassedTests: 1,
+  numPendingTests: 0,
+  numTodoTests: 0,
+  numTotalTests: 2,
+  startTime: 1000,
+  success: false,
+  testResults: [
+    {
+      name: "/repo/apps/demo/evals/refund.eval.ts",
+      status: "failed",
+      message: "",
+      startTime: 1000,
+      endTime: 5500,
+      assertionResults: [
+        {
+          ancestorTitles: ["refund agent"],
+          fullName: "refund agent rejects fraud",
+          title: "rejects fraud",
+          status: "failed",
+          duration: 42,
+          failureMessages: ["Score: 0.20 below threshold: 1.00"],
+          location: {
+            line: 42,
+            column: 3,
+          },
+          tags: [],
+          meta: {
+            eval: {
+              avgScore: 0.2,
+              thresholdFailed: true,
+              output: {
+                status: "denied",
+                reason: "invoice is not refundable",
+              },
+              scores: [
+                {
+                  name: "StructuredOutputJudge",
+                  score: 0.2,
+                  metadata: {
+                    rationale:
+                      "status mismatch\nExpected status=approved, got status=denied",
+                  },
+                },
+                {
+                  name: "ToolCallJudge",
+                  score: 1,
+                },
+              ],
+            },
+            harness: {
+              name: "pi-ai",
+              run: {
+                output: {
+                  status: "denied",
+                },
+                usage: {
+                  totalTokens: 1220,
+                  toolCalls: 2,
+                },
+                timings: {
+                  totalMs: 4100,
+                },
+                session: {
+                  messages: [
+                    {
+                      role: "assistant",
+                      toolCalls: [
+                        {
+                          name: "lookupInvoice",
+                          durationMs: 6,
+                        },
+                        {
+                          name: "createRefund",
+                          error: {
+                            message: "skipped: invoice not refundable",
+                          },
+                        },
+                      ],
+                    },
+                  ],
+                },
+                errors: [],
+              },
+            },
+          },
+        },
+        {
+          ancestorTitles: ["unit"],
+          fullName: "unit plain test",
+          title: "plain test",
+          status: "passed",
+          duration: 3,
+          failureMessages: [],
+          location: {
+            line: 12,
+            column: 1,
+          },
+          tags: [],
+          meta: {},
+        },
+      ],
+    },
+  ],
+};
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.unstubAllEnvs();
+});
+
+describe("collectEvalReport", () => {
+  test("extracts eval metadata from Vitest JSON assertions", () => {
+    const report = collectEvalReport(sampleJson, {
+      workspace: "/repo",
+    });
+
+    expect(report.status).toBe("failed");
+    expect(report.totals).toMatchObject({
+      total: 2,
+      failed: 1,
+      evalTotal: 1,
+      evalFailed: 1,
+    });
+    expect(report.score).toEqual({
+      average: 0.2,
+      minimum: 0.2,
+    });
+    expect(report.usage.totalTokens).toBe(1220);
+    expect(report.usage.toolCalls).toBe(2);
+    expect(report.failures[0]).toMatchObject({
+      displayFile: "apps/demo/evals/refund.eval.ts",
+      displayName: "refund agent > rejects fraud",
+      primaryFailure: {
+        judgeName: "StructuredOutputJudge",
+        score: 0.2,
+      },
+    });
+  });
+});
+
+describe("normalizePathForGitHub", () => {
+  test("only strips the exact workspace path prefix", () => {
+    expect(
+      normalizePathForGitHub("/repo/apps/demo/evals/refund.eval.ts", "/repo"),
+    ).toBe("apps/demo/evals/refund.eval.ts");
+    expect(normalizePathForGitHub("/repo-other/file.ts", "/repo")).toBe(
+      "/repo-other/file.ts",
+    );
+  });
+});
+
+describe("renderJobSummary", () => {
+  test("renders compact ASCII markdown without failure tables", () => {
+    const report = collectEvalReport(sampleJson, {
+      workspace: "/repo",
+    });
+    const summary = renderJobSummary(report);
+
+    expect(summary).toContain("## vitest-evals");
+    expect(summary).toContain("Status: failed");
+    expect(summary).toContain("Score: avg 0.20, min 0.20");
+    expect(summary).toContain("1. refund agent > rejects fraud");
+    expect(summary).toContain("Reason:");
+    expect(summary).toContain("```text");
+    expect(summary).not.toContain("| Test |");
+  });
+
+  test("surfaces non-eval failures without pretending the run passed", () => {
+    const json: VitestJsonReport = {
+      ...sampleJson,
+      numFailedTests: 1,
+      numPassedTests: 0,
+      numTotalTests: 1,
+      success: false,
+      testResults: [
+        {
+          name: "/repo/src/plain.test.ts",
+          status: "failed",
+          message: "",
+          startTime: 1000,
+          endTime: 1100,
+          assertionResults: [
+            {
+              ancestorTitles: [],
+              fullName: "plain failure",
+              title: "plain failure",
+              status: "failed",
+              duration: 10,
+              failureMessages: ["plain failure"],
+              location: {
+                line: 4,
+                column: 1,
+              },
+              tags: [],
+              meta: {},
+            },
+          ],
+        },
+      ],
+    };
+
+    const summary = renderJobSummary(
+      collectEvalReport(json, {
+        workspace: "/repo",
+      }),
+    );
+
+    expect(summary).toContain("Status: failed");
+    expect(summary).toContain("Evals: 0 passed, 0 failed, 0 total");
+    expect(summary).toContain("Other Failures: 1 non-eval test failure");
+    expect(summary).toContain("No eval metadata was found");
+  });
+});
+
+describe("renderWorkflowCommands", () => {
+  test("emits escaped terse annotations", () => {
+    const json = structuredClone(sampleJson);
+    const evalMeta = (json.testResults[0]?.assertionResults[0]?.meta as any)
+      .eval;
+    evalMeta.scores[0].metadata.rationale =
+      "bad value: expected, got 20%\nwith extra detail";
+    const report = collectEvalReport(json, {
+      workspace: "/repo",
+    });
+
+    expect(renderWorkflowCommands(report)).toEqual([
+      "::error file=apps/demo/evals/refund.eval.ts,line=42,column=3,title=vitest-evals::refund agent > rejects fraud - score 0.20 - StructuredOutputJudge - bad value: expected, got 20%25",
+    ]);
+  });
+});
+
+describe("publishCheckRun", () => {
+  test("skips when GitHub configuration is missing", async () => {
+    const report = collectEvalReport(sampleJson);
+
+    await expect(publishCheckRun(report)).resolves.toEqual({
+      status: "skipped",
+      reason: "missing GITHUB_TOKEN",
+    });
+  });
+
+  test("creates a Check Run with annotations", async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({
+        id: 123,
+        html_url: "https://github.test/checks/123",
+      }),
+      text: async () => "",
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const report = collectEvalReport(sampleJson, {
+      workspace: "/repo",
+    });
+    const result = await publishCheckRun(report, {
+      token: "token",
+      repository: "getsentry/vitest-evals",
+      sha: "abc123",
+    });
+
+    expect(result).toEqual({
+      status: "created",
+      id: 123,
+      htmlUrl: "https://github.test/checks/123",
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, request] = fetchMock.mock.calls[0] as unknown as [
+      string,
+      { method: string; body: string },
+    ];
+    expect(url).toBe(
+      "https://api.github.com/repos/getsentry/vitest-evals/check-runs",
+    );
+    expect(request.method).toBe("POST");
+    expect(JSON.parse(request.body)).toMatchObject({
+      name: "vitest-evals",
+      head_sha: "abc123",
+      status: "completed",
+      conclusion: "failure",
+      output: {
+        title: "1 eval failure",
+        annotations: [
+          {
+            path: "apps/demo/evals/refund.eval.ts",
+            start_line: 42,
+            annotation_level: "failure",
+          },
+        ],
+      },
+    });
+  });
+
+  test("uses a non-eval failure title for failed runs without eval failures", async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({
+        id: 124,
+      }),
+      text: async () => "",
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const report = collectEvalReport({
+      ...sampleJson,
+      success: false,
+      testResults: [
+        {
+          name: "/repo/src/plain.test.ts",
+          status: "failed",
+          message: "",
+          startTime: 1000,
+          endTime: 1100,
+          assertionResults: [
+            {
+              ancestorTitles: [],
+              fullName: "plain failure",
+              title: "plain failure",
+              status: "failed",
+              duration: 10,
+              failureMessages: ["plain failure"],
+              location: {
+                line: 4,
+                column: 1,
+              },
+              tags: [],
+              meta: {},
+            },
+          ],
+        },
+      ],
+    });
+
+    await publishCheckRun(report, {
+      token: "token",
+      repository: "getsentry/vitest-evals",
+      sha: "abc123",
+    });
+
+    const [, request] = fetchMock.mock.calls[0] as unknown as [
+      string,
+      { body: string },
+    ];
+    expect(JSON.parse(request.body)).toMatchObject({
+      conclusion: "failure",
+      output: {
+        title: "Vitest run failed",
+        annotations: [],
+      },
+    });
+  });
+});

--- a/packages/github-reporter/src/report.test.ts
+++ b/packages/github-reporter/src/report.test.ts
@@ -182,6 +182,13 @@ describe("parseCliArgs", () => {
       jsonPath: "custom-results.json",
     });
   });
+
+  test("stops parsing after help", () => {
+    expect(parseCliArgs(["--help", "--invalid"], {})).toMatchObject({
+      help: true,
+      jsonPath: "vitest-results.json",
+    });
+  });
 });
 
 describe("formatDuration", () => {
@@ -267,6 +274,19 @@ describe("renderWorkflowCommands", () => {
     expect(renderWorkflowCommands(report)).toEqual([
       "::error file=apps/demo/evals/refund.eval.ts,line=42,column=3,title=vitest-evals::refund agent > rejects fraud - score 0.20 - StructuredOutputJudge - bad value: expected, got 20%25",
     ]);
+  });
+
+  test("uses the canonical score formatter in annotations", () => {
+    const json = structuredClone(sampleJson);
+    const evalMeta = (json.testResults[0]?.assertionResults[0]?.meta as any)
+      .eval;
+    evalMeta.avgScore = Number.NaN;
+    evalMeta.scores = [];
+    const report = collectEvalReport(json, {
+      workspace: "/repo",
+    });
+
+    expect(renderWorkflowCommands(report)[0]).toContain("score n/a");
   });
 });
 

--- a/packages/github-reporter/src/summary.ts
+++ b/packages/github-reporter/src/summary.ts
@@ -159,9 +159,7 @@ function renderFailureDetails(
   if (testCase.eval?.scores.length) {
     lines.push("Scores:");
     for (const score of testCase.eval.scores) {
-      lines.push(
-        `- ${score.name ?? "Unknown"}: ${formatScore(score.score ?? 0)}`,
-      );
+      lines.push(`- ${score.name ?? "Unknown"}: ${formatScore(score.score)}`);
     }
     lines.push("");
   }

--- a/packages/github-reporter/src/summary.ts
+++ b/packages/github-reporter/src/summary.ts
@@ -1,0 +1,252 @@
+import type { EvalCase, EvalReport, UsageSummary } from "./types";
+import {
+  compactLine,
+  escapeFence,
+  escapeHtml,
+  formatDuration,
+  formatLocation,
+  formatNumber,
+  formatScore,
+  stringifyValue,
+  truncate,
+} from "./utils";
+
+export type SummaryOptions = {
+  maxFailures?: number;
+  maxReasonChars?: number;
+  maxOutputChars?: number;
+  maxToolCalls?: number;
+};
+
+const DEFAULT_MAX_FAILURES = 20;
+const DEFAULT_MAX_REASON_CHARS = 8000;
+const DEFAULT_MAX_OUTPUT_CHARS = 4000;
+const DEFAULT_MAX_TOOL_CALLS = 20;
+
+/** Renders the GitHub Actions job summary markdown for an eval report. */
+export function renderJobSummary(
+  report: EvalReport,
+  options: SummaryOptions = {},
+) {
+  const maxFailures = options.maxFailures ?? DEFAULT_MAX_FAILURES;
+  const failures = report.failures.slice(0, maxFailures);
+  const nonEvalFailures = report.totals.failed - report.totals.evalFailed;
+  const lines: string[] = [
+    "## vitest-evals",
+    "",
+    `Status: ${report.status}`,
+    `Tests: ${formatCountLine(report.totals.passed, report.totals.failed, report.totals.total)}`,
+    `Evals: ${formatCountLine(report.totals.evalPassed, report.totals.evalFailed, report.totals.evalTotal)}`,
+  ];
+
+  if (report.score) {
+    lines.push(
+      `Score: avg ${formatScore(report.score.average)}${
+        report.score.minimum === undefined
+          ? ""
+          : `, min ${formatScore(report.score.minimum)}`
+      }`,
+    );
+  }
+
+  const usage = formatUsage(report.usage);
+  if (usage) {
+    lines.push(`Usage: ${usage}`);
+  }
+  if (nonEvalFailures > 0) {
+    lines.push(
+      `Other Failures: ${formatNumber(nonEvalFailures)} non-eval test failure${
+        nonEvalFailures === 1 ? "" : "s"
+      }`,
+    );
+  }
+
+  lines.push(`Duration: ${formatDuration(report.durationMs)}`, "");
+
+  if (report.totals.evalTotal === 0) {
+    lines.push("No eval metadata was found in the Vitest JSON report.", "");
+    return `${lines.join("\n")}\n`;
+  }
+
+  if (report.failures.length === 0) {
+    lines.push("No eval failures.", "");
+    return `${lines.join("\n")}\n`;
+  }
+
+  lines.push("### Failures", "");
+  failures.forEach((testCase, index) => {
+    lines.push(...renderFailureIndexItem(testCase, index + 1), "");
+  });
+
+  if (report.failures.length > failures.length) {
+    lines.push(
+      `${report.failures.length - failures.length} more failures omitted from this summary.`,
+      "",
+    );
+  }
+
+  lines.push("### Details", "");
+  failures.forEach((testCase, index) => {
+    lines.push(...renderFailureDetails(testCase, index + 1, options), "");
+  });
+
+  return `${lines.join("\n")}\n`;
+}
+
+function formatCountLine(passed: number, failed: number, total: number) {
+  return `${formatNumber(passed)} passed, ${formatNumber(failed)} failed, ${formatNumber(total)} total`;
+}
+
+function renderFailureIndexItem(testCase: EvalCase, number: number) {
+  const failure = testCase.primaryFailure;
+  const reason = compactLine(failure?.reason ?? "", 180);
+  const lines = [
+    `${number}. ${testCase.displayName}`,
+    `   Score: ${formatScore(failure?.score ?? testCase.eval?.avgScore)}`,
+    `   Judge: ${failure?.judgeName ?? "n/a"}`,
+    `   Location: ${formatLocation(testCase.displayFile, testCase.location)}`,
+  ];
+
+  if (reason) {
+    lines.push(`   Reason: ${reason}`);
+  }
+
+  return lines;
+}
+
+function renderFailureDetails(
+  testCase: EvalCase,
+  number: number,
+  options: SummaryOptions,
+) {
+  const failure = testCase.primaryFailure;
+  const maxReasonChars = options.maxReasonChars ?? DEFAULT_MAX_REASON_CHARS;
+  const maxOutputChars = options.maxOutputChars ?? DEFAULT_MAX_OUTPUT_CHARS;
+  const maxToolCalls = options.maxToolCalls ?? DEFAULT_MAX_TOOL_CALLS;
+  const usage = formatCaseUsage(testCase);
+  const finalOutput = testCase.eval?.output ?? testCase.harness?.output;
+  const summary = `${number}. ${testCase.displayName} - ${
+    failure?.judgeName ?? "failure"
+  } - ${formatScore(failure?.score ?? testCase.eval?.avgScore)}`;
+  const lines = [
+    "<details>",
+    `<summary>${escapeHtml(summary)}</summary>`,
+    "",
+    `Location: ${formatLocation(testCase.displayFile, testCase.location)}`,
+    `Harness: ${testCase.harness?.name ?? "n/a"}`,
+  ];
+
+  if (usage) {
+    lines.push(`Usage: ${usage}`);
+  }
+  if (testCase.durationMs !== undefined) {
+    lines.push(`Duration: ${formatDuration(testCase.durationMs)}`);
+  }
+
+  lines.push("");
+
+  if (failure?.reason) {
+    lines.push(
+      "Reason:",
+      "",
+      "```text",
+      escapeFence(truncate(failure.reason, maxReasonChars)),
+      "```",
+      "",
+    );
+  }
+
+  if (testCase.eval?.scores.length) {
+    lines.push("Scores:");
+    for (const score of testCase.eval.scores) {
+      lines.push(
+        `- ${score.name ?? "Unknown"}: ${formatScore(score.score ?? 0)}`,
+      );
+    }
+    lines.push("");
+  }
+
+  if (finalOutput !== undefined) {
+    lines.push(
+      "Final:",
+      "",
+      "```text",
+      escapeFence(stringifyValue(finalOutput, maxOutputChars)),
+      "```",
+      "",
+    );
+  }
+
+  if (testCase.harness?.toolCalls.length) {
+    lines.push("Tools:");
+    for (const toolCall of testCase.harness.toolCalls.slice(0, maxToolCalls)) {
+      const status = toolCall.error
+        ? `error: ${compactLine(toolCall.error, 120)}`
+        : "ok";
+      const duration =
+        toolCall.durationMs === undefined
+          ? ""
+          : `, ${formatDuration(toolCall.durationMs)}`;
+      lines.push(`- ${toolCall.name}: ${status}${duration}`);
+    }
+    if (testCase.harness.toolCalls.length > maxToolCalls) {
+      lines.push(
+        `- ${testCase.harness.toolCalls.length - maxToolCalls} more tool calls omitted`,
+      );
+    }
+    lines.push("");
+  }
+
+  if (testCase.harness?.errors.length) {
+    lines.push(
+      "Harness errors:",
+      "",
+      "```text",
+      escapeFence(stringifyValue(testCase.harness.errors, maxReasonChars)),
+      "```",
+      "",
+    );
+  }
+
+  lines.push("</details>");
+  return lines;
+}
+
+function formatUsage(usage: Required<UsageSummary>) {
+  const parts: string[] = [];
+  if (usage.totalTokens > 0) {
+    parts.push(`${formatNumber(usage.totalTokens)} tokens`);
+  }
+  if (usage.toolCalls > 0) {
+    parts.push(
+      `${formatNumber(usage.toolCalls)} tool${usage.toolCalls === 1 ? "" : "s"}`,
+    );
+  }
+  if (usage.estimatedCost > 0) {
+    parts.push(`$${usage.estimatedCost.toFixed(4)}`);
+  }
+  return parts.join(", ");
+}
+
+function formatCaseUsage(testCase: EvalCase) {
+  const usage = testCase.harness?.usage;
+  const parts: string[] = [];
+  const totalTokens =
+    usage?.totalTokens ??
+    (usage?.inputTokens ?? 0) +
+      (usage?.outputTokens ?? 0) +
+      (usage?.reasoningTokens ?? 0);
+  const toolCalls = usage?.toolCalls ?? testCase.harness?.toolCalls.length ?? 0;
+
+  if (totalTokens > 0) {
+    parts.push(`${formatNumber(totalTokens)} tokens`);
+  }
+  if (toolCalls > 0) {
+    parts.push(`${formatNumber(toolCalls)} tool${toolCalls === 1 ? "" : "s"}`);
+  }
+  if (testCase.harness?.timingMs !== undefined) {
+    parts.push(formatDuration(testCase.harness.timingMs));
+  }
+
+  return parts.join(", ");
+}

--- a/packages/github-reporter/src/summary.ts
+++ b/packages/github-reporter/src/summary.ts
@@ -22,6 +22,14 @@ const DEFAULT_MAX_FAILURES = 20;
 const DEFAULT_MAX_REASON_CHARS = 8000;
 const DEFAULT_MAX_OUTPUT_CHARS = 4000;
 const DEFAULT_MAX_TOOL_CALLS = 20;
+const SCORE_DISTRIBUTION_BUCKETS = [
+  "0-19%",
+  "20-39%",
+  "40-59%",
+  "60-79%",
+  "80-100%",
+] as const;
+const SCORE_DISTRIBUTION_BAR_WIDTH = 20;
 
 /** Renders the GitHub Actions job summary markdown for an eval report. */
 export function renderJobSummary(
@@ -32,63 +40,34 @@ export function renderJobSummary(
   const failures = report.failures.slice(0, maxFailures);
   const nonEvalFailures = report.totals.failed - report.totals.evalFailed;
   const lines: string[] = [
-    "## vitest-evals",
+    "# vitest-evals",
     "",
-    `Status: ${report.status}`,
-    `Tests: ${formatCountLine(report.totals.passed, report.totals.failed, report.totals.total)}`,
-    `Evals: ${formatCountLine(report.totals.evalPassed, report.totals.evalFailed, report.totals.evalTotal)}`,
+    ...renderSummaryTable(report, nonEvalFailures),
+    "",
+    ...renderScoreDistribution(report),
+    "## Results",
+    "",
   ];
 
-  if (report.score) {
-    lines.push(
-      `Score: avg ${formatScore(report.score.average)}${
-        report.score.minimum === undefined
-          ? ""
-          : `, min ${formatScore(report.score.minimum)}`
-      }`,
-    );
-  }
+  if (report.failures.length > 0) {
+    lines.push("### Failures", "");
+    failures.forEach((testCase, index) => {
+      lines.push(...renderFailureDetails(testCase, index + 1, options), "");
+    });
 
-  const usage = formatUsage(report.usage);
-  if (usage) {
-    lines.push(`Usage: ${usage}`);
+    if (report.failures.length > failures.length) {
+      lines.push(
+        `${report.failures.length - failures.length} more failures omitted from this summary.`,
+        "",
+      );
+    }
+  } else if (report.totals.evalTotal > 0) {
+    lines.push("### Failures", "", "No eval failures.", "");
   }
-  if (nonEvalFailures > 0) {
-    lines.push(
-      `Other Failures: ${formatNumber(nonEvalFailures)} non-eval test failure${
-        nonEvalFailures === 1 ? "" : "s"
-      }`,
-    );
-  }
-
-  lines.push(`Duration: ${formatDuration(report.durationMs)}`, "");
 
   if (report.totals.evalTotal === 0) {
     lines.push("No eval metadata was found in the Vitest JSON report.", "");
-    return `${lines.join("\n")}\n`;
   }
-
-  if (report.failures.length === 0) {
-    lines.push("No eval failures.", "");
-    return `${lines.join("\n")}\n`;
-  }
-
-  lines.push("### Failures", "");
-  failures.forEach((testCase, index) => {
-    lines.push(...renderFailureIndexItem(testCase, index + 1), "");
-  });
-
-  if (report.failures.length > failures.length) {
-    lines.push(
-      `${report.failures.length - failures.length} more failures omitted from this summary.`,
-      "",
-    );
-  }
-
-  lines.push("### Details", "");
-  failures.forEach((testCase, index) => {
-    lines.push(...renderFailureDetails(testCase, index + 1, options), "");
-  });
 
   return `${lines.join("\n")}\n`;
 }
@@ -97,21 +76,117 @@ function formatCountLine(passed: number, failed: number, total: number) {
   return `${formatNumber(passed)} passed, ${formatNumber(failed)} failed, ${formatNumber(total)} total`;
 }
 
-function renderFailureIndexItem(testCase: EvalCase, number: number) {
-  const failure = testCase.primaryFailure;
-  const reason = compactLine(failure?.reason ?? "", 180);
-  const lines = [
-    `${number}. ${testCase.displayName}`,
-    `   Score: ${formatScore(failure?.score ?? testCase.eval?.avgScore)}`,
-    `   Judge: ${failure?.judgeName ?? "n/a"}`,
-    `   Location: ${formatLocation(testCase.displayFile, testCase.location)}`,
+function renderSummaryTable(report: EvalReport, nonEvalFailures: number) {
+  const rows: Array<[string, string]> = [
+    ["Status", report.status],
+    [
+      "Tests",
+      formatCountLine(
+        report.totals.passed,
+        report.totals.failed,
+        report.totals.total,
+      ),
+    ],
+    [
+      "Evals",
+      formatCountLine(
+        report.totals.evalPassed,
+        report.totals.evalFailed,
+        report.totals.evalTotal,
+      ),
+    ],
   ];
 
-  if (reason) {
-    lines.push(`   Reason: ${reason}`);
+  if (report.score) {
+    rows.push(["Score", formatScoreSummary(report.score)]);
   }
 
-  return lines;
+  const usage = formatUsage(report.usage);
+  if (usage) {
+    rows.push(["Usage", usage]);
+  }
+
+  if (nonEvalFailures > 0) {
+    rows.push([
+      "Other Failures",
+      `${formatNumber(nonEvalFailures)} non-eval test failure${
+        nonEvalFailures === 1 ? "" : "s"
+      }`,
+    ]);
+  }
+
+  rows.push(["Duration", formatDuration(report.durationMs)]);
+
+  return [
+    "| Metric | Value |",
+    "| --- | --- |",
+    ...rows.map(
+      ([metric, value]) =>
+        `| ${escapeTableCell(metric)} | ${escapeTableCell(value)} |`,
+    ),
+  ];
+}
+
+function formatScoreSummary(score: NonNullable<EvalReport["score"]>) {
+  return `avg ${formatScore(score.average)}${
+    score.minimum === undefined ? "" : `, min ${formatScore(score.minimum)}`
+  }`;
+}
+
+function escapeTableCell(value: string) {
+  return value
+    .replace(/\r?\n/g, " ")
+    .replace(/\\/g, "\\\\")
+    .replace(/\|/g, "\\|");
+}
+
+function renderScoreDistribution(report: EvalReport) {
+  const scores = report.cases
+    .map((testCase) => testCase.eval?.avgScore)
+    .filter(
+      (score): score is number =>
+        typeof score === "number" && Number.isFinite(score),
+    );
+  if (scores.length === 0) {
+    return [];
+  }
+
+  const counts = SCORE_DISTRIBUTION_BUCKETS.map(() => 0);
+  for (const score of scores) {
+    const bucket = Math.min(
+      SCORE_DISTRIBUTION_BUCKETS.length - 1,
+      Math.max(0, Math.floor(score * SCORE_DISTRIBUTION_BUCKETS.length)),
+    );
+    counts[bucket] = (counts[bucket] ?? 0) + 1;
+  }
+
+  const maxCount = Math.max(...counts);
+  return [
+    "Score distribution",
+    "",
+    "```text",
+    ...SCORE_DISTRIBUTION_BUCKETS.map((label, index) =>
+      formatScoreDistributionBucket(label, counts[index] ?? 0, maxCount),
+    ),
+    "```",
+    "",
+  ];
+}
+
+function formatScoreDistributionBucket(
+  label: string,
+  count: number,
+  maxCount: number,
+) {
+  const barLength =
+    count === 0
+      ? 0
+      : Math.max(
+          1,
+          Math.round((count / maxCount) * SCORE_DISTRIBUTION_BAR_WIDTH),
+        );
+  const bar = "#".repeat(barLength).padEnd(SCORE_DISTRIBUTION_BAR_WIDTH, " ");
+  return `${label.padEnd(7)} | ${bar} ${formatNumber(count)}`;
 }
 
 function renderFailureDetails(
@@ -132,64 +207,111 @@ function renderFailureDetails(
     "<details>",
     `<summary>${escapeHtml(summary)}</summary>`,
     "",
-    `Location: ${formatLocation(testCase.displayFile, testCase.location)}`,
-    `Harness: ${testCase.harness?.name ?? "n/a"}`,
+    "```text",
+    ...renderFailureBlock(testCase, {
+      finalOutput,
+      maxOutputChars,
+      maxReasonChars,
+      maxToolCalls,
+      number,
+      usage,
+    }).map(escapeFence),
+    "```",
+    "",
+    "</details>",
   ];
+  return lines;
+}
 
+function renderFailureBlock(
+  testCase: EvalCase,
+  {
+    finalOutput,
+    maxOutputChars,
+    maxReasonChars,
+    maxToolCalls,
+    number,
+    usage,
+  }: {
+    finalOutput: unknown;
+    maxOutputChars: number;
+    maxReasonChars: number;
+    maxToolCalls: number;
+    number: number;
+    usage: string;
+  },
+) {
+  const failure = testCase.primaryFailure;
+  const overviewRows: Array<[string, string]> = [
+    ["Case", `${number}. ${testCase.displayName}`],
+    ["Status", testCase.status],
+    ["Location", formatLocation(testCase.displayFile, testCase.location)],
+    ["Harness", testCase.harness?.name ?? "n/a"],
+    ["Score", formatScore(failure?.score ?? testCase.eval?.avgScore)],
+    ["Judge", failure?.judgeName ?? "n/a"],
+  ];
   if (usage) {
-    lines.push(`Usage: ${usage}`);
+    overviewRows.push(["Usage", usage]);
   }
   if (testCase.durationMs !== undefined) {
-    lines.push(`Duration: ${formatDuration(testCase.durationMs)}`);
+    overviewRows.push(["Duration", formatDuration(testCase.durationMs)]);
   }
 
-  lines.push("");
+  const lines = [
+    ...renderAsciiSection("Result", renderKeyValues(overviewRows)),
+    "",
+  ];
 
   if (failure?.reason) {
     lines.push(
-      "Reason:",
-      "",
-      "```text",
-      escapeFence(truncate(failure.reason, maxReasonChars)),
-      "```",
+      ...renderAsciiSection(
+        "Reason",
+        truncate(failure.reason, maxReasonChars).split(/\r?\n/),
+      ),
       "",
     );
   }
 
   if (testCase.eval?.scores.length) {
-    lines.push("Scores:");
-    for (const score of testCase.eval.scores) {
-      lines.push(`- ${score.name ?? "Unknown"}: ${formatScore(score.score)}`);
-    }
-    lines.push("");
+    lines.push(
+      ...renderAsciiTable(
+        ["Judge", "Score"],
+        testCase.eval.scores.map((score) => [
+          score.name ?? "Unknown",
+          formatScore(score.score),
+        ]),
+      ),
+      "",
+    );
   }
 
   if (finalOutput !== undefined) {
     lines.push(
-      "Final:",
-      "",
-      "```text",
-      escapeFence(stringifyValue(finalOutput, maxOutputChars)),
-      "```",
+      ...renderAsciiSection(
+        "Final Output",
+        stringifyValue(finalOutput, maxOutputChars).split(/\r?\n/),
+      ),
       "",
     );
   }
 
   if (testCase.harness?.toolCalls.length) {
-    lines.push("Tools:");
-    for (const toolCall of testCase.harness.toolCalls.slice(0, maxToolCalls)) {
-      const status = toolCall.error
-        ? `error: ${compactLine(toolCall.error, 120)}`
-        : "ok";
-      const duration =
-        toolCall.durationMs === undefined
-          ? ""
-          : `, ${formatDuration(toolCall.durationMs)}`;
-      lines.push(`- ${toolCall.name}: ${status}${duration}`);
-    }
+    const toolCalls = testCase.harness.toolCalls.slice(0, maxToolCalls);
+    lines.push(
+      ...renderAsciiTable(
+        ["Tool", "Status", "Duration"],
+        toolCalls.map((toolCall) => [
+          toolCall.name,
+          toolCall.error ? `error: ${compactLine(toolCall.error, 120)}` : "ok",
+          toolCall.durationMs === undefined
+            ? "n/a"
+            : formatDuration(toolCall.durationMs),
+        ]),
+      ),
+    );
     if (testCase.harness.toolCalls.length > maxToolCalls) {
       lines.push(
-        `- ${testCase.harness.toolCalls.length - maxToolCalls} more tool calls omitted`,
+        `${testCase.harness.toolCalls.length - maxToolCalls} more tool calls omitted`,
       );
     }
     lines.push("");
@@ -197,17 +319,47 @@ function renderFailureDetails(
 
   if (testCase.harness?.errors.length) {
     lines.push(
-      "Harness errors:",
-      "",
-      "```text",
-      escapeFence(stringifyValue(testCase.harness.errors, maxReasonChars)),
-      "```",
+      ...renderAsciiSection(
+        "Harness Errors",
+        stringifyValue(testCase.harness.errors, maxReasonChars).split(/\r?\n/),
+      ),
       "",
     );
   }
 
-  lines.push("</details>");
+  while (lines[lines.length - 1] === "") {
+    lines.pop();
+  }
   return lines;
+}
+
+function renderAsciiSection(title: string, content: string[]) {
+  return [title, "-".repeat(title.length), ...content];
+}
+
+function renderKeyValues(rows: Array<[string, string]>) {
+  const labelWidth = Math.max(...rows.map(([label]) => label.length));
+  return rows.map(
+    ([label, value]) =>
+      `${label.padEnd(labelWidth)}  ${compactLine(value, 500)}`,
+  );
+}
+
+function renderAsciiTable(headers: string[], rows: string[][]) {
+  const widths = headers.map((header, index) =>
+    Math.max(header.length, ...rows.map((row) => row[index]?.length ?? 0)),
+  );
+  const renderRow = (row: string[]) =>
+    row
+      .map((cell, index) => cell.padEnd(widths[index] ?? cell.length))
+      .join("  ")
+      .trimEnd();
+
+  return [
+    renderRow(headers),
+    widths.map((width) => "-".repeat(width)).join("  "),
+    ...rows.map(renderRow),
+  ];
 }
 
 function formatUsage(usage: Required<UsageSummary>) {

--- a/packages/github-reporter/src/types.ts
+++ b/packages/github-reporter/src/types.ts
@@ -1,0 +1,128 @@
+export type VitestJsonStatus =
+  | "passed"
+  | "failed"
+  | "skipped"
+  | "pending"
+  | "todo"
+  | "disabled";
+
+export type VitestJsonLocation = {
+  line: number;
+  column: number;
+};
+
+export type VitestJsonAssertion = {
+  ancestorTitles: string[];
+  fullName: string;
+  status: VitestJsonStatus;
+  title: string;
+  meta?: unknown;
+  duration?: number | null;
+  failureMessages?: string[] | null;
+  location?: VitestJsonLocation | null;
+  tags?: string[];
+};
+
+export type VitestJsonFile = {
+  message: string;
+  name: string;
+  status: "failed" | "passed";
+  startTime: number;
+  endTime: number;
+  assertionResults: VitestJsonAssertion[];
+};
+
+export type VitestJsonReport = {
+  numFailedTests: number;
+  numPassedTests: number;
+  numPendingTests: number;
+  numTodoTests: number;
+  numTotalTests: number;
+  startTime: number;
+  success: boolean;
+  testResults: VitestJsonFile[];
+};
+
+export type EvalScore = {
+  name?: string;
+  score?: number | null;
+  metadata?: {
+    rationale?: unknown;
+    output?: unknown;
+    [key: string]: unknown;
+  };
+};
+
+export type EvalCase = {
+  id: string;
+  file: string;
+  displayFile: string;
+  title: string;
+  displayName: string;
+  status: VitestJsonStatus;
+  durationMs?: number;
+  location?: VitestJsonLocation;
+  failureMessages: string[];
+  eval?: {
+    avgScore?: number;
+    thresholdFailed?: boolean;
+    output?: unknown;
+    scores: EvalScore[];
+  };
+  harness?: {
+    name?: string;
+    output?: unknown;
+    usage?: UsageSummary;
+    timingMs?: number;
+    toolCalls: ToolCallSummary[];
+    errors: unknown[];
+  };
+  primaryFailure?: EvalFailure;
+};
+
+export type EvalFailure = {
+  judgeName?: string;
+  score?: number;
+  reason?: string;
+};
+
+export type EvalReport = {
+  status: "passed" | "failed";
+  startedAt?: number;
+  durationMs?: number;
+  totals: {
+    total: number;
+    passed: number;
+    failed: number;
+    skipped: number;
+    evalTotal: number;
+    evalPassed: number;
+    evalFailed: number;
+  };
+  score?: {
+    average: number;
+    minimum?: number;
+  };
+  usage: Required<UsageSummary>;
+  cases: EvalCase[];
+  failures: EvalCase[];
+};
+
+export type UsageSummary = {
+  inputTokens?: number;
+  outputTokens?: number;
+  reasoningTokens?: number;
+  totalTokens?: number;
+  estimatedCost?: number;
+  toolCalls?: number;
+};
+
+export type ToolCallSummary = {
+  name: string;
+  error?: string;
+  durationMs?: number;
+};
+
+export type CollectOptions = {
+  workspace?: string;
+};

--- a/packages/github-reporter/src/utils.ts
+++ b/packages/github-reporter/src/utils.ts
@@ -46,7 +46,7 @@ export function formatNumber(value: number) {
 }
 
 export function formatScore(value: number | null | undefined) {
-  if (value == null || Number.isNaN(value)) {
+  if (value == null || !Number.isFinite(value)) {
     return "n/a";
   }
   return value.toFixed(2);

--- a/packages/github-reporter/src/utils.ts
+++ b/packages/github-reporter/src/utils.ts
@@ -63,8 +63,9 @@ export function formatDuration(ms: number | undefined) {
   if (seconds < 60) {
     return `${seconds.toFixed(seconds < 10 ? 1 : 0)}s`;
   }
-  const minutes = Math.floor(seconds / 60);
-  const remainingSeconds = Math.round(seconds % 60);
+  const totalSeconds = Math.round(seconds);
+  const minutes = Math.floor(totalSeconds / 60);
+  const remainingSeconds = totalSeconds % 60;
   return `${minutes}m ${remainingSeconds}s`;
 }
 

--- a/packages/github-reporter/src/utils.ts
+++ b/packages/github-reporter/src/utils.ts
@@ -45,8 +45,8 @@ export function formatNumber(value: number) {
   }).format(value);
 }
 
-export function formatScore(value: number | undefined) {
-  if (value === undefined || Number.isNaN(value)) {
+export function formatScore(value: number | null | undefined) {
+  if (value == null || Number.isNaN(value)) {
     return "n/a";
   }
   return value.toFixed(2);

--- a/packages/github-reporter/src/utils.ts
+++ b/packages/github-reporter/src/utils.ts
@@ -1,0 +1,116 @@
+import { posix } from "node:path";
+
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+export function compactLine(value: string, maxLength: number) {
+  const line = value
+    .split(/\r?\n/)
+    .map((part) => part.trim())
+    .find((part) => part.length > 0);
+  if (!line) {
+    return "";
+  }
+  return truncate(line, maxLength);
+}
+
+export function truncate(value: string, maxLength: number) {
+  if (maxLength <= 0) {
+    return "";
+  }
+  if (value.length <= maxLength) {
+    return value;
+  }
+  return `${value.slice(0, Math.max(0, maxLength - 15)).trimEnd()}... [truncated]`;
+}
+
+export function stringifyValue(value: unknown, maxLength: number) {
+  if (value === undefined) {
+    return "";
+  }
+  if (typeof value === "string") {
+    return truncate(value, maxLength);
+  }
+  try {
+    return truncate(JSON.stringify(value, null, 2), maxLength);
+  } catch {
+    return truncate(String(value), maxLength);
+  }
+}
+
+export function formatNumber(value: number) {
+  return new Intl.NumberFormat("en-US", {
+    maximumFractionDigits: 0,
+  }).format(value);
+}
+
+export function formatScore(value: number | undefined) {
+  if (value === undefined || Number.isNaN(value)) {
+    return "n/a";
+  }
+  return value.toFixed(2);
+}
+
+export function formatDuration(ms: number | undefined) {
+  if (ms === undefined || !Number.isFinite(ms)) {
+    return "n/a";
+  }
+  if (ms < 1000) {
+    return `${Math.round(ms)}ms`;
+  }
+  const seconds = ms / 1000;
+  if (seconds < 60) {
+    return `${seconds.toFixed(seconds < 10 ? 1 : 0)}s`;
+  }
+  const minutes = Math.floor(seconds / 60);
+  const remainingSeconds = Math.round(seconds % 60);
+  return `${minutes}m ${remainingSeconds}s`;
+}
+
+export function formatLocation(
+  file: string,
+  location?: { line: number; column: number },
+) {
+  if (!location) {
+    return file;
+  }
+  return `${file}:${location.line}`;
+}
+
+export function normalizePathForGitHub(path: string, workspace?: string) {
+  const normalized = path.replace(/\\/g, "/");
+  if (!workspace) {
+    return normalized;
+  }
+
+  const workspacePath = workspace.replace(/\\/g, "/").replace(/\/+$/, "");
+  if (
+    normalized !== workspacePath &&
+    !normalized.startsWith(`${workspacePath}/`)
+  ) {
+    return normalized;
+  }
+
+  return posix.relative(workspacePath, normalized);
+}
+
+export function escapeFence(value: string) {
+  return value.replace(/```/g, "'''");
+}
+
+export function escapeHtml(value: string) {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+export function escapeCommandData(value: string) {
+  return value.replace(/%/g, "%25").replace(/\r/g, "%0D").replace(/\n/g, "%0A");
+}
+
+export function escapeCommandProperty(value: string) {
+  return escapeCommandData(value).replace(/:/g, "%3A").replace(/,/g, "%2C");
+}

--- a/packages/github-reporter/tsconfig.json
+++ b/packages/github-reporter/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["src/**/*.ts"]
+}

--- a/packages/github-reporter/tsup.config.ts
+++ b/packages/github-reporter/tsup.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts", "src/cli.ts"],
+  format: ["cjs", "esm"],
+  dts: true,
+  splitting: false,
+  sourcemap: true,
+  clean: true,
+  external: ["vitest"],
+});

--- a/packages/vitest-evals/README.md
+++ b/packages/vitest-evals/README.md
@@ -18,6 +18,12 @@ npm install -D @vitest-evals/harness-ai-sdk
 npm install -D @vitest-evals/harness-openai-agents
 ```
 
+For GitHub Actions summaries and annotations, install the JSON post-processor:
+
+```sh
+npm install -D @vitest-evals/github-reporter
+```
+
 ## Core Model
 
 - `describeEval(...)` binds exactly one harness to a suite
@@ -134,6 +140,24 @@ describeEval("refund agent", { harness }, (it) => {
   });
 });
 ```
+
+## GitHub Actions Reporting
+
+Use Vitest JSON as the eval report artifact. It preserves the `meta` field that
+contains eval scores and normalized harness runs.
+
+```sh
+vitest run evals \
+  --reporter=vitest-evals/reporter \
+  --reporter=json \
+  --outputFile.json=vitest-results.json
+
+vitest-evals-github-report
+```
+
+The GitHub reporter writes a job summary when `GITHUB_STEP_SUMMARY` is present,
+emits short failure annotations in Actions, and can publish a separate Check Run
+with `--check-run` when `checks: write` permission is configured.
 
 ## Existing Agents
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,6 +105,12 @@ importers:
         specifier: workspace:*
         version: link:../../packages/vitest-evals
 
+  packages/github-reporter:
+    devDependencies:
+      vitest:
+        specifier: ^4.1.2
+        version: 4.1.2(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(vite@7.0.6(@types/node@25.5.0)(yaml@2.8.0))
+
   packages/harness-ai-sdk:
     devDependencies:
       ai:
@@ -607,10 +613,12 @@ packages:
   '@mariozechner/pi-agent-core@0.67.68':
     resolution: {integrity: sha512-anwFuzeUL7Qjbyih4DWY7w1zrOTrBxaz1L6+duLUuuzpHOun0EiP4KWIGTXPT5oJA7ZaeRNTyXJ7PlWfGQG33g==}
     engines: {node: '>=20.0.0'}
+    deprecated: please use @earendil-works/pi-agent-core instead going forward
 
   '@mariozechner/pi-ai@0.67.68':
     resolution: {integrity: sha512-DWWQmcb3IV3mbGXmzYBScfKA6kA52n/stY029eiBikrIxVT7DGLG6n7KSvTA2R4qBSgi1iFL3nGHtwxmtIn6Lg==}
     engines: {node: '>=20.0.0'}
+    deprecated: please use @earendil-works/pi-ai instead going forward
     hasBin: true
 
   '@mistralai/mistralai@2.2.0':

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -14,7 +14,10 @@
       "@vitest-evals/harness-openai-agents": [
         "packages/harness-openai-agents/src/index.ts"
       ],
-      "@vitest-evals/harness-pi-ai": ["packages/harness-pi-ai/src/index.ts"]
+      "@vitest-evals/harness-pi-ai": ["packages/harness-pi-ai/src/index.ts"],
+      "@vitest-evals/github-reporter": [
+        "packages/github-reporter/src/index.ts"
+      ]
     }
   }
 }


### PR DESCRIPTION
Add a GitHub Actions reporter package that reads Vitest JSON as the eval artifact and turns `vitest-evals` metadata into CI-native output. The package writes ASCII job summaries, emits terse workflow annotations for eval failures, and can publish an optional Check Run when configured with `checks: write`.

**JSON Artifact Flow**

The reporter uses Vitest's built-in JSON output because it preserves `task.meta.eval` and `task.meta.harness`. JUnit can still be emitted for CI systems that need XML, but it is not the source of truth for eval metadata.

**GitHub Output**

The CLI defaults to `vitest-results.json`, writes to `GITHUB_STEP_SUMMARY` when present, and keeps workflow setup to a run step plus an `if: always()` publish step. Check Run publishing is explicit via `--check-run` and degrades to warnings if token or permission setup is missing.

**Documentation**

Adds a minimal GitHub Actions setup guide and updates the package, architecture, development, and testing docs to describe the JSON-based reporting flow.