### PR TITLE
docs(api): Simplify public API reference

### DIFF
--- a/packages/docs/src/pages/api.astro
+++ b/packages/docs/src/pages/api.astro
@@ -436,130 +436,22 @@ function entriesFor(names: string[]) {
     .filter(Boolean) as TypeDocReflection[];
 }
 
-const coreApiItems = [
-  {
-    name: "describeEval",
-    summary:
-      "Define a Vitest suite that owns one harness and exposes the eval-aware it/run fixtures.",
-    example: `describeEval("refund agent", {
-  harness: refundHarness,
-}, (it) => {
-  it("approves a refund", async ({ run }) => {
-    const result = await run("Refund invoice inv_123");
-    expect(result.output.status).toBe("approved");
-  });
-});`,
-  },
-  {
-    name: "createHarness",
-    summary:
-      "Adapt application code that returns JSON-safe output, tool calls, usage, or artifacts.",
-    example: `export const refundHarness = createHarness({
-  name: "refund-agent",
-  run: async ({ input }) => ({
-    output: await runRefundFlow(input),
-  }),
-});`,
-  },
-  {
-    name: "createJudge",
-    summary:
-      "Create a named judge for domain-specific scoring, rubric checks, or model-backed assessment.",
-    example: `export const RefundStatusJudge = createJudge(
-  "RefundStatusJudge",
-  async ({ output, metadata }) => ({
-    score: output.status === metadata.expected.status ? 1 : 0,
-  }),
-);`,
-  },
-  {
-    name: "ToolCallJudge",
-    summary:
-      "Check that the normalized session contains the expected tool calls, optionally in order.",
-    example: `const result = await run("Refund invoice inv_123", {
-  metadata: {
-    expectedTools: ["lookupInvoice", "createRefund"],
-  },
-});
-
-await expect(result).toSatisfyJudge(ToolCallJudge({ ordered: true }));`,
-  },
-  {
-    name: "StructuredOutputJudge",
-    summary:
-      "Compare structured fields from result.output against expected values in metadata or matcher options.",
-    example: `const result = await run("Refund invoice inv_123", {
-  metadata: {
-    expected: { status: "approved" },
-  },
-});
-
-await expect(result).toSatisfyJudge(StructuredOutputJudge());`,
-  },
-  {
-    name: "toolCalls",
-    summary:
-      "Flatten normalized tool-call messages from a run session for ordinary Vitest assertions.",
-    example: `const result = await run("Refund invoice inv_123");
-
-expect(toolCalls(result.session).map((call) => call.name)).toEqual([
-  "lookupInvoice",
-  "createRefund",
-]);`,
-  },
-].map((item) => ({
-  ...item,
-  href: `#${slug(item.name)}`,
+const sidebarLinks = renderedGroups.map((group) => ({
+  href: `#${group.id}`,
+  label: group.label,
 }));
 ---
 
 <Base title="API" description="Generated TypeDoc reference for the public vitest-evals root API.">
-  <DocsPageShell
-    links={[
-      { href: "#core-api", label: "Core API" },
-      ...renderedGroups.map((group) => ({
-        href: `#${group.id}`,
-        label: group.label,
-      })),
-    ]}
-  >
+  <DocsPageShell links={sidebarLinks}>
     <p class="eyebrow">Reference</p>
-    <h1>Public API</h1>
-    <p class="lead">
+    <h1 class="api-title">Public API</h1>
+    <p class="lead api-lead">
       Generated from source JSDoc and TypeDoc metadata for the public
-      <code>vitest-evals</code> root exports. Examples come from docstrings so
-      the reference stays tied to the library surface.
+      <code>vitest-evals</code> root exports. Use the grouped sections below
+      for signatures, examples, parameters, overloads, and member
+      documentation.
     </p>
-
-    <section class="api-core" id="core-api">
-      <h2>Core API</h2>
-      <p>
-        Most projects only need these exports to get started. Use the generated
-        reference below when you need full type details, overloads, and member
-        documentation.
-      </p>
-      <div class="api-core-grid">
-        {
-          coreApiItems.map((item) => (
-            <article class="api-core-item">
-              <div class="api-core-heading">
-                <h3>
-                  <code>{item.name}</code>
-                </h3>
-                <a href={item.href}>Reference</a>
-              </div>
-              <p>{item.summary}</p>
-              <Code
-                code={item.example}
-                lang="ts"
-                theme="vitesse-black"
-                wrap={true}
-              />
-            </article>
-          ))
-        }
-      </div>
-    </section>
 
     {
       renderedGroups.map((group) => (

--- a/packages/docs/src/pages/api.astro
+++ b/packages/docs/src/pages/api.astro
@@ -445,7 +445,7 @@ const sidebarLinks = renderedGroups.map((group) => ({
 <Base title="API" description="Generated TypeDoc reference for the public vitest-evals root API.">
   <DocsPageShell links={sidebarLinks}>
     <p class="eyebrow">Reference</p>
-    <h1 class="api-title">Public API</h1>
+    <h1>Public API</h1>
     <p class="lead api-lead">
       Generated from source JSDoc and TypeDoc metadata for the public
       <code>vitest-evals</code> root exports. Use the grouped sections below

--- a/packages/docs/src/styles/global.css
+++ b/packages/docs/src/styles/global.css
@@ -1043,10 +1043,6 @@ blockquote p:last-child {
     padding-top: 1rem;
   }
 
-  .docs-content h1 {
-    font-size: clamp(2.35rem, 10vw, 3.2rem);
-  }
-
   th,
   td {
     padding: 0.75rem 0.7rem;

--- a/packages/docs/src/styles/global.css
+++ b/packages/docs/src/styles/global.css
@@ -609,10 +609,6 @@ blockquote p:last-child {
   color: var(--text-secondary);
 }
 
-.api-title {
-  font-size: clamp(2rem, 3.6vw, 3rem);
-}
-
 .api-lead {
   max-width: 48rem;
 }

--- a/packages/docs/src/styles/global.css
+++ b/packages/docs/src/styles/global.css
@@ -190,14 +190,14 @@ h1 {
 }
 
 h2 {
-  margin-top: 3rem;
+  margin-top: 2.6rem;
   padding-top: 0.25rem;
-  font-size: 1.48rem;
+  font-size: 1.36rem;
 }
 
 h3 {
-  margin-top: 2rem;
-  font-size: 1.05rem;
+  margin-top: 1.75rem;
+  font-size: 1rem;
   overflow-wrap: anywhere;
 }
 
@@ -221,22 +221,19 @@ strong {
 }
 
 code {
-  border: 1px solid var(--border);
-  border-radius: 5px;
-  background: rgba(225, 236, 226, 0.055);
   color: #dfe8dc;
   font-family: var(--font-mono);
-  font-size: 0.88em;
-  padding: 0.08rem 0.3rem;
+  font-size: 0.9em;
+  font-weight: 500;
   overflow-wrap: anywhere;
 }
 
 pre {
   overflow-x: auto;
   margin: 1rem 0;
-  border: 1px solid var(--border);
+  border: 1px solid rgba(225, 236, 226, 0.1);
   border-radius: var(--radius);
-  background: #060806;
+  background: rgba(6, 8, 6, 0.86);
   padding: 1rem;
   color: var(--text);
   font-family: var(--font-mono);
@@ -249,6 +246,8 @@ pre code {
   background: transparent;
   padding: 0;
   color: inherit;
+  font-size: 1em;
+  font-weight: inherit;
 }
 
 table {
@@ -455,7 +454,8 @@ blockquote p:last-child {
 }
 
 .docs-content h1 {
-  font-size: clamp(2.65rem, 5.2vw, 4.45rem);
+  font-size: clamp(2rem, 3.6vw, 3rem);
+  line-height: 1.08;
 }
 
 .docs-content h1 + .lead {
@@ -609,77 +609,27 @@ blockquote p:last-child {
   color: var(--text-secondary);
 }
 
-.api-core {
-  margin-top: 2.8rem;
+.api-title {
+  font-size: clamp(2rem, 3.6vw, 3rem);
 }
 
-.api-core > h2 {
-  margin-top: 0;
-}
-
-.api-core-grid {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 1rem;
-  margin-top: 1.25rem;
-}
-
-.api-core-item {
-  min-width: 0;
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  background: rgba(21, 26, 22, 0.34);
-  padding: 1rem;
-}
-
-.api-core-heading {
-  display: flex;
-  align-items: baseline;
-  justify-content: space-between;
-  gap: 0.8rem;
-}
-
-.api-core-heading h3 {
-  margin: 0;
-}
-
-.api-core-heading a {
-  flex: 0 0 auto;
-  color: var(--text-tertiary);
-  font-family: var(--font-mono);
-  font-size: 0.74rem;
-  text-transform: uppercase;
-}
-
-.api-core-heading a:hover {
-  color: var(--text);
-}
-
-.api-core-item > p {
-  margin-top: 0.55rem;
-  font-size: 0.92rem;
-}
-
-.api-core-item pre {
-  margin: 0.9rem 0 0;
-  font-size: 0.78rem;
-  line-height: 1.58;
-}
-
-.api-core-item pre,
-.api-core-item code {
-  white-space: pre-wrap !important;
-  overflow-wrap: anywhere;
-  word-break: break-word;
+.api-lead {
+  max-width: 48rem;
 }
 
 .api-group {
   margin-top: 3rem;
+  scroll-margin-top: 6rem;
+}
+
+.api-lead + .api-group {
+  margin-top: 2.6rem;
 }
 
 .api-entry {
   border-top: 1px solid var(--border);
   padding: 1.6rem 0 1.8rem;
+  scroll-margin-top: 6rem;
 }
 
 .api-entry-heading {
@@ -1056,10 +1006,6 @@ blockquote p:last-child {
 
   .docs-sidebar a.subsection {
     font-size: 0.82rem;
-  }
-
-  .api-core-grid {
-    grid-template-columns: 1fr;
   }
 }
 


### PR DESCRIPTION
Make the public API page use the generated TypeDoc reference as the only reading path instead of leading with a separate Core API card grid. This avoids duplicating the same exports and gives the page a more linear reference structure.

**Typography**

Inline code now reads as prose instead of bordered pills, code blocks keep a subtler container, and docs headings use a smaller reference-page scale.
