### PR TITLE
feat(github-reporter): Add native GitHub Action

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -2,6 +2,9 @@ minVersion: 0.23.1
 changelogPolicy: none
 preReleaseCommand: bash scripts/craft-pre-release.sh
 targets:
+  - name: github
+    tagPrefix: v
+    includeNames: /^$/
   - name: npm
     id: "vitest-evals"
     includeNames: /^vitest-evals-\d.*\.tgz$/

--- a/.craft.yml
+++ b/.craft.yml
@@ -2,9 +2,6 @@ minVersion: 0.23.1
 changelogPolicy: none
 preReleaseCommand: bash scripts/craft-pre-release.sh
 targets:
-  - name: github
-    tagPrefix: v
-    includeNames: /^$/
   - name: npm
     id: "vitest-evals"
     includeNames: /^vitest-evals-\d.*\.tgz$/
@@ -24,3 +21,6 @@ targets:
     id: "@vitest-evals/github-reporter"
     access: public
     includeNames: /^vitest-evals-github-reporter-\d.*\.tgz$/
+  - name: github
+    tagPrefix: v
+    includeNames: /^$/

--- a/.github/workflows/github-reporter-smoke.yml
+++ b/.github/workflows/github-reporter-smoke.yml
@@ -312,7 +312,7 @@ jobs:
 
           grep -F "# vitest-evals" "$GITHUB_STEP_SUMMARY"
           grep -F "| Metric | Value |" "$GITHUB_STEP_SUMMARY"
-          grep -F "Score distribution" "$GITHUB_STEP_SUMMARY"
+          grep -F "## Scores" "$GITHUB_STEP_SUMMARY"
           grep -F "0-19%   | #######              1" "$GITHUB_STEP_SUMMARY"
           grep -F "20-39%  | #############        2" "$GITHUB_STEP_SUMMARY"
           grep -F "40-59%  | #############        2" "$GITHUB_STEP_SUMMARY"
@@ -335,9 +335,12 @@ jobs:
           grep -F "Tool           Status  Duration" "$GITHUB_STEP_SUMMARY"
           grep -F "lookupInvoice  ok      7ms" "$GITHUB_STEP_SUMMARY"
           grep -F "| Status | failed |" "$GITHUB_STEP_SUMMARY"
-          grep -F "| Tests | 8 passed, 2 failed, 10 total |" "$GITHUB_STEP_SUMMARY"
           grep -F "| Evals | 8 passed, 2 failed, 10 total |" "$GITHUB_STEP_SUMMARY"
           grep -F "| Score | avg 0.59, min 0.10 |" "$GITHUB_STEP_SUMMARY"
+          if grep -F "| Tests |" "$GITHUB_STEP_SUMMARY"; then
+            echo "test totals row should not be shown"
+            exit 1
+          fi
           if grep -F "| Usage |" "$GITHUB_STEP_SUMMARY"; then
             echo "top-level usage row should not be shown"
             exit 1

--- a/.github/workflows/github-reporter-smoke.yml
+++ b/.github/workflows/github-reporter-smoke.yml
@@ -5,6 +5,8 @@ on:
     branches: [main]
     paths:
       - ".github/workflows/github-reporter-smoke.yml"
+      - "action.yml"
+      - "github-reporter/**"
       - "package.json"
       - "pnpm-lock.yaml"
       - "pnpm-workspace.yaml"
@@ -12,6 +14,8 @@ on:
   pull_request:
     paths:
       - ".github/workflows/github-reporter-smoke.yml"
+      - "action.yml"
+      - "github-reporter/**"
       - "package.json"
       - "pnpm-lock.yaml"
       - "pnpm-workspace.yaml"
@@ -23,7 +27,7 @@ permissions:
 
 jobs:
   smoke:
-    name: Smoke test GitHub reporter CLI
+    name: Smoke test GitHub reporter
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
@@ -31,7 +35,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
-          node-version: "20"
+          node-version: "24"
 
       # pnpm/action-setup@v4
       - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda
@@ -59,6 +63,9 @@ jobs:
       - name: Build reporter
         run: pnpm --filter @vitest-evals/github-reporter run build
 
+      - name: Build reporter action
+        run: pnpm build:action
+
       - name: Create fake Vitest JSON report
         run: |
           mkdir -p tmp/github-reporter-smoke
@@ -77,7 +84,7 @@ jobs:
               judge: "SmokeJudge",
               rationale: "expected approved but got denied",
               output: { status: "denied" },
-              usage: { totalTokens: 42, toolCalls: 1, estimatedCost: 0.0011 },
+              usage: { totalTokens: 42, toolCalls: 1 },
               timingMs: 1200,
               toolCalls: [{ name: "lookupInvoice", durationMs: 7 }],
             },
@@ -90,7 +97,7 @@ jobs:
               judge: "AmountJudge",
               rationale: "expected amount=5000, got amount=499",
               output: { status: "approved", amount: 499 },
-              usage: { totalTokens: 120, toolCalls: 2, estimatedCost: 0.0042 },
+              usage: { totalTokens: 120, toolCalls: 2 },
               timingMs: 1800,
               toolCalls: [
                 { name: "lookupInvoice", durationMs: 9 },
@@ -111,7 +118,7 @@ jobs:
               score: 0.22,
               judge: "PolicyJudge",
               output: { status: "needs_review" },
-              usage: { totalTokens: 80, estimatedCost: 0.0018 },
+              usage: { totalTokens: 80 },
               timingMs: 610,
             },
             {
@@ -122,7 +129,7 @@ jobs:
               score: 0.45,
               judge: "ToneJudge",
               output: { tone: "calm" },
-              usage: { totalTokens: 95, toolCalls: 1, estimatedCost: 0.002 },
+              usage: { totalTokens: 95, toolCalls: 1 },
               timingMs: 740,
               toolCalls: [{ name: "loadCustomer", durationMs: 11 }],
             },
@@ -134,7 +141,7 @@ jobs:
               score: 0.58,
               judge: "ExplanationJudge",
               output: { status: "approved", amount: 2500 },
-              usage: { totalTokens: 110, estimatedCost: 0.0024 },
+              usage: { totalTokens: 110 },
               timingMs: 860,
             },
             {
@@ -145,7 +152,7 @@ jobs:
               score: 0.62,
               judge: "ClarificationJudge",
               output: { status: "needs_more_info" },
-              usage: { totalTokens: 130, toolCalls: 1, estimatedCost: 0.003 },
+              usage: { totalTokens: 130, toolCalls: 1 },
               timingMs: 920,
               toolCalls: [{ name: "readPolicy", durationMs: 5 }],
             },
@@ -157,7 +164,7 @@ jobs:
               score: 0.74,
               judge: "ToolUseJudge",
               output: { status: "approved", amount: 1800 },
-              usage: { totalTokens: 155, toolCalls: 2, estimatedCost: 0.0037 },
+              usage: { totalTokens: 155, toolCalls: 2 },
               timingMs: 1100,
               toolCalls: [
                 { name: "lookupOrder", durationMs: 8 },
@@ -172,7 +179,7 @@ jobs:
               score: 0.86,
               judge: "RefundJudge",
               output: { status: "approved", amount: 1200 },
-              usage: { totalTokens: 170, toolCalls: 1, estimatedCost: 0.004 },
+              usage: { totalTokens: 170, toolCalls: 1 },
               timingMs: 990,
               toolCalls: [{ name: "createRefund", durationMs: 22 }],
             },
@@ -184,7 +191,7 @@ jobs:
               score: 0.95,
               judge: "PolicyJudge",
               output: { status: "denied" },
-              usage: { totalTokens: 190, toolCalls: 1, estimatedCost: 0.0045 },
+              usage: { totalTokens: 190, toolCalls: 1 },
               timingMs: 1040,
               toolCalls: [{ name: "readPolicy", durationMs: 6 }],
             },
@@ -196,7 +203,7 @@ jobs:
               score: 1,
               judge: "DuplicateJudge",
               output: { status: "denied", reason: "duplicate" },
-              usage: { totalTokens: 210, estimatedCost: 0.005 },
+              usage: { totalTokens: 210 },
               timingMs: 1150,
             },
           ];
@@ -325,7 +332,10 @@ jobs:
           grep -F "| Tests | 8 passed, 2 failed, 10 total |" "$GITHUB_STEP_SUMMARY"
           grep -F "| Evals | 8 passed, 2 failed, 10 total |" "$GITHUB_STEP_SUMMARY"
           grep -F "| Score | avg 0.59, min 0.10 |" "$GITHUB_STEP_SUMMARY"
-          grep -F '| Usage | 1,302 tokens, 9 tools, $0.0317 |' "$GITHUB_STEP_SUMMARY"
+          if grep -F "| Usage |" "$GITHUB_STEP_SUMMARY"; then
+            echo "top-level usage row should not be shown"
+            exit 1
+          fi
           grep -F "::error file=apps/demo/evals/smoke.eval.ts,line=12,col=5,title=vitest-evals::refund eval > rejects fraud - score 0.10 - SmokeJudge - expected approved but got denied" tmp/github-reporter-smoke/stdout.txt
           grep -F "::error file=apps/demo/evals/smoke.eval.ts,line=28,col=5,title=vitest-evals::refund eval > returns wrong refund amount - score 0.35 - AmountJudge - expected amount=5000, got amount=499" tmp/github-reporter-smoke/stdout.txt
           grep -F "::warning::GitHub Check Run skipped: missing GITHUB_TOKEN" tmp/github-reporter-smoke/stdout.txt
@@ -333,3 +343,30 @@ jobs:
             echo "warning workflow command was emitted on stderr"
             exit 1
           fi
+
+      - name: Run reporter action
+        id: reporter_action
+        uses: ./
+        with:
+          results: tmp/github-reporter-smoke/vitest-results.json
+          publish-summary: false
+          publish-check: true
+          github-token: ""
+          fail-on-failures: false
+
+      - name: Assert reporter action outputs
+        env:
+          ACTION_STATUS: ${{ steps.reporter_action.outputs.status }}
+          ACTION_RESULTS_COUNT: ${{ steps.reporter_action.outputs['results-count'] }}
+          ACTION_EVALS_TOTAL: ${{ steps.reporter_action.outputs['evals-total'] }}
+          ACTION_EVALS_FAILED: ${{ steps.reporter_action.outputs['evals-failed'] }}
+          ACTION_SCORE_AVERAGE: ${{ steps.reporter_action.outputs['score-average'] }}
+          ACTION_CHECK_URL: ${{ steps.reporter_action.outputs['check-url'] }}
+        run: |
+          set -euo pipefail
+          test "$ACTION_STATUS" = "failed"
+          test "$ACTION_RESULTS_COUNT" = "1"
+          test "$ACTION_EVALS_TOTAL" = "10"
+          test "$ACTION_EVALS_FAILED" = "2"
+          test "$ACTION_SCORE_AVERAGE" = "0.59"
+          test -z "$ACTION_CHECK_URL"

--- a/.github/workflows/github-reporter-smoke.yml
+++ b/.github/workflows/github-reporter-smoke.yml
@@ -66,6 +66,12 @@ jobs:
       - name: Build reporter action
         run: pnpm build:action
 
+      - name: Assert reporter action bundle
+        run: |
+          set -euo pipefail
+          grep -F 'main: "github-reporter/dist/action/index.js"' action.yml
+          test -s github-reporter/dist/action/index.js
+
       - name: Create fake Vitest JSON report
         run: |
           mkdir -p tmp/github-reporter-smoke

--- a/.github/workflows/merge-jobs.yml
+++ b/.github/workflows/merge-jobs.yml
@@ -11,8 +11,7 @@ on:
 
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 jobs:
   build-publish:
     runs-on: ubuntu-latest
@@ -24,7 +23,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
-          node-version: "20"
+          node-version: "24"
 
       # pnpm/action-setup@v4
       - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda
@@ -60,6 +59,9 @@ jobs:
 
       - name: Build
         run: pnpm build
+
+      - name: Build GitHub reporter action
+        run: pnpm build:action
 
       - name: Pack NPM Tarballs
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
       with:
         app-id: ${{ vars.SENTRY_RELEASE_BOT_CLIENT_ID }}
         private-key: ${{ secrets.SENTRY_RELEASE_BOT_PRIVATE_KEY }}
-    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v2
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       with:
         token: ${{ steps.token.outputs.token }}
         fetch-depth: 0
@@ -55,7 +55,7 @@ jobs:
     - name: Setup Node.js
       uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
       with:
-        node-version: "20"
+        node-version: "24"
 
     - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda
       name: Install pnpm
@@ -76,6 +76,52 @@ jobs:
           "$CURRENT" "$BUMP" "$PRERELEASE" "$PRERELEASE_ID")
         echo "current=$CURRENT" >> "$GITHUB_OUTPUT"
         echo "new=$NEW" >> "$GITHUB_OUTPUT"
+
+    # Craft uses `git describe --tags` to find the previous version. Published
+    # action tags point to bundled artifact commits, so the previous release
+    # must leave a reachable source tag for the next changelog baseline.
+    - name: Verify previous source tag
+      run: |
+        set -euo pipefail
+        VERSION="${{ steps.version.outputs.current }}"
+        SOURCE_TAG="v${VERSION}-src"
+        CURRENT_TAG="v${VERSION}"
+        DESCRIBED_TAG="$(git describe --tags --abbrev=0)"
+        DESCRIBED_SHA="$(git rev-parse "$DESCRIBED_TAG^{commit}")"
+
+        if git rev-parse "$SOURCE_TAG^{commit}" >/dev/null 2>&1; then
+          SOURCE_SHA="$(git rev-parse "$SOURCE_TAG^{commit}")"
+
+          if [ "$DESCRIBED_SHA" != "$SOURCE_SHA" ]; then
+            echo "::error::Expected git describe to resolve to $SOURCE_TAG ($SOURCE_SHA), got $DESCRIBED_TAG ($DESCRIBED_SHA)"
+            exit 1
+          fi
+
+          if ! git rev-parse "$CURRENT_TAG^{commit}" >/dev/null 2>&1; then
+            echo "::error::Missing bundled action tag $CURRENT_TAG."
+            exit 1
+          fi
+
+          if ! git cat-file -e "$CURRENT_TAG:github-reporter/dist/action/index.js" 2>/dev/null; then
+            echo "::error::Bundled action tag $CURRENT_TAG is missing github-reporter/dist/action/index.js."
+            exit 1
+          fi
+
+          echo "Craft previous-release baseline: $SOURCE_TAG ($SOURCE_SHA)"
+          exit 0
+        fi
+
+        if git tag --list "v*-src" | grep -q .; then
+          echo "::error::Missing source tag $SOURCE_TAG, but prior action source tags exist. The previous action release did not finalize its source tag."
+          exit 1
+        fi
+
+        if git tag --list "v*" | grep -q .; then
+          echo "::error::Missing source tag $SOURCE_TAG, but v-prefixed release tags already exist. Create the missing source tag before preparing another action release."
+          exit 1
+        fi
+
+        echo "No action source tags found; allowing first action-bundle release from existing baseline $DESCRIBED_TAG ($DESCRIBED_SHA)."
 
     - name: Prepare release
       uses: getsentry/action-prepare-release@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,8 +7,9 @@ on:
 
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
+  checks: write
+  pull-requests: read
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -18,7 +19,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
-          node-version: "20"
+          node-version: "24"
 
       # pnpm/action-setup@v4
       - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda
@@ -60,6 +61,9 @@ jobs:
 
       - name: Build
         run: pnpm build
+
+      - name: Build GitHub reporter action
+        run: pnpm build:action
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v4

--- a/.github/workflows/update-action-tag.yml
+++ b/.github/workflows/update-action-tag.yml
@@ -11,13 +11,29 @@ jobs:
   update-tag:
     runs-on: ubuntu-latest
     steps:
+      - name: Validate release tag
+        id: release_tag
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+          if [[ "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$ ]]; then
+            echo "publish=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "Skipping non-action release tag: $RELEASE_TAG"
+          echo "publish=false" >> "$GITHUB_OUTPUT"
+
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        if: steps.release_tag.outputs.publish == 'true'
         with:
           ref: ${{ github.event.release.tag_name }}
           fetch-depth: 0
           fetch-tags: true
 
       - name: Ensure source release tag
+        if: steps.release_tag.outputs.publish == 'true'
         env:
           RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
@@ -48,22 +64,27 @@ jobs:
           git push origin "refs/tags/$SOURCE_TAG"
 
       - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda
+        if: steps.release_tag.outputs.publish == 'true'
         with:
           version: 10.33.0
           run_install: false
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        if: steps.release_tag.outputs.publish == 'true'
         with:
           node-version: "24"
           cache: pnpm
 
       - name: Install dependencies
+        if: steps.release_tag.outputs.publish == 'true'
         run: pnpm install --frozen-lockfile
 
       - name: Build action bundle
+        if: steps.release_tag.outputs.publish == 'true'
         run: pnpm build:action
 
       - name: Commit bundle and update tags
+        if: steps.release_tag.outputs.publish == 'true'
         env:
           RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |

--- a/.github/workflows/update-action-tag.yml
+++ b/.github/workflows/update-action-tag.yml
@@ -1,0 +1,87 @@
+name: Update GitHub Reporter Action Tag
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+
+jobs:
+  update-tag:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          ref: ${{ github.event.release.tag_name }}
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Ensure source release tag
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+          VERSION="${RELEASE_TAG#v}"
+          SOURCE_TAG="v${VERSION}-src"
+          ARTIFACT_SUBJECT="Build github-reporter action for $RELEASE_TAG"
+          SOURCE_SHA="$(git rev-parse HEAD)"
+
+          while [ "$(git show -s --format=%s "$SOURCE_SHA")" = "$ARTIFACT_SUBJECT" ]; do
+            SOURCE_SHA="$(git rev-parse "$SOURCE_SHA^")"
+            echo "Detected existing artifact commit. Walking back to $SOURCE_SHA for $SOURCE_TAG"
+          done
+
+          if git rev-parse "$SOURCE_TAG^{commit}" >/dev/null 2>&1; then
+            EXISTING_SHA="$(git rev-parse "$SOURCE_TAG^{commit}")"
+            if [ "$EXISTING_SHA" = "$SOURCE_SHA" ]; then
+              echo "Source tag $SOURCE_TAG already points to $SOURCE_SHA"
+              exit 0
+            fi
+
+            echo "::error::Source tag $SOURCE_TAG points to $EXISTING_SHA, expected $SOURCE_SHA"
+            exit 1
+          fi
+
+          echo "Creating source tag $SOURCE_TAG on $SOURCE_SHA"
+          git tag "$SOURCE_TAG" "$SOURCE_SHA"
+          git push origin "refs/tags/$SOURCE_TAG"
+
+      - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda
+        with:
+          version: 10.33.0
+          run_install: false
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: "24"
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build action bundle
+        run: pnpm build:action
+
+      - name: Commit bundle and update tags
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+          VERSION="${RELEASE_TAG#v}"
+          MAJOR="v${VERSION%%.*}"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          git add -f github-reporter/dist/action/index.js
+
+          git diff --cached --quiet || git commit -m "Build github-reporter action for $RELEASE_TAG"
+
+          git tag -fa "$RELEASE_TAG" -m "Release $RELEASE_TAG"
+          git push -f origin "$RELEASE_TAG"
+
+          if [[ "$VERSION" != *-* ]]; then
+            git tag -fa "$MAJOR" -m "Update $MAJOR to $RELEASE_TAG"
+            git push -f origin "$MAJOR"
+          fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,12 +21,17 @@ Co-Authored-By: OpenAI Codex <codex@openai.com>
 - Root API work is harness-first and judge-first.
 - Legacy scorer-first changes stay under `packages/vitest-evals/src/legacy/...`.
 - Keep normalized session and run data JSON-serializable.
+- Keep `UsageSummary` to stable usage units such as tokens, tools, retries, provider, and model. Do not add first-class cost fields; provider-specific cost estimates belong in `usage.metadata`.
+- GitHub reporting is action-first: document workflows with `uses: getsentry/vitest-evals@v0`, not CLI commands.
+- Sharded eval reporting uses distinct JSON artifacts per matrix job and one reducer job that publishes the combined action report.
+- Root GitHub Action releases keep source and bundled tags separate: Craft publishes the source release, `vX.Y.Z-src` preserves the source baseline, and `vX`/`vX.Y.Z` point at the bundled action commit. Keep the Craft `github` target filtered away from package artifacts.
 - Update `README.md`, `packages/vitest-evals/README.md`, and relevant docs when product shape changes.
 - Follow `policies/code-comments.md` for exported-function JSDoc and non-obvious comments only.
 
 ## Read First
 - `docs/architecture.md`
 - `docs/development-guide.md`
+- `docs/github-actions.md`
 - `docs/testing.md`
 - `policies/README.md`
 - `policies/code-comments.md`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,7 +78,11 @@ surfaces.
 - Legacy changes should stay under `src/legacy/...`.
 - New examples should show the actual runtime seam, not placeholders.
 - Normalized session data must remain JSON-serializable.
+- `UsageSummary` should stay limited to stable usage units such as tokens, tools, retries, provider, and model. Provider-specific cost estimates belong in `usage.metadata`, not first-class fields.
 - Reporter changes require reporter tests.
+- GitHub reporting is action-first; docs should show `uses: getsentry/vitest-evals@v0`, not CLI commands.
+- Sharded eval reporting uses distinct JSON artifacts per matrix job and one reducer job that publishes the combined action report.
+- Root GitHub Action releases keep source and bundled tags separate: Craft publishes the source release, `vX.Y.Z-src` preserves the source baseline, and `vX`/`vX.Y.Z` point at the bundled action commit. Keep the Craft `github` target filtered away from package artifacts.
 - Harness changes require harness package tests.
 - Legacy scorer changes require legacy tests.
 

--- a/README.md
+++ b/README.md
@@ -66,20 +66,28 @@ The JSON report preserves `task.meta`, including eval scores, harness runs,
 usage, and tool calls. JUnit can still be emitted alongside it for CI systems
 that expect XML.
 
-```sh
-pnpm exec vitest run apps packages \
-  --config=./vitest.config.ts \
-  --reporter=vitest-evals/reporter \
-  --reporter=json \
-  --outputFile.json=vitest-results.json
+```yaml
+steps:
+  - name: Run evals
+    run: |
+      pnpm exec vitest run apps packages \
+        --config=./vitest.config.ts \
+        --reporter=vitest-evals/reporter \
+        --reporter=json \
+        --outputFile.json=vitest-results.json
 
-pnpm exec vitest-evals-github-report --check-run
+  - uses: getsentry/vitest-evals@v0
+    if: always()
+    with:
+      results: vitest-results.json
+      publish-check: true
 ```
 
-The reporter writes a plain ASCII job summary through `GITHUB_STEP_SUMMARY`,
-emits terse annotations for failed evals, and publishes a separate Check Run
-only when `--check-run` is set, `GITHUB_TOKEN` is available, and `checks: write`
-permission is configured.
+The reporter action writes a plain ASCII job summary through
+`GITHUB_STEP_SUMMARY`, emits terse annotations for failed evals, and publishes a
+separate Check Run when `publish-check` is enabled and `checks: write`
+permission is configured. It can also reduce sharded eval JSON artifacts into
+one combined report.
 See [docs/github-actions.md](docs/github-actions.md) for the minimal workflow.
 
 ## Releases
@@ -93,6 +101,13 @@ For a preview release that should not become the main stable version, set
 `bump=major` produces `1.0.0-beta.0`; running prerelease again from
 `1.0.0-beta.0` produces `1.0.0-beta.1`. Craft publishes npm prereleases under a
 prerelease dist-tag so the stable `latest` line is not moved.
+
+Release tags are updated after publish with the bundled `github-reporter`
+action so workflows can use `getsentry/vitest-evals@v0`. The release workflow
+keeps `vX.Y.Z-src` on the source commit for Craft's next changelog baseline,
+then moves `vX.Y.Z` and the stable `vX` tag to the bundled action commit. The
+Craft GitHub target creates the release but is filtered away from package
+artifacts so it does not upload npm package contents as release assets.
 
 ## Example
 

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,61 @@
+name: "vitest-evals GitHub Reporter"
+description: "Publish vitest-evals results to GitHub Actions summaries, annotations, and checks"
+author: "Functional Software, Inc."
+
+branding:
+  icon: "check-circle"
+  color: "green"
+
+inputs:
+  results:
+    description: "Vitest JSON result files to report. Supports paths, * and ** globs, and newline-separated entries."
+    required: false
+    default: "vitest-results.json"
+  publish-summary:
+    description: "Write a GitHub Actions job summary."
+    required: false
+    default: "true"
+  publish-annotations:
+    description: "Emit GitHub workflow annotations for failed evals."
+    required: false
+    default: "true"
+  publish-check:
+    description: "Publish a GitHub Check Run for the combined report."
+    required: false
+    default: "false"
+  check-name:
+    description: "Name of the GitHub Check Run."
+    required: false
+    default: "vitest-evals"
+  github-token:
+    description: "GitHub token used for Check Run publishing."
+    required: false
+    default: "${{ github.token }}"
+  fail-on-failures:
+    description: "Fail the action when the combined eval report failed."
+    required: false
+    default: "false"
+  max-annotations:
+    description: "Maximum number of failure annotations to publish. Check Run annotations are capped at 50."
+    required: false
+  max-failures:
+    description: "Maximum number of detailed failures to include in summaries and checks."
+    required: false
+
+outputs:
+  status:
+    description: "Combined report status: passed or failed."
+  results-count:
+    description: "Number of Vitest JSON result files included."
+  evals-total:
+    description: "Total eval cases included in the report."
+  evals-failed:
+    description: "Failed eval cases included in the report."
+  score-average:
+    description: "Average eval score across the combined report."
+  check-url:
+    description: "URL of the published GitHub Check Run, when available."
+
+runs:
+  using: "node24"
+  main: "github-reporter/dist/action/index.js"

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -53,6 +53,11 @@ The normalized session is intentionally JSON-serializable so it can be
 persisted, attached to errors, and emitted by reporters without custom
 serialization logic.
 
+`UsageSummary` is intentionally limited to stable usage units such as tokens,
+tool counts, retries, provider, and model. Provider-specific cost estimates are
+not normalized because pricing semantics vary by runtime and can be stale; if a
+harness needs to retain them, store them under `usage.metadata`.
+
 ### `packages/vitest-evals/src/index.ts`
 
 Defines the harness-first public API:
@@ -110,19 +115,21 @@ Provides the custom Vitest reporter that reads normalized run metadata from
 
 ## GitHub Reporting
 
-`packages/github-reporter` is a post-run reporter for GitHub Actions. It reads
-Vitest's built-in JSON output instead of attaching directly to the Vitest
-reporter lifecycle. That JSON output includes each assertion's `meta` field, so
-it preserves the normalized eval and harness metadata recorded by core.
+`packages/github-reporter` is the implementation behind the native
+`getsentry/vitest-evals` GitHub Action. It reads Vitest's
+built-in JSON output instead of attaching directly to the Vitest reporter
+lifecycle. That JSON output includes each assertion's `meta` field, so it
+preserves the normalized eval and harness metadata recorded by core.
 
 This split keeps the terminal reporter focused on local output and gives CI a
 stable artifact to process:
 
 1. Vitest runs evals and writes `--reporter=json` to `vitest-results.json`.
-2. The GitHub reporter reads that JSON.
-3. It writes an ASCII job summary to `GITHUB_STEP_SUMMARY`.
-4. It emits terse workflow-command annotations for failed evals.
-5. When explicitly configured, it publishes a separate GitHub Check Run.
+2. The GitHub reporter action reads one or more JSON result files.
+3. It merges sharded reports when multiple result files are provided.
+4. It writes an ASCII job summary to `GITHUB_STEP_SUMMARY`.
+5. It emits terse workflow-command annotations for failed evals.
+6. When explicitly configured, it publishes a separate GitHub Check Run.
 
 JUnit XML can be emitted alongside JSON, but it is not used as the source of
 truth for eval reporting because it does not carry the full harness metadata.

--- a/docs/development-guide.md
+++ b/docs/development-guide.md
@@ -87,13 +87,16 @@ Owns:
 Owns:
 
 - reading Vitest JSON reports that include eval task metadata
+- the native `getsentry/vitest-evals` action implementation
+- merging sharded JSON reports into one combined report
 - rendering GitHub Actions job summaries
 - rendering workflow-command annotations
 - optional GitHub Check Run publishing
 
-Keep this package file/artifact based. Do not make it depend on Vitest's live
-reporter lifecycle unless the JSON contract stops carrying the metadata core
-needs.
+Keep this package file/artifact based. The public GitHub surface is the action,
+so workflow docs should show `uses: getsentry/vitest-evals@v0`
+instead of package CLI commands. Do not make it depend on Vitest's live reporter
+lifecycle unless the JSON contract stops carrying the metadata core needs.
 
 ## Demo Apps
 

--- a/docs/github-actions.md
+++ b/docs/github-actions.md
@@ -1,15 +1,11 @@
 # GitHub Actions Reporting
 
-`@vitest-evals/github-reporter` reads Vitest JSON output and publishes the
-GitHub-facing report. Use JSON as the eval artifact because it preserves
-`task.meta.eval` and `task.meta.harness`; JUnit XML does not carry the full eval
-metadata.
+`getsentry/vitest-evals` is the GitHub Actions reporting
+surface for `vitest-evals`. It reads Vitest JSON output and publishes GitHub
+job summaries, workflow annotations, and optional Check Runs.
 
-## Install
-
-```sh
-pnpm add -D @vitest-evals/github-reporter
-```
+Use JSON as the eval artifact because it preserves `task.meta.eval` and
+`task.meta.harness`; JUnit XML does not carry the full eval metadata.
 
 ## Minimal Workflow
 
@@ -22,7 +18,7 @@ jobs:
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           cache: pnpm
       - run: pnpm install
 
@@ -33,18 +29,18 @@ jobs:
             --reporter=json \
             --outputFile.json=vitest-results.json
 
-      - name: Publish eval report
+      - uses: getsentry/vitest-evals@v0
         if: always()
-        run: pnpm exec vitest-evals-github-report
+        with:
+          results: vitest-results.json
 ```
 
-The publish step still runs after failed evals because of `if: always()`. The
+The report step still runs after failed evals because of `if: always()`. The
 job remains failed when the eval step fails.
 
-## Optional Check Run
+## Check Run
 
-Add `checks: write`, pass the GitHub token as an environment variable, and opt
-in with `--check-run`.
+Add `checks: write` and enable `publish-check`.
 
 ```yaml
 permissions:
@@ -52,15 +48,89 @@ permissions:
   checks: write
 
 steps:
-  - name: Publish eval report
+  - uses: getsentry/vitest-evals@v0
     if: always()
-    env:
-      GITHUB_TOKEN: ${{ github.token }}
-    run: pnpm exec vitest-evals-github-report --check-run
+    with:
+      results: vitest-results.json
+      publish-check: true
 ```
 
-If the token or permission is missing, the command keeps the job summary and
+If the token or permission is missing, the action keeps the job summary and
 workflow annotations and warns instead of failing the job.
+
+## Sharded Evals
+
+Split evals with a matrix, upload one JSON artifact per shard, then reduce them
+in one final reporting job.
+
+```yaml
+jobs:
+  evals:
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+      - run: pnpm install
+
+      - name: Run eval shard
+        run: |
+          pnpm exec vitest run evals \
+            --shard=${{ matrix.shard }}/4 \
+            --reporter=vitest-evals/reporter \
+            --reporter=json \
+            --outputFile.json=vitest-results-${{ matrix.shard }}.json
+
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: vitest-evals-${{ matrix.shard }}
+          path: vitest-results-${{ matrix.shard }}.json
+
+  report:
+    if: always()
+    needs: [evals]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: vitest-evals-*
+          path: eval-results
+          merge-multiple: true
+
+      - uses: getsentry/vitest-evals@v0
+        with:
+          results: eval-results/*.json
+          publish-check: true
+          fail-on-failures: true
+```
+
+`fail-on-failures` is useful when the reducer job should be the final required
+check. If shard jobs are already required and fail on their own, leave it off.
+
+## Inputs
+
+| Input | Default | Description |
+| --- | --- | --- |
+| `results` | `vitest-results.json` | Vitest JSON result files. Supports paths, `*` and `**` globs, and newline-separated entries. |
+| `publish-summary` | `true` | Write a GitHub Actions job summary. |
+| `publish-annotations` | `true` | Emit GitHub workflow annotations for failed evals. |
+| `publish-check` | `false` | Publish one GitHub Check Run for the combined report. |
+| `check-name` | `vitest-evals` | Name of the GitHub Check Run. |
+| `github-token` | `${{ github.token }}` | Token used for Check Run publishing. |
+| `fail-on-failures` | `false` | Fail the action when the combined report failed. |
+| `max-annotations` | unset | Maximum number of failure annotations to publish. Check Run annotations are capped at 50 by GitHub. |
+| `max-failures` | unset | Maximum number of detailed failures to include in summaries and checks. |
 
 ## JUnit
 

--- a/docs/provider-transformations.md
+++ b/docs/provider-transformations.md
@@ -50,7 +50,9 @@ Harness adapters should:
 - keep the stored session JSON-serializable
 - normalize tool calls into `ToolCallRecord`
 - preserve the application-facing result separately in `run.output`
-- attach provider/model and usage data when available
+- attach provider/model and stable usage data when available
+- keep provider-specific cost estimates in `usage.metadata`, not as normalized
+  usage fields
 - attach replay/cache metadata in the tool record metadata rather than in
   provider-specific side channels
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -68,7 +68,9 @@ Cover:
 
 Cover:
 
+- native action input parsing when the workflow-facing contract changes
 - Vitest JSON metadata collection
+- sharded report merging when multiple JSON files are accepted
 - ASCII job summary rendering
 - long judge rationale handling without tables
 - workflow-command escaping

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "packageManager": "pnpm@10.33.0",
   "scripts": {
     "build": "pnpm -r --if-present run build",
+    "build:action": "pnpm --filter @vitest-evals/github-reporter run build:action",
     "evals": "node ./scripts/run-workspace-evals.mjs",
     "evals:verbose": "node ./scripts/run-workspace-evals.mjs -v",
     "evals:fail": "node ./scripts/run-workspace-evals.mjs --fail",

--- a/packages/github-reporter/README.md
+++ b/packages/github-reporter/README.md
@@ -1,86 +1,74 @@
 # @vitest-evals/github-reporter
 
-GitHub Actions reporting for `vitest-evals` runs.
+GitHub Actions reporting internals for `vitest-evals` runs.
 
-This package reads Vitest's built-in JSON report. Vitest JSON includes each
-test's `meta` field, which is where `vitest-evals` records harness runs,
-scores, judge rationales, usage, and tool calls.
+The user-facing API is the native GitHub Action:
+
+```yaml
+- uses: getsentry/vitest-evals@v0
+  if: always()
+  with:
+    results: vitest-results.json
+```
+
+The action reads Vitest's built-in JSON report. Vitest JSON includes each test's
+`meta` field, which is where `vitest-evals` records harness runs, scores, judge
+rationales, usage, and tool calls.
 
 JUnit XML can still be emitted for CI systems that expect it, but it is not the
 source of truth for eval reporting.
 
-## Usage
-
-```sh
-pnpm exec vitest run apps packages \
-  --config=./vitest.config.ts \
-  --reporter=vitest-evals/reporter \
-  --reporter=json \
-  --outputFile.json=vitest-results.json
-
-pnpm exec vitest-evals-github-report
-```
-
-In GitHub Actions, the reporter writes to `GITHUB_STEP_SUMMARY` when available
-and emits terse workflow-command annotations for failed evals.
-
 ## Check Run
-
-To publish a separate `vitest-evals` Check Run, opt in explicitly:
-
-```sh
-GITHUB_TOKEN=... pnpm exec vitest-evals-github-report --check-run
-```
-
-The Check Run path requires the normal GitHub Actions environment plus a token
-with `checks: write`. If configuration or permission is missing, the command
-keeps the job summary and workflow annotations and warns instead of failing.
 
 ```yaml
 permissions:
   contents: read
   checks: write
+
+steps:
+  - uses: getsentry/vitest-evals@v0
+    if: always()
+    with:
+      results: vitest-results.json
+      publish-check: true
 ```
 
-## Recommended Workflow
+If configuration or permission is missing, the action keeps the job summary and
+workflow annotations and warns instead of failing.
+
+## Sharded Reports
+
+Upload one JSON artifact per shard, then publish one combined report from a
+final reducer job:
 
 ```yaml
-jobs:
-  evals:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      checks: write
-    steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: pnpm
-      - run: pnpm install
+- uses: actions/download-artifact@v4
+  with:
+    pattern: vitest-evals-*
+    path: eval-results
+    merge-multiple: true
 
-      - name: Run evals
-        run: |
-          pnpm exec vitest run apps packages \
-            --config=./vitest.config.ts \
-            --reporter=vitest-evals/reporter \
-            --reporter=json \
-            --outputFile.json=vitest-results.json
-
-      - name: Publish eval report
-        if: always()
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        run: |
-          pnpm exec vitest-evals-github-report --check-run
+- uses: getsentry/vitest-evals@v0
+  with:
+    results: eval-results/*.json
+    publish-check: true
 ```
 
-## Output Rules
+## Inputs
 
-- Job summary is the primary human-readable report.
-- Failure lists use numbered key/value blocks, not wide tables.
-- Long judge reasons live inside `<details>` blocks and fenced text.
-- Workflow annotations include only the first useful failure line.
-- Check Run annotations include richer `raw_details` when available.
-- Output is plain ASCII markdown.
+| Input | Default | Description |
+| --- | --- | --- |
+| `results` | `vitest-results.json` | Vitest JSON result files. Supports paths, `*` and `**` globs, and newline-separated entries. |
+| `publish-summary` | `true` | Write a GitHub Actions job summary. |
+| `publish-annotations` | `true` | Emit GitHub workflow annotations for failed evals. |
+| `publish-check` | `false` | Publish one GitHub Check Run for the combined report. |
+| `check-name` | `vitest-evals` | Name of the GitHub Check Run. |
+| `github-token` | `${{ github.token }}` | Token used for Check Run publishing. |
+| `fail-on-failures` | `false` | Fail the action when the combined report failed. |
+| `max-annotations` | unset | Maximum number of failure annotations to publish. Check Run annotations are capped at 50 by GitHub. |
+| `max-failures` | unset | Maximum number of detailed failures to include in summaries and checks. |
+
+## CLI
+
+The package still ships `vitest-evals-github-report` for local debugging and
+backward compatibility. GitHub workflows should use the native action.

--- a/packages/github-reporter/package.json
+++ b/packages/github-reporter/package.json
@@ -8,9 +8,7 @@
   "bin": {
     "vitest-evals-github-report": "./dist/cli.js"
   },
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "publishConfig": {
     "access": "public"
   },
@@ -23,7 +21,8 @@
     }
   },
   "scripts": {
-    "build": "tsup --config ./tsup.config.ts"
+    "build": "tsup --config ./tsup.config.ts",
+    "build:action": "tsup --config ./tsup.action.config.ts"
   },
   "peerDependencies": {
     "vitest": ">=4 <5"

--- a/packages/github-reporter/src/action/inputs.ts
+++ b/packages/github-reporter/src/action/inputs.ts
@@ -1,0 +1,65 @@
+import { splitResultsInput } from "../results";
+
+export type ActionInputs = {
+  results: string[];
+  publishSummary: boolean;
+  publishAnnotations: boolean;
+  publishCheck: boolean;
+  checkName: string;
+  githubToken?: string;
+  failOnFailures: boolean;
+  maxAnnotations?: number;
+  maxFailures?: number;
+};
+
+/** Parses GitHub Action inputs from INPUT_* environment variables. */
+export function parseActionInputs(
+  env: NodeJS.ProcessEnv = process.env,
+): ActionInputs {
+  return {
+    results: splitResultsInput(
+      getInput(env, "results") || "vitest-results.json",
+    ),
+    publishSummary: parseBooleanInput(getInput(env, "publish-summary"), true),
+    publishAnnotations: parseBooleanInput(
+      getInput(env, "publish-annotations"),
+      true,
+    ),
+    publishCheck: parseBooleanInput(getInput(env, "publish-check"), false),
+    checkName: getInput(env, "check-name") || "vitest-evals",
+    githubToken: getInput(env, "github-token"),
+    failOnFailures: parseBooleanInput(getInput(env, "fail-on-failures"), false),
+    maxAnnotations: parseOptionalInteger(getInput(env, "max-annotations")),
+    maxFailures: parseOptionalInteger(getInput(env, "max-failures")),
+  };
+}
+
+function getInput(env: NodeJS.ProcessEnv, name: string) {
+  const hyphenKey = `INPUT_${name.toUpperCase()}`;
+  const underscoreKey = `INPUT_${name.toUpperCase().replace(/-/g, "_")}`;
+  return (env[hyphenKey] ?? env[underscoreKey] ?? "").trim();
+}
+
+function parseBooleanInput(value: string, defaultValue: boolean) {
+  if (!value) {
+    return defaultValue;
+  }
+  const normalizedValue = value.toLowerCase();
+  if (normalizedValue === "true") {
+    return true;
+  }
+  if (normalizedValue === "false") {
+    return false;
+  }
+  throw new Error(`Invalid boolean input: ${value}`);
+}
+
+function parseOptionalInteger(value: string) {
+  if (!value) {
+    return undefined;
+  }
+  if (!/^\d+$/.test(value)) {
+    throw new Error(`Invalid integer input: ${value}`);
+  }
+  return Number(value);
+}

--- a/packages/github-reporter/src/action/main.ts
+++ b/packages/github-reporter/src/action/main.ts
@@ -1,0 +1,63 @@
+import { appendFileSync } from "node:fs";
+import { randomUUID } from "node:crypto";
+import { parseActionInputs } from "./inputs";
+import { publishEvalReport } from "../report";
+import { escapeCommandData, formatScore } from "../utils";
+
+main().catch((error) => {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(`::error::${escapeCommandData(message)}`);
+  process.exit(1);
+});
+
+async function main() {
+  const inputs = parseActionInputs();
+  const result = await publishEvalReport({
+    resultPatterns: inputs.results,
+    cwd: process.env.GITHUB_WORKSPACE ?? process.cwd(),
+    workspace: process.env.GITHUB_WORKSPACE ?? process.cwd(),
+    summaryEnabled: inputs.publishSummary,
+    summaryPath: process.env.GITHUB_STEP_SUMMARY,
+    annotations: inputs.publishAnnotations,
+    checkRun: inputs.publishCheck,
+    checkName: inputs.checkName,
+    failOnCheckError: false,
+    maxAnnotations: inputs.maxAnnotations,
+    maxFailures: inputs.maxFailures,
+    token: inputs.githubToken,
+    warn: (message) => console.log(`::warning::${escapeCommandData(message)}`),
+  });
+
+  setOutput("status", result.report.status);
+  setOutput("results-count", result.resultFiles.length);
+  setOutput("evals-total", result.report.totals.evalTotal);
+  setOutput("evals-failed", result.report.totals.evalFailed);
+  setOutput("score-average", formatScore(result.report.score?.average));
+  if (result.checkRun?.status !== "skipped" && result.checkRun?.htmlUrl) {
+    setOutput("check-url", result.checkRun.htmlUrl);
+  }
+
+  if (inputs.failOnFailures && result.report.status === "failed") {
+    console.error("::error::vitest-evals report failed");
+    process.exit(1);
+  }
+}
+
+function setOutput(name: string, value: string | number) {
+  const outputFile = process.env.GITHUB_OUTPUT;
+  if (!outputFile) {
+    return;
+  }
+
+  const stringValue = String(value);
+  if (!stringValue.includes("\n")) {
+    appendFileSync(outputFile, `${name}=${stringValue}\n`);
+    return;
+  }
+
+  const delimiter = `vitest_evals_${randomUUID()}`;
+  appendFileSync(
+    outputFile,
+    `${name}<<${delimiter}\n${stringValue}\n${delimiter}\n`,
+  );
+}

--- a/packages/github-reporter/src/annotations.ts
+++ b/packages/github-reporter/src/annotations.ts
@@ -62,8 +62,10 @@ export function buildCheckAnnotations(
   report: EvalReport,
   options: AnnotationOptions = {},
 ): CheckAnnotation[] {
-  const maxAnnotations =
-    options.maxAnnotations ?? DEFAULT_MAX_CHECK_ANNOTATIONS;
+  const maxAnnotations = Math.min(
+    options.maxAnnotations ?? DEFAULT_MAX_CHECK_ANNOTATIONS,
+    DEFAULT_MAX_CHECK_ANNOTATIONS,
+  );
 
   return report.failures
     .filter(hasAnnotationLocation)

--- a/packages/github-reporter/src/cli-options.ts
+++ b/packages/github-reporter/src/cli-options.ts
@@ -1,9 +1,10 @@
 export type CliOptions = {
-  jsonPath: string;
+  resultPatterns: string[];
   summaryPath?: string;
   summaryEnabled: boolean;
   annotations: boolean;
   checkRun: boolean;
+  failOnFailures: boolean;
   failOnCheckError: boolean;
   maxAnnotations?: number;
   maxFailures?: number;
@@ -16,8 +17,8 @@ export type CliOptions = {
   help: boolean;
 };
 
-type MutableCliOptions = Omit<CliOptions, "jsonPath"> & {
-  jsonPath?: string;
+type MutableCliOptions = Omit<CliOptions, "resultPatterns"> & {
+  resultPatterns: string[];
 };
 
 /** Parses GitHub reporter CLI arguments, with explicit arguments taking precedence over environment defaults. */
@@ -30,7 +31,9 @@ export function parseCliArgs(
     summaryEnabled: true,
     annotations: env.GITHUB_ACTIONS === "true",
     checkRun: false,
+    failOnFailures: false,
     failOnCheckError: false,
+    resultPatterns: [],
     help: false,
   };
 
@@ -38,7 +41,7 @@ export function parseCliArgs(
     const arg = args[index];
     switch (arg) {
       case "--json":
-        options.jsonPath = readValue(args, ++index, arg);
+        options.resultPatterns.push(readValue(args, ++index, arg));
         break;
       case "--summary":
         options.summaryPath = readValue(args, ++index, arg);
@@ -55,6 +58,9 @@ export function parseCliArgs(
         break;
       case "--check-run":
         options.checkRun = true;
+        break;
+      case "--fail-on-failures":
+        options.failOnFailures = true;
         break;
       case "--fail-on-check-error":
         options.failOnCheckError = true;
@@ -89,8 +95,8 @@ export function parseCliArgs(
         options.help = true;
         return withDefaultJsonPath(options, env);
       default:
-        if (!arg.startsWith("-") && !options.jsonPath) {
-          options.jsonPath = arg;
+        if (!arg.startsWith("-")) {
+          options.resultPatterns.push(arg);
           break;
         }
         throw new Error(`Unknown argument: ${arg}`);
@@ -106,8 +112,10 @@ function withDefaultJsonPath(
 ): CliOptions {
   return {
     ...options,
-    jsonPath:
-      options.jsonPath || env.VITEST_EVALS_JSON_REPORT || "vitest-results.json",
+    resultPatterns:
+      options.resultPatterns.length > 0
+        ? options.resultPatterns
+        : [env.VITEST_EVALS_JSON_REPORT || "vitest-results.json"],
   };
 }
 
@@ -120,9 +128,9 @@ function readValue(args: string[], index: number, flag: string) {
 }
 
 function readInteger(args: string[], index: number, flag: string) {
-  const value = Number.parseInt(readValue(args, index, flag), 10);
-  if (!Number.isFinite(value) || value < 0) {
+  const rawValue = readValue(args, index, flag);
+  if (!/^\d+$/.test(rawValue)) {
     throw new Error(`Invalid integer for ${flag}`);
   }
-  return value;
+  return Number(rawValue);
 }

--- a/packages/github-reporter/src/cli.ts
+++ b/packages/github-reporter/src/cli.ts
@@ -1,11 +1,6 @@
 #!/usr/bin/env node
-import { appendFile, readFile } from "node:fs/promises";
 import { parseCliArgs } from "./cli-options";
-import { collectEvalReport } from "./collect";
-import { publishCheckRun } from "./github";
-import { renderWorkflowCommands } from "./annotations";
-import { renderJobSummary } from "./summary";
-import type { VitestJsonReport } from "./types";
+import { publishEvalReport } from "./report";
 import { escapeCommandData } from "./utils";
 
 main().catch((error) => {
@@ -20,55 +15,28 @@ async function main() {
     return;
   }
 
-  const json = JSON.parse(
-    await readFile(options.jsonPath, "utf8"),
-  ) as VitestJsonReport;
-  const report = collectEvalReport(json, {
+  const result = await publishEvalReport({
+    resultPatterns: options.resultPatterns,
+    cwd: options.workspace ?? process.env.GITHUB_WORKSPACE ?? process.cwd(),
     workspace:
       options.workspace ?? process.env.GITHUB_WORKSPACE ?? process.cwd(),
-  });
-  const summary = renderJobSummary(report, {
+    summaryEnabled: options.summaryEnabled,
+    summaryPath: options.summaryPath,
+    annotations: options.annotations,
+    checkRun: options.checkRun,
+    checkRunId: options.checkRunId,
+    checkName: options.checkName,
+    failOnCheckError: options.failOnCheckError,
+    maxAnnotations: options.maxAnnotations,
     maxFailures: options.maxFailures,
+    repository: options.repository,
+    sha: options.sha,
+    token: options.token,
+    warn,
   });
 
-  if (options.summaryEnabled) {
-    if (options.summaryPath) {
-      await appendFile(options.summaryPath, `${summary}\n`);
-    } else {
-      console.log(summary);
-    }
-  }
-
-  if (options.annotations) {
-    for (const command of renderWorkflowCommands(report, {
-      maxAnnotations: options.maxAnnotations,
-    })) {
-      console.log(command);
-    }
-  }
-
-  if (options.checkRun) {
-    try {
-      const result = await publishCheckRun(report, {
-        checkRunId: options.checkRunId,
-        maxAnnotations: options.maxAnnotations,
-        maxFailures: options.maxFailures,
-        name: options.checkName,
-        repository: options.repository,
-        sha: options.sha,
-        token: options.token,
-      });
-
-      if (result.status === "skipped") {
-        warn(`GitHub Check Run skipped: ${result.reason}`);
-      }
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      if (options.failOnCheckError) {
-        throw error;
-      }
-      warn(message);
-    }
+  if (options.failOnFailures && result.report.status === "failed") {
+    process.exitCode = 1;
   }
 }
 
@@ -82,15 +50,16 @@ function warn(message: string) {
 
 function usage() {
   return [
-    "Usage: vitest-evals-github-report [vitest-results.json] [--json <path>]",
+    "Usage: vitest-evals-github-report [vitest-results.json ...] [--json <path>]",
     "",
     "Options:",
-    "  --json <path>             Read Vitest JSON report from this path",
+    "  --json <path>             Read a Vitest JSON report from this path or glob",
     "  --summary <path>          Write job summary markdown to this path",
     "  --no-summary             Disable summary output",
     "  --annotations            Emit GitHub workflow-command annotations",
     "  --no-annotations         Disable workflow-command annotations",
     "  --check-run              Publish a GitHub Check Run when configured",
+    "  --fail-on-failures       Exit non-zero when the combined report failed",
     "  --fail-on-check-error    Fail when Check Run publishing fails",
     "  --check-run-id <id>      Update an existing Check Run",
     "  --check-name <name>      Check Run name (default: vitest-evals)",

--- a/packages/github-reporter/src/collect.ts
+++ b/packages/github-reporter/src/collect.ts
@@ -208,7 +208,6 @@ function getUsage(value: Record<string, unknown>): UsageSummary {
     outputTokens: numberField(value.outputTokens),
     reasoningTokens: numberField(value.reasoningTokens),
     totalTokens: numberField(value.totalTokens),
-    estimatedCost: numberField(value.estimatedCost),
     toolCalls: numberField(value.toolCalls),
   };
 }
@@ -304,7 +303,6 @@ function sumUsage(cases: EvalCase[]) {
     outputTokens: 0,
     reasoningTokens: 0,
     totalTokens: 0,
-    estimatedCost: 0,
     toolCalls: 0,
   };
 
@@ -318,7 +316,6 @@ function sumUsage(cases: EvalCase[]) {
       (caseUsage?.inputTokens ?? 0) +
         (caseUsage?.outputTokens ?? 0) +
         (caseUsage?.reasoningTokens ?? 0);
-    usage.estimatedCost += caseUsage?.estimatedCost ?? 0;
     usage.toolCalls +=
       caseUsage?.toolCalls ?? testCase.harness?.toolCalls.length ?? 0;
   }

--- a/packages/github-reporter/src/merge.ts
+++ b/packages/github-reporter/src/merge.ts
@@ -1,0 +1,104 @@
+import type { EvalReport, UsageSummary } from "./types";
+
+/** Merges multiple collected eval reports into one combined report. */
+export function mergeEvalReports(reports: EvalReport[]): EvalReport {
+  const cases = reports.flatMap((report) => report.cases);
+  const failures = reports.flatMap((report) => report.failures);
+  const scoredCases = cases
+    .map((testCase) => testCase.eval?.avgScore)
+    .filter(
+      (score): score is number =>
+        typeof score === "number" && Number.isFinite(score),
+    );
+  const startedAtValues = reports
+    .map((report) => report.startedAt)
+    .filter(
+      (startedAt): startedAt is number =>
+        typeof startedAt === "number" && Number.isFinite(startedAt),
+    );
+  const startedAt =
+    startedAtValues.length > 0 ? Math.min(...startedAtValues) : undefined;
+
+  return {
+    status: reports.some((report) => report.status === "failed")
+      ? "failed"
+      : "passed",
+    startedAt,
+    durationMs: mergeDuration(reports),
+    totals: {
+      total: sum(reports, (report) => report.totals.total),
+      passed: sum(reports, (report) => report.totals.passed),
+      failed: sum(reports, (report) => report.totals.failed),
+      skipped: sum(reports, (report) => report.totals.skipped),
+      evalTotal: sum(reports, (report) => report.totals.evalTotal),
+      evalPassed: sum(reports, (report) => report.totals.evalPassed),
+      evalFailed: sum(reports, (report) => report.totals.evalFailed),
+    },
+    score:
+      scoredCases.length > 0
+        ? {
+            average:
+              scoredCases.reduce((total, score) => total + score, 0) /
+              scoredCases.length,
+            minimum: Math.min(...scoredCases),
+          }
+        : undefined,
+    usage: mergeUsage(reports.map((report) => report.usage)),
+    cases,
+    failures,
+  };
+}
+
+function mergeUsage(usages: Array<Required<UsageSummary>>) {
+  return {
+    inputTokens: sum(usages, (usage) => usage.inputTokens),
+    outputTokens: sum(usages, (usage) => usage.outputTokens),
+    reasoningTokens: sum(usages, (usage) => usage.reasoningTokens),
+    totalTokens: sum(usages, (usage) => usage.totalTokens),
+    toolCalls: sum(usages, (usage) => usage.toolCalls),
+  };
+}
+
+function mergeDuration(reports: EvalReport[]) {
+  const intervals = reports
+    .map((report) => {
+      if (
+        typeof report.startedAt !== "number" ||
+        !Number.isFinite(report.startedAt) ||
+        typeof report.durationMs !== "number" ||
+        !Number.isFinite(report.durationMs)
+      ) {
+        return undefined;
+      }
+
+      return {
+        start: report.startedAt,
+        end: report.startedAt + report.durationMs,
+      };
+    })
+    .filter((interval): interval is { start: number; end: number } =>
+      Boolean(interval),
+    );
+
+  if (intervals.length > 0) {
+    return (
+      Math.max(...intervals.map((interval) => interval.end)) -
+      Math.min(...intervals.map((interval) => interval.start))
+    );
+  }
+
+  const durations = reports
+    .map((report) => report.durationMs)
+    .filter(
+      (durationMs): durationMs is number =>
+        typeof durationMs === "number" && Number.isFinite(durationMs),
+    );
+
+  return durations.length > 0
+    ? durations.reduce((total, durationMs) => total + durationMs, 0)
+    : undefined;
+}
+
+function sum<T>(items: T[], select: (item: T) => number) {
+  return items.reduce((total, item) => total + select(item), 0);
+}

--- a/packages/github-reporter/src/report.test.ts
+++ b/packages/github-reporter/src/report.test.ts
@@ -487,6 +487,16 @@ describe("parseActionInputs", () => {
     });
   });
 
+  test("keeps commas inside action result paths", () => {
+    expect(
+      parseActionInputs({
+        INPUT_RESULTS: "eval-results/report,v2.json\neval-results/*.json",
+      }),
+    ).toMatchObject({
+      results: ["eval-results/report,v2.json", "eval-results/*.json"],
+    });
+  });
+
   test("does not fall back to env token when the token input is blank", () => {
     expect(
       parseActionInputs({

--- a/packages/github-reporter/src/report.test.ts
+++ b/packages/github-reporter/src/report.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, test, vi } from "vitest";
@@ -338,6 +338,46 @@ describe("publishEvalReport", () => {
         summaryEnabled: false,
       }),
     ).rejects.toThrow(`Failed to read eval result file ${resultFile}`);
+  });
+
+  test("forwards summary detail limits when publishing reports", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "vitest-evals-report-"));
+    const resultFile = join(directory, "vitest-results.json");
+    const summaryFile = join(directory, "summary.md");
+    const json = structuredClone(sampleJson);
+    const assertion = json.testResults[0]?.assertionResults[0];
+    if (!assertion) {
+      throw new Error("sample assertion missing");
+    }
+
+    const evalMeta = (assertion.meta as any).eval;
+    const harnessRun = (assertion.meta as any).harness.run;
+    evalMeta.scores[0].metadata.rationale = "abcdefghijklmnopqrstuvwxyz";
+    evalMeta.output = {
+      value: "abcdefghijklmnopqrstuvwxyz",
+    };
+    harnessRun.session.messages[0].toolCalls.push({
+      name: "notifyCustomer",
+      durationMs: 4,
+    });
+
+    await writeFile(resultFile, `${JSON.stringify(json)}\n`);
+
+    await publishEvalReport({
+      resultPatterns: [resultFile],
+      summaryPath: summaryFile,
+      maxReasonChars: 20,
+      maxOutputChars: 30,
+      maxToolCalls: 1,
+    });
+
+    const summary = await readFile(summaryFile, "utf8");
+
+    expect(summary).toContain("abcde... [truncated]");
+    expect(summary).not.toContain('"value": "abcdefghijklmnopqrstuvwxyz"');
+    expect(summary).toContain("lookupInvoice  ok");
+    expect(summary).not.toContain("createRefund");
+    expect(summary).toContain("2 more tool calls omitted");
   });
 });
 

--- a/packages/github-reporter/src/report.test.ts
+++ b/packages/github-reporter/src/report.test.ts
@@ -1,8 +1,15 @@
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { afterEach, describe, expect, test, vi } from "vitest";
-import { renderWorkflowCommands } from "./annotations";
+import { parseActionInputs } from "./action/inputs";
+import { buildCheckAnnotations, renderWorkflowCommands } from "./annotations";
 import { parseCliArgs } from "./cli-options";
 import { collectEvalReport } from "./collect";
 import { publishCheckRun } from "./github";
+import { mergeEvalReports } from "./merge";
+import { publishEvalReport } from "./report";
+import { resolveResultFiles } from "./results";
 import { renderJobSummary } from "./summary";
 import type { VitestJsonReport } from "./types";
 import { formatDuration, normalizePathForGitHub } from "./utils";
@@ -148,6 +155,23 @@ describe("collectEvalReport", () => {
     });
   });
 
+  test("does not normalize provider-specific cost as usage", () => {
+    const json = structuredClone(sampleJson);
+    const usage = (json.testResults[0]?.assertionResults[0]?.meta as any)
+      .harness.run.usage;
+    usage.estimatedCost = 20;
+    usage.metadata = {
+      costUSD: 20,
+    };
+
+    const report = collectEvalReport(json, {
+      workspace: "/repo",
+    });
+
+    expect("estimatedCost" in report.usage).toBe(false);
+    expect(renderJobSummary(report)).not.toContain("$20");
+  });
+
   test("ignores non-finite eval scores", () => {
     const json = structuredClone(sampleJson);
     const evalMeta = (json.testResults[0]?.assertionResults[0]?.meta as any)
@@ -167,6 +191,156 @@ describe("collectEvalReport", () => {
   });
 });
 
+describe("mergeEvalReports", () => {
+  test("combines sharded reports into one report", () => {
+    const secondJson = structuredClone(sampleJson);
+    secondJson.success = true;
+    secondJson.numFailedTests = 0;
+    secondJson.numPassedTests = 1;
+    secondJson.numTotalTests = 1;
+    secondJson.startTime = 6000;
+    secondJson.testResults[0]!.name = "/repo/apps/demo/evals/other.eval.ts";
+    secondJson.testResults[0]!.status = "passed";
+    secondJson.testResults[0]!.startTime = 6000;
+    secondJson.testResults[0]!.endTime = 8000;
+    secondJson.testResults[0]!.assertionResults = [
+      {
+        ...secondJson.testResults[0]!.assertionResults[0]!,
+        fullName: "refund agent approves refund",
+        title: "approves refund",
+        status: "passed",
+        failureMessages: [],
+        meta: {
+          eval: {
+            avgScore: 0.8,
+            thresholdFailed: false,
+            output: { status: "approved" },
+            scores: [{ name: "StructuredOutputJudge", score: 0.8 }],
+          },
+          harness: {
+            name: "pi-ai",
+            run: {
+              output: { status: "approved" },
+              usage: {
+                totalTokens: 300,
+                toolCalls: 1,
+              },
+              timings: {
+                totalMs: 2000,
+              },
+              session: {
+                messages: [{ role: "assistant", toolCalls: [] }],
+              },
+              errors: [],
+            },
+          },
+        },
+      },
+    ];
+
+    const report = mergeEvalReports([
+      collectEvalReport(sampleJson, { workspace: "/repo" }),
+      collectEvalReport(secondJson, { workspace: "/repo" }),
+    ]);
+
+    expect(report.status).toBe("failed");
+    expect(report.totals).toMatchObject({
+      total: 3,
+      passed: 2,
+      failed: 1,
+      evalTotal: 2,
+      evalPassed: 1,
+      evalFailed: 1,
+    });
+    expect(report.score).toEqual({
+      average: 0.5,
+      minimum: 0.2,
+    });
+    expect(report.usage.totalTokens).toBe(1520);
+    expect(report.usage.toolCalls).toBe(3);
+    expect(report.cases).toHaveLength(2);
+    expect(report.failures).toHaveLength(1);
+    expect(report.durationMs).toBe(7000);
+  });
+});
+
+describe("resolveResultFiles", () => {
+  test("resolves result globs relative to the workspace", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "vitest-evals-report-"));
+    const resultsDirectory = join(directory, "eval-results");
+    await mkdir(resultsDirectory);
+    await writeFile(join(resultsDirectory, "one.json"), "{}");
+    await writeFile(join(resultsDirectory, "two.json"), "{}");
+    await writeFile(join(resultsDirectory, "notes.txt"), "");
+
+    await expect(
+      resolveResultFiles(["eval-results/*.json"], {
+        cwd: directory,
+      }),
+    ).resolves.toEqual([
+      join(resultsDirectory, "one.json"),
+      join(resultsDirectory, "two.json"),
+    ]);
+  });
+
+  test("resolves result globs with an explicit current-directory prefix", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "vitest-evals-report-"));
+    const resultsDirectory = join(directory, "eval-results");
+    await mkdir(resultsDirectory);
+    await writeFile(join(resultsDirectory, "one.json"), "{}");
+
+    await expect(
+      resolveResultFiles(["./eval-results/*.json"], {
+        cwd: directory,
+      }),
+    ).resolves.toEqual([join(resultsDirectory, "one.json")]);
+  });
+
+  test("resolves parent-directory relative result globs", async () => {
+    const parentDirectory = await mkdtemp(
+      join(tmpdir(), "vitest-evals-report-"),
+    );
+    const workspaceDirectory = join(parentDirectory, "workspace");
+    const resultsDirectory = join(parentDirectory, "eval-results");
+    await mkdir(workspaceDirectory);
+    await mkdir(resultsDirectory);
+    await writeFile(join(resultsDirectory, "one.json"), "{}");
+
+    await expect(
+      resolveResultFiles(["../eval-results/*.json"], {
+        cwd: workspaceDirectory,
+      }),
+    ).resolves.toEqual([join(resultsDirectory, "one.json")]);
+  });
+
+  test("treats bracket characters as literal path characters", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "vitest-evals-report-"));
+    const resultFile = join(directory, "eval-results[1].json");
+    await writeFile(resultFile, "{}");
+
+    await expect(
+      resolveResultFiles(["eval-results[1].json"], {
+        cwd: directory,
+      }),
+    ).resolves.toEqual([resultFile]);
+  });
+});
+
+describe("publishEvalReport", () => {
+  test("includes the result filename when JSON parsing fails", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "vitest-evals-report-"));
+    const resultFile = join(directory, "broken.json");
+    await writeFile(resultFile, "{");
+
+    await expect(
+      publishEvalReport({
+        resultPatterns: [resultFile],
+        summaryEnabled: false,
+      }),
+    ).rejects.toThrow(`Failed to read eval result file ${resultFile}`);
+  });
+});
+
 describe("normalizePathForGitHub", () => {
   test("only strips the exact workspace path prefix", () => {
     expect(
@@ -181,13 +355,29 @@ describe("normalizePathForGitHub", () => {
 describe("parseCliArgs", () => {
   test("accepts a positional JSON report path", () => {
     expect(parseCliArgs(["custom-results.json"], {})).toMatchObject({
-      jsonPath: "custom-results.json",
+      resultPatterns: ["custom-results.json"],
+    });
+  });
+
+  test("accepts multiple positional JSON report paths", () => {
+    expect(
+      parseCliArgs(["one-results.json", "two-results.json"], {}),
+    ).toMatchObject({
+      resultPatterns: ["one-results.json", "two-results.json"],
+    });
+  });
+
+  test("accepts repeated JSON report flags", () => {
+    expect(
+      parseCliArgs(["--json", "one-results.json", "--json", "two-*.json"], {}),
+    ).toMatchObject({
+      resultPatterns: ["one-results.json", "two-*.json"],
     });
   });
 
   test("uses the default JSON report path when no path is provided", () => {
     expect(parseCliArgs([], {})).toMatchObject({
-      jsonPath: "vitest-results.json",
+      resultPatterns: ["vitest-results.json"],
     });
   });
 
@@ -197,15 +387,88 @@ describe("parseCliArgs", () => {
         VITEST_EVALS_JSON_REPORT: "env-results.json",
       }),
     ).toMatchObject({
-      jsonPath: "custom-results.json",
+      resultPatterns: ["custom-results.json"],
     });
   });
 
   test("stops parsing after help", () => {
     expect(parseCliArgs(["--help", "--invalid"], {})).toMatchObject({
       help: true,
-      jsonPath: "vitest-results.json",
+      resultPatterns: ["vitest-results.json"],
     });
+  });
+
+  test("rejects non-integer numeric options", () => {
+    expect(() => parseCliArgs(["--max-failures", "5abc"], {})).toThrow(
+      "Invalid integer for --max-failures",
+    );
+    expect(() => parseCliArgs(["--max-failures", "1e2"], {})).toThrow(
+      "Invalid integer for --max-failures",
+    );
+  });
+});
+
+describe("parseActionInputs", () => {
+  test("parses semantic action inputs", () => {
+    expect(
+      parseActionInputs({
+        INPUT_RESULTS: "eval-results/*.json\nother-results.json",
+        "INPUT_PUBLISH-CHECK": "true",
+        "INPUT_GITHUB-TOKEN": "token",
+        "INPUT_FAIL-ON-FAILURES": "true",
+        "INPUT_CHECK-NAME": "sharded evals",
+        "INPUT_MAX-FAILURES": "5",
+      }),
+    ).toMatchObject({
+      results: ["eval-results/*.json", "other-results.json"],
+      publishSummary: true,
+      publishAnnotations: true,
+      publishCheck: true,
+      githubToken: "token",
+      failOnFailures: true,
+      checkName: "sharded evals",
+      maxFailures: 5,
+    });
+  });
+
+  test("trims action inputs and accepts case-insensitive booleans", () => {
+    expect(
+      parseActionInputs({
+        INPUT_RESULTS: " ./eval-results/*.json ",
+        "INPUT_PUBLISH-CHECK": " TRUE ",
+        "INPUT_PUBLISH-SUMMARY": " False ",
+        "INPUT_MAX-FAILURES": " 5 ",
+      }),
+    ).toMatchObject({
+      results: ["./eval-results/*.json"],
+      publishSummary: false,
+      publishCheck: true,
+      maxFailures: 5,
+    });
+  });
+
+  test("does not fall back to env token when the token input is blank", () => {
+    expect(
+      parseActionInputs({
+        "INPUT_GITHUB-TOKEN": "",
+        GITHUB_TOKEN: "env-token",
+      }),
+    ).toMatchObject({
+      githubToken: "",
+    });
+  });
+
+  test("rejects non-integer numeric inputs", () => {
+    expect(() =>
+      parseActionInputs({
+        INPUT_MAX_FAILURES: "5abc",
+      }),
+    ).toThrow("Invalid integer input: 5abc");
+    expect(() =>
+      parseActionInputs({
+        INPUT_MAX_FAILURES: "1e2",
+      }),
+    ).toThrow("Invalid integer input: 1e2");
   });
 });
 
@@ -237,6 +500,7 @@ describe("renderJobSummary", () => {
     expect(summary).toContain("| Tests | 1 passed, 1 failed, 2 total |");
     expect(summary).toContain("| Evals | 0 passed, 1 failed, 1 total |");
     expect(summary).toContain("| Score | avg 0.20, min 0.20 |");
+    expect(summary).not.toContain("| Usage |");
     expect(summary).toContain("Score distribution");
     expect(summary.indexOf("Score distribution")).toBeLessThan(
       summary.indexOf("## Results"),
@@ -353,6 +617,23 @@ describe("renderWorkflowCommands", () => {
     });
 
     expect(renderWorkflowCommands(report)[0]).toContain("score n/a");
+  });
+});
+
+describe("buildCheckAnnotations", () => {
+  test("caps Check Run annotations at GitHub's per-request limit", () => {
+    const report = collectEvalReport(sampleJson, {
+      workspace: "/repo",
+    });
+    const failure = report.failures[0]!;
+    report.failures = Array.from({ length: 60 }, (_, index) => ({
+      ...failure,
+      id: `${failure.id}:${index}`,
+    }));
+
+    expect(buildCheckAnnotations(report, { maxAnnotations: 100 })).toHaveLength(
+      50,
+    );
   });
 });
 

--- a/packages/github-reporter/src/report.test.ts
+++ b/packages/github-reporter/src/report.test.ts
@@ -537,12 +537,12 @@ describe("renderJobSummary", () => {
     );
     expect(summary).toContain("| Metric | Value |");
     expect(summary).toContain("| Status | failed |");
-    expect(summary).toContain("| Tests | 1 passed, 1 failed, 2 total |");
     expect(summary).toContain("| Evals | 0 passed, 1 failed, 1 total |");
+    expect(summary).not.toContain("| Tests |");
     expect(summary).toContain("| Score | avg 0.20, min 0.20 |");
     expect(summary).not.toContain("| Usage |");
-    expect(summary).toContain("Score distribution");
-    expect(summary.indexOf("Score distribution")).toBeLessThan(
+    expect(summary).toContain("## Scores");
+    expect(summary.indexOf("## Scores")).toBeLessThan(
       summary.indexOf("## Results"),
     );
     expect(summary).toContain("20-39%  | #################### 1");
@@ -613,6 +613,7 @@ describe("renderJobSummary", () => {
 
     expect(summary).toContain("| Status | failed |");
     expect(summary).toContain("| Evals | 0 passed, 0 failed, 0 total |");
+    expect(summary).not.toContain("| Tests |");
     expect(summary).toContain("| Other Failures | 1 non-eval test failure |");
     expect(summary).toContain("## Results");
     expect(summary).toContain("No eval metadata was found");

--- a/packages/github-reporter/src/report.ts
+++ b/packages/github-reporter/src/report.ts
@@ -57,6 +57,9 @@ export async function publishEvalReport(
   const report = mergeEvalReports(reports);
   const summary = renderJobSummary(report, {
     maxFailures: options.maxFailures,
+    maxOutputChars: options.maxOutputChars,
+    maxReasonChars: options.maxReasonChars,
+    maxToolCalls: options.maxToolCalls,
   });
 
   if (options.summaryEnabled !== false) {
@@ -82,6 +85,9 @@ export async function publishEvalReport(
         checkRunId: options.checkRunId,
         maxAnnotations: options.maxAnnotations,
         maxFailures: options.maxFailures,
+        maxOutputChars: options.maxOutputChars,
+        maxReasonChars: options.maxReasonChars,
+        maxToolCalls: options.maxToolCalls,
         name: options.checkName,
         repository: options.repository,
         sha: options.sha,

--- a/packages/github-reporter/src/report.ts
+++ b/packages/github-reporter/src/report.ts
@@ -1,0 +1,119 @@
+import { appendFile, readFile } from "node:fs/promises";
+import { renderWorkflowCommands } from "./annotations";
+import { collectEvalReport } from "./collect";
+import { publishCheckRun, type PublishCheckRunResult } from "./github";
+import { mergeEvalReports } from "./merge";
+import { resolveResultFiles } from "./results";
+import { renderJobSummary, type SummaryOptions } from "./summary";
+import type { EvalReport, VitestJsonReport } from "./types";
+
+/** Options for reading eval JSON files and publishing GitHub report surfaces. */
+export type PublishEvalReportOptions = SummaryOptions & {
+  resultPatterns: string[];
+  cwd?: string;
+  workspace?: string;
+  summaryEnabled?: boolean;
+  summaryPath?: string;
+  annotations?: boolean;
+  checkRun?: boolean;
+  failOnCheckError?: boolean;
+  maxAnnotations?: number;
+  checkRunId?: number;
+  checkName?: string;
+  token?: string;
+  repository?: string;
+  sha?: string;
+  warn?: (message: string) => void;
+};
+
+/** Result from publishing eval reports, including merged report data. */
+export type PublishEvalReportResult = {
+  report: EvalReport;
+  resultFiles: string[];
+  checkRun?: PublishCheckRunResult;
+};
+
+/** Reads, merges, and publishes eval reports to GitHub Actions surfaces. */
+export async function publishEvalReport(
+  options: PublishEvalReportOptions,
+): Promise<PublishEvalReportResult> {
+  const resultFiles = await resolveResultFiles(options.resultPatterns, {
+    cwd: options.cwd,
+  });
+  if (resultFiles.length === 0) {
+    throw new Error(
+      `No eval result files matched: ${options.resultPatterns.join(", ")}`,
+    );
+  }
+
+  const reports = await Promise.all(
+    resultFiles.map(async (resultFile) => {
+      const json = await readVitestJsonReport(resultFile);
+      return collectEvalReport(json, {
+        workspace: options.workspace,
+      });
+    }),
+  );
+  const report = mergeEvalReports(reports);
+  const summary = renderJobSummary(report, {
+    maxFailures: options.maxFailures,
+  });
+
+  if (options.summaryEnabled !== false) {
+    if (options.summaryPath) {
+      await appendFile(options.summaryPath, `${summary}\n`);
+    } else {
+      console.log(summary);
+    }
+  }
+
+  if (options.annotations) {
+    for (const command of renderWorkflowCommands(report, {
+      maxAnnotations: options.maxAnnotations,
+    })) {
+      console.log(command);
+    }
+  }
+
+  let checkRun: PublishCheckRunResult | undefined;
+  if (options.checkRun) {
+    try {
+      checkRun = await publishCheckRun(report, {
+        checkRunId: options.checkRunId,
+        maxAnnotations: options.maxAnnotations,
+        maxFailures: options.maxFailures,
+        name: options.checkName,
+        repository: options.repository,
+        sha: options.sha,
+        token: options.token,
+      });
+
+      if (checkRun.status === "skipped") {
+        options.warn?.(`GitHub Check Run skipped: ${checkRun.reason}`);
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      if (options.failOnCheckError) {
+        throw error;
+      }
+      options.warn?.(message);
+    }
+  }
+
+  return {
+    report,
+    resultFiles,
+    checkRun,
+  };
+}
+
+async function readVitestJsonReport(resultFile: string) {
+  try {
+    return JSON.parse(await readFile(resultFile, "utf8")) as VitestJsonReport;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(
+      `Failed to read eval result file ${resultFile}: ${message}`,
+    );
+  }
+}

--- a/packages/github-reporter/src/results.ts
+++ b/packages/github-reporter/src/results.ts
@@ -1,0 +1,152 @@
+import { readdir } from "node:fs/promises";
+import { isAbsolute, relative, resolve, sep } from "node:path";
+
+/** Options for resolving eval result file paths. */
+export type ResolveResultFilesOptions = {
+  cwd?: string;
+};
+
+const GLOB_META_PATTERN = /[*?]/;
+
+/** Resolves result file paths and simple glob patterns into concrete files. */
+export async function resolveResultFiles(
+  patterns: string[],
+  options: ResolveResultFilesOptions = {},
+) {
+  const cwd = options.cwd ?? process.cwd();
+  const files: string[] = [];
+
+  for (const pattern of patterns.map((entry) => entry.trim()).filter(Boolean)) {
+    if (hasGlob(pattern)) {
+      files.push(...(await expandGlob(pattern, cwd)));
+    } else {
+      files.push(isAbsolute(pattern) ? pattern : resolve(cwd, pattern));
+    }
+  }
+
+  return [...new Set(files)].sort();
+}
+
+/** Splits a GitHub Action results input into path and glob entries. */
+export function splitResultsInput(value: string | undefined) {
+  return (value ?? "")
+    .split(/\r?\n|,/)
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+}
+
+function hasGlob(pattern: string) {
+  return GLOB_META_PATTERN.test(pattern);
+}
+
+async function expandGlob(pattern: string, cwd: string) {
+  const normalizedPattern = normalizeGlobPattern(pattern);
+  const absolutePattern = isAbsolute(pattern);
+  const base = globBase(normalizedPattern);
+  const basePath = absolutePattern ? base || sep : resolve(cwd, base || ".");
+  const regex = globToRegExp(normalizedPattern);
+  const matches: string[] = [];
+
+  for (const file of await listFiles(basePath)) {
+    const normalizedFile = normalizePath(file);
+    const candidate = absolutePattern
+      ? normalizedFile
+      : normalizePath(relative(resolve(cwd), file));
+    if (regex.test(candidate)) {
+      matches.push(file);
+    }
+  }
+
+  return matches;
+}
+
+function globBase(pattern: string) {
+  const segments = pattern.split("/");
+  const baseSegments: string[] = [];
+
+  for (const segment of segments) {
+    if (hasGlob(segment)) {
+      break;
+    }
+    baseSegments.push(segment);
+  }
+
+  return baseSegments.join("/");
+}
+
+async function listFiles(directory: string): Promise<string[]> {
+  const entries = await readDirectory(directory);
+  if (!entries) {
+    return [];
+  }
+
+  const files: string[] = [];
+  for (const entry of entries) {
+    const child = resolve(directory, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...(await listFiles(child)));
+    } else if (entry.isFile()) {
+      files.push(child);
+    }
+  }
+  return files;
+}
+
+async function readDirectory(directory: string) {
+  try {
+    return await readdir(directory, { withFileTypes: true });
+  } catch {
+    return undefined;
+  }
+}
+
+function globToRegExp(pattern: string) {
+  let source = "";
+  for (let index = 0; index < pattern.length; index += 1) {
+    const char = pattern[index];
+    const next = pattern[index + 1];
+
+    if (char === "*" && next === "*") {
+      const following = pattern[index + 2];
+      if (following === "/") {
+        source += "(?:.*/)?";
+        index += 2;
+      } else {
+        source += ".*";
+        index += 1;
+      }
+      continue;
+    }
+
+    if (char === "*") {
+      source += "[^/]*";
+      continue;
+    }
+
+    if (char === "?") {
+      source += "[^/]";
+      continue;
+    }
+
+    source += escapeRegExp(char ?? "");
+  }
+
+  return new RegExp(`^${source}$`);
+}
+
+function escapeRegExp(value: string) {
+  return value.replace(/[|\\{}()[\]^$+?.]/g, "\\$&");
+}
+
+function normalizePath(path: string) {
+  return path.replace(/\\/g, "/");
+}
+
+function normalizeGlobPattern(pattern: string) {
+  const normalizedPattern = normalizePath(pattern);
+  if (isAbsolute(pattern)) {
+    return normalizedPattern;
+  }
+
+  return normalizedPattern.replace(/^(\.\/)+/, "");
+}

--- a/packages/github-reporter/src/results.ts
+++ b/packages/github-reporter/src/results.ts
@@ -30,7 +30,7 @@ export async function resolveResultFiles(
 /** Splits a GitHub Action results input into path and glob entries. */
 export function splitResultsInput(value: string | undefined) {
   return (value ?? "")
-    .split(/\r?\n|,/)
+    .split(/\r?\n/)
     .map((entry) => entry.trim())
     .filter(Boolean);
 }

--- a/packages/github-reporter/src/summary.ts
+++ b/packages/github-reporter/src/summary.ts
@@ -1,4 +1,4 @@
-import type { EvalCase, EvalReport, UsageSummary } from "./types";
+import type { EvalCase, EvalReport } from "./types";
 import {
   compactLine,
   escapeFence,
@@ -100,11 +100,6 @@ function renderSummaryTable(report: EvalReport, nonEvalFailures: number) {
 
   if (report.score) {
     rows.push(["Score", formatScoreSummary(report.score)]);
-  }
-
-  const usage = formatUsage(report.usage);
-  if (usage) {
-    rows.push(["Usage", usage]);
   }
 
   if (nonEvalFailures > 0) {
@@ -361,22 +356,6 @@ function renderAsciiTable(headers: string[], rows: string[][]) {
     widths.map((width) => "-".repeat(width)).join("  "),
     ...rows.map(renderRow),
   ];
-}
-
-function formatUsage(usage: Required<UsageSummary>) {
-  const parts: string[] = [];
-  if (usage.totalTokens > 0) {
-    parts.push(`${formatNumber(usage.totalTokens)} tokens`);
-  }
-  if (usage.toolCalls > 0) {
-    parts.push(
-      `${formatNumber(usage.toolCalls)} tool${usage.toolCalls === 1 ? "" : "s"}`,
-    );
-  }
-  if (usage.estimatedCost > 0) {
-    parts.push(`$${usage.estimatedCost.toFixed(4)}`);
-  }
-  return parts.join(", ");
 }
 
 function formatCaseUsage(testCase: EvalCase) {

--- a/packages/github-reporter/src/summary.ts
+++ b/packages/github-reporter/src/summary.ts
@@ -81,14 +81,6 @@ function renderSummaryTable(report: EvalReport, nonEvalFailures: number) {
   const rows: Array<[string, string]> = [
     ["Status", report.status],
     [
-      "Tests",
-      formatCountLine(
-        report.totals.passed,
-        report.totals.failed,
-        report.totals.total,
-      ),
-    ],
-    [
       "Evals",
       formatCountLine(
         report.totals.evalPassed,
@@ -158,7 +150,7 @@ function renderScoreDistribution(report: EvalReport) {
 
   const maxCount = Math.max(...counts);
   return [
-    "Score distribution",
+    "## Scores",
     "",
     "```text",
     ...SCORE_DISTRIBUTION_BUCKETS.map((label, index) =>

--- a/packages/github-reporter/src/types.ts
+++ b/packages/github-reporter/src/types.ts
@@ -117,13 +117,12 @@ export type EvalReport = {
   failures: EvalCase[];
 };
 
-/** Aggregated usage values shown in reporter output. */
+/** Aggregated usage values collected from eval metadata. */
 export type UsageSummary = {
   inputTokens?: number;
   outputTokens?: number;
   reasoningTokens?: number;
   totalTokens?: number;
-  estimatedCost?: number;
   toolCalls?: number;
 };
 

--- a/packages/github-reporter/tsup.action.config.ts
+++ b/packages/github-reporter/tsup.action.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: {
+    index: "src/action/main.ts",
+  },
+  format: ["cjs"],
+  platform: "node",
+  target: "node24",
+  dts: false,
+  splitting: false,
+  sourcemap: false,
+  clean: true,
+  outDir: "../../github-reporter/dist/action",
+  external: [],
+});

--- a/packages/harness-pi-ai/src/index.test.ts
+++ b/packages/harness-pi-ai/src/index.test.ts
@@ -1019,6 +1019,50 @@ test("applies output selectors to HarnessRun-shaped results", async () => {
   expect(result.usage.totalTokens).toBe(7);
 });
 
+test("moves provider-specific usage fields into metadata", async () => {
+  const normalizedHarness = piAiHarness({
+    agent: () => ({ id: "refund-agent" }),
+    run: async () => ({
+      output: {
+        status: "approved",
+      },
+      usage: {
+        provider: "pi-ai",
+        model: "refund-model",
+        totalTokens: 7,
+        toolCalls: 0,
+        retries: 1,
+        costUSD: 20,
+        estimatedCost: 20,
+        metadata: {
+          cacheReadTokens: 3,
+        },
+      },
+    }),
+  });
+
+  const result = await normalizedHarness.run("Refund invoice inv_123", {
+    metadata: {},
+    artifacts: {},
+    setArtifact: vi.fn(),
+  });
+
+  expect(result.usage).toMatchObject({
+    provider: "pi-ai",
+    model: "refund-model",
+    totalTokens: 7,
+    toolCalls: 0,
+    retries: 1,
+    metadata: {
+      cacheReadTokens: 3,
+      costUSD: 20,
+      estimatedCost: 20,
+    },
+  });
+  expect("costUSD" in result.usage).toBe(false);
+  expect("estimatedCost" in result.usage).toBe(false);
+});
+
 test("attaches a partial run when the harness errors", async () => {
   const erroringHarness = piAiHarness({
     agent: () => ({ id: "refund-agent" }),

--- a/packages/harness-pi-ai/src/index.ts
+++ b/packages/harness-pi-ai/src/index.ts
@@ -14,6 +14,7 @@ import {
   attachHarnessRunToError,
   isHarnessRun,
   isNormalizedSession,
+  normalizeMetadata,
   normalizeContent,
   resolveHarnessRunErrors,
   serializeError,
@@ -1764,16 +1765,74 @@ function resolveUsage(result: unknown, toolCallCount: number): UsageSummary {
     (result as Record<string, unknown>).usage ??
     (result as Record<string, unknown>).metrics;
 
-  const usage =
-    usageValue && typeof usageValue === "object"
-      ? ({ ...(usageValue as Record<string, unknown>) } as UsageSummary)
-      : {};
+  if (
+    !usageValue ||
+    typeof usageValue !== "object" ||
+    Array.isArray(usageValue)
+  ) {
+    return toolCallCount > 0 ? { toolCalls: toolCallCount } : {};
+  }
+
+  const usageRecord = usageValue as Record<string, unknown>;
+  const usage: UsageSummary = {
+    provider: stringField(usageRecord.provider),
+    model: stringField(usageRecord.model),
+    inputTokens: numberField(usageRecord.inputTokens),
+    outputTokens: numberField(usageRecord.outputTokens),
+    reasoningTokens: numberField(usageRecord.reasoningTokens),
+    totalTokens: numberField(usageRecord.totalTokens),
+    toolCalls: numberField(usageRecord.toolCalls),
+    retries: numberField(usageRecord.retries),
+    metadata: collectUsageMetadata(usageRecord),
+  };
 
   if (usage.toolCalls === undefined && toolCallCount > 0) {
     usage.toolCalls = toolCallCount;
   }
 
   return usage;
+}
+
+function collectUsageMetadata(usage: Record<string, unknown>) {
+  const metadata: Record<string, unknown> = {};
+  const nestedMetadata = usage.metadata;
+  if (
+    nestedMetadata &&
+    typeof nestedMetadata === "object" &&
+    !Array.isArray(nestedMetadata)
+  ) {
+    Object.assign(metadata, nestedMetadata);
+  }
+
+  for (const [key, value] of Object.entries(usage)) {
+    if (key === "metadata" || USAGE_SUMMARY_KEYS.has(key)) {
+      continue;
+    }
+    metadata[key] = value;
+  }
+
+  return normalizeMetadata(metadata);
+}
+
+const USAGE_SUMMARY_KEYS = new Set([
+  "provider",
+  "model",
+  "inputTokens",
+  "outputTokens",
+  "reasoningTokens",
+  "totalTokens",
+  "toolCalls",
+  "retries",
+]);
+
+function stringField(value: unknown) {
+  return typeof value === "string" ? value : undefined;
+}
+
+function numberField(value: unknown) {
+  return typeof value === "number" && Number.isFinite(value)
+    ? value
+    : undefined;
 }
 
 function resolveSession(

--- a/packages/vitest-evals/README.md
+++ b/packages/vitest-evals/README.md
@@ -18,11 +18,9 @@ npm install -D @vitest-evals/harness-ai-sdk
 npm install -D @vitest-evals/harness-openai-agents
 ```
 
-For GitHub Actions summaries and annotations, install the JSON post-processor:
-
-```sh
-npm install -D @vitest-evals/github-reporter
-```
+For GitHub Actions summaries and annotations, emit Vitest JSON and use the
+native `getsentry/vitest-evals` action. No extra npm package is needed in the
+workflow.
 
 ## Core Model
 
@@ -159,13 +157,18 @@ vitest run evals \
   --reporter=vitest-evals/reporter \
   --reporter=json \
   --outputFile.json=vitest-results.json
-
-vitest-evals-github-report
 ```
 
-The GitHub reporter writes a job summary when `GITHUB_STEP_SUMMARY` is present,
-emits short failure annotations in Actions, and can publish a separate Check Run
-with `--check-run` when `checks: write` permission is configured.
+```yaml
+- uses: getsentry/vitest-evals@v0
+  if: always()
+  with:
+    results: vitest-results.json
+```
+
+The GitHub reporter action writes a job summary, emits short failure
+annotations, can publish a separate Check Run, and can reduce sharded eval JSON
+artifacts into one combined report.
 
 ## Existing Agents
 

--- a/packages/vitest-evals/src/harness.ts
+++ b/packages/vitest-evals/src/harness.ts
@@ -40,7 +40,6 @@ export type UsageSummary = {
   outputTokens?: number;
   reasoningTokens?: number;
   totalTokens?: number;
-  estimatedCost?: number;
   toolCalls?: number;
   retries?: number;
   metadata?: Record<string, JsonValue>;

--- a/scripts/check-release-config.mjs
+++ b/scripts/check-release-config.mjs
@@ -18,20 +18,38 @@ function collectCraftPackages() {
   return collectMatches(readFile(".craft.yml"), /^\s*id:\s*"([^"]+)"/gm);
 }
 
-function assertGitHubTargetFiltersArtifacts() {
+function collectCraftTargets() {
   const craftConfig = readFile(".craft.yml");
-  const githubTarget = craftConfig.match(
-    /^\s*-\s*name:\s*github\b[\s\S]*?(?=^\s*-\s*name:|(?![\s\S]))/m,
-  )?.[0];
+  return [
+    ...craftConfig.matchAll(
+      /^\s*-\s*name:\s*([^\s#]+)\b[\s\S]*?(?=^\s*-\s*name:|(?![\s\S]))/gm,
+    ),
+  ].map((match) => ({
+    name: match[1],
+    block: match[0],
+  }));
+}
 
-  if (!githubTarget) {
+function assertGitHubTargetConfig() {
+  const targets = collectCraftTargets();
+  const githubTargets = targets.filter((target) => target.name === "github");
+
+  if (githubTargets.length !== 1) {
     console.error(
-      "Release config check failed: .craft.yml must define a github target for root action tags.",
+      "Release config check failed: .craft.yml must define exactly one github target for root action tags.",
     );
     process.exit(1);
   }
 
-  if (!/^\s*includeNames:\s*\/\^\$\/\s*$/m.test(githubTarget)) {
+  const [githubTarget] = githubTargets;
+  if (targets.at(-1) !== githubTarget) {
+    console.error(
+      "Release config check failed: the github target must be the final target so npm publishes before the public GitHub release and action tags.",
+    );
+    process.exit(1);
+  }
+
+  if (!/^\s*includeNames:\s*\/\^\$\/\s*$/m.test(githubTarget.block)) {
     console.error(
       "Release config check failed: the github target must keep includeNames: /^$/ so package artifacts are not uploaded as GitHub release assets.",
     );
@@ -85,7 +103,7 @@ const sources = [
 
 const [expectedSource, ...otherSources] = sources;
 
-assertGitHubTargetFiltersArtifacts();
+assertGitHubTargetConfig();
 
 if (expectedSource.packages.length === 0) {
   console.error(

--- a/scripts/check-release-config.mjs
+++ b/scripts/check-release-config.mjs
@@ -18,6 +18,27 @@ function collectCraftPackages() {
   return collectMatches(readFile(".craft.yml"), /^\s*id:\s*"([^"]+)"/gm);
 }
 
+function assertGitHubTargetFiltersArtifacts() {
+  const craftConfig = readFile(".craft.yml");
+  const githubTarget = craftConfig.match(
+    /^\s*-\s*name:\s*github\b[\s\S]*?(?=^\s*-\s*name:|(?![\s\S]))/m,
+  )?.[0];
+
+  if (!githubTarget) {
+    console.error(
+      "Release config check failed: .craft.yml must define a github target for root action tags.",
+    );
+    process.exit(1);
+  }
+
+  if (!/^\s*includeNames:\s*\/\^\$\/\s*$/m.test(githubTarget)) {
+    console.error(
+      "Release config check failed: the github target must keep includeNames: /^$/ so package artifacts are not uploaded as GitHub release assets.",
+    );
+    process.exit(1);
+  }
+}
+
 function collectBumpPackages() {
   const packageFiles = collectMatches(
     readFile("scripts/bump-release-versions.mjs"),
@@ -63,6 +84,8 @@ const sources = [
 ];
 
 const [expectedSource, ...otherSources] = sources;
+
+assertGitHubTargetFiltersArtifacts();
 
 if (expectedSource.packages.length === 0) {
   console.error(


### PR DESCRIPTION
Expose `vitest-evals` as a native root GitHub Action so workflows can reduce one or more Vitest JSON reports into a single GitHub summary, workflow annotations, and optional Check Run. The user-facing workflow now uses `getsentry/vitest-evals@v0` directly instead of invoking the child package CLI.

**User-facing Action**

The root `action.yml` provides semantic inputs for result paths, summary and annotation publishing, Check Run creation, failure gating, and output values. Sharded workflows can upload one JSON artifact per runner, download them with `pattern` and `merge-multiple`, and pass `results: eval-results/*.json` to publish one combined report.

```yaml
- uses: getsentry/vitest-evals@v0
  if: always()
  with:
    results: eval-results/*.json
    publish-check: true
    fail-on-failures: true
```

**Reporter Runtime**

Shared publishing now resolves multiple paths or globs, merges collected eval reports, clamps Check Run annotations to the GitHub limit, and keeps action input parsing strict but friendly for workflow YAML. Top-level summary usage and provider-specific cost reporting were removed so the report only shows eval-specific diagnostics.

**Release Tags**

Release automation now mirrors the Warden source-tag plus bundled-action-tag pattern. Source releases keep `vX.Y.Z-src` for Craft baselines, while published action tags and stable major tags point at a bundle commit containing `github-reporter/dist/action/index.js` without including that generated bundle in npm packages.

Known local caveat: full `pnpm test` can still fail when provider keys are present because it runs intentional demo failure evals and long-running demo evals. The reporter and release gates for this branch pass locally.