### PR TITLE
feat(judges): Add judge harness and factuality judge

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,46 +138,21 @@ artifacts so it does not upload npm package contents as release assets.
 The `apps/demo-pi` app shows the intended explicit-run flow:
 
 ```ts
+import { getModel } from "@mariozechner/pi-ai";
 import { expect } from "vitest";
-import { piAiHarness } from "@vitest-evals/harness-pi-ai";
+import { piAiHarness, piAiJudgeHarness } from "@vitest-evals/harness-pi-ai";
 import {
-  createJudge,
   describeEval,
+  FactualityJudge,
   toolCalls,
-  type JudgeContext,
 } from "vitest-evals";
 import { createRefundAgent } from "../src/refundAgent";
 
-type RefundEvalMetadata = {
-  expectedStatus: "approved" | "denied";
-  expectedTools: string[];
-};
-
-type RefundOutput = {
-  status: "approved" | "denied";
-};
-
-const FactualityJudge = createJudge(
-  "FactualityJudge",
-  async ({
-    input,
-    output,
-    metadata,
-  }: JudgeContext<string, RefundOutput, RefundEvalMetadata>) => {
-    const verdict = await judgeFactuality({
-      question: input,
-      answer: output,
-      expectedStatus: metadata.expectedStatus,
-    });
-
-    return {
-      score: verdict.score,
-      metadata: {
-        rationale: verdict.rationale,
-      },
-    };
-  },
-);
+const judgeHarness = piAiJudgeHarness({
+  model: getModel("anthropic", "claude-sonnet-4-5"),
+  temperature: 0,
+});
+const factualityJudge = FactualityJudge({ judgeHarness });
 
 describeEval(
   "demo pi refund agent",
@@ -185,13 +160,15 @@ describeEval(
     harness: piAiHarness({
       agent: () => createRefundAgent(),
     }),
-    judges: [FactualityJudge],
+    judges: [factualityJudge],
+    judgeThreshold: 0.6,
   },
   (it) => {
     it.for([
       {
         name: "approves refundable invoice",
         input: "Refund invoice inv_123",
+        expected: "The refund request is approved.",
         expectedStatus: "approved",
         expectedTools: ["lookupInvoice", "createRefund"],
       },
@@ -221,18 +198,20 @@ Harness-backed suites stay close to plain Vitest:
 - every judge receives `JudgeContext` with typed `input`, typed `output`, the
   normalized run/session, tool calls, and metadata; `output` is only optional
   when the harness output type includes `undefined`
-- judges own their prompt, rubric, model call, and parsing; use
-  `createJudge(...)` for custom judges and its provider-helper overload only
-  when multiple judges share setup
+- judges own their prompt, rubric, and parsing; LLM-backed judges use
+  `ctx.runJudge(...)` from a configured `judgeHarness`
 - scenario-specific judge criteria can live in `input`; use `metadata` for
   per-run expectations or harness configuration that are not part of the
   scenario payload
 - reporter output, replay, usage, and tool traces come from the normalized run
 
-Built-in judges like `StructuredOutputJudge()` are still available for
-deterministic contract checks, but the more realistic explicit-judge path is a
-custom factuality or rubric judge over `output`, with `JudgeContext` available
-when the judge needs richer run/session data.
+Built-in judges include `FactualityJudge()` for model-backed factuality
+grading plus deterministic helpers such as `StructuredOutputJudge()` and
+`ToolCallJudge()`. Configure the judge-side model separately with
+`FactualityJudge({ judgeHarness })`, `describeEval({ judgeHarness })`, or
+matcher options only when a judge calls `ctx.runJudge(...)`. A `judgeHarness` is
+a dedicated judge-model adapter, so the same factuality judge can be reused
+across AI SDK, Pi, OpenAI Agents, or custom app harnesses.
 
 Tool replay is available for opt-in tools in the first-party harnesses.
 Configure the replay mode and directory globally in Vitest, then opt individual

--- a/README.md
+++ b/README.md
@@ -211,7 +211,9 @@ grading plus deterministic helpers such as `StructuredOutputJudge()` and
 `FactualityJudge({ judgeHarness })`, `describeEval({ judgeHarness })`, or
 matcher options only when a judge calls `ctx.runJudge(...)`. A `judgeHarness` is
 a dedicated judge-model adapter, so the same factuality judge can be reused
-across AI SDK, Pi, OpenAI Agents, or custom app harnesses.
+across AI SDK, Pi, OpenAI Agents, or custom app harnesses. Automatic inference
+for explicit matcher calls only applies when suite judges share the same judge
+harness instance.
 
 Tool replay is available for opt-in tools in the first-party harnesses.
 Configure the replay mode and directory globally in Vitest, then opt individual

--- a/apps/demo-ai-sdk/README.md
+++ b/apps/demo-ai-sdk/README.md
@@ -7,8 +7,9 @@ through the workspace packages:
 - `@vitest-evals/harness-ai-sdk`
 
 The passing live eval lives in `evals/refund.eval.ts`.
-It demonstrates app-local refund tools and explicit Vitest assertions on
-`run.output` and the normalized session trace.
+It demonstrates app-local refund tools, the built-in factuality judge over
+normalized harness output, and explicit Vitest assertions on `run.output` and
+the normalized session trace.
 
 The intentionally failing examples live in `evals/refund.fail.eval.ts`.
 One fails an automatic harness-backed judge, and one fails explicit assertions

--- a/apps/demo-ai-sdk/evals/refund.eval.ts
+++ b/apps/demo-ai-sdk/evals/refund.eval.ts
@@ -1,25 +1,54 @@
-import { describeEval } from "vitest-evals";
-import { assertRefundCase, refundHarness } from "./shared";
+import { anthropic } from "@ai-sdk/anthropic";
+import { aiSdkJudgeHarness } from "@vitest-evals/harness-ai-sdk";
+import { describeEval, FactualityJudge } from "vitest-evals";
+import {
+  assertRefundCase,
+  REFUND_MODEL,
+  refundHarness,
+  type RefundCase,
+} from "./shared";
+
+const judgeHarness = aiSdkJudgeHarness({
+  model: anthropic(REFUND_MODEL),
+  temperature: 0,
+});
+const factualityJudge = FactualityJudge({ judgeHarness });
 
 describeEval(
   "demo ai-sdk refund agent",
   {
     skipIf: () => !process.env.ANTHROPIC_API_KEY,
     harness: refundHarness,
+    judges: [factualityJudge],
+    judgeThreshold: 0.6,
   },
   (it) => {
     it("approves refundable invoice", async ({ run }) => {
-      await assertRefundCase(await run("Refund invoice inv_123"), {
+      const metadata: Omit<RefundCase, "input"> = {
+        expected:
+          "Invoice inv_123 should be approved and refunded for the full 4200 cents.",
         expectedStatus: "approved",
         expectedTools: ["lookupInvoice", "createRefund"],
-      });
+      };
+
+      await assertRefundCase(
+        await run("Refund invoice inv_123", { metadata }),
+        metadata,
+      );
     });
 
     it("denies non-refundable invoice", async ({ run }) => {
-      await assertRefundCase(await run("Refund invoice inv_404"), {
+      const metadata: Omit<RefundCase, "input"> = {
+        expected:
+          "Invoice inv_404 should be denied because it is not refundable.",
         expectedStatus: "denied",
         expectedTools: ["lookupInvoice"],
-      });
+      };
+
+      await assertRefundCase(
+        await run("Refund invoice inv_404", { metadata }),
+        metadata,
+      );
     });
   },
 );

--- a/apps/demo-ai-sdk/evals/shared.ts
+++ b/apps/demo-ai-sdk/evals/shared.ts
@@ -27,9 +27,12 @@ type RefundDecision =
 
 export type RefundCase = {
   input: string;
+  expected?: unknown;
   expectedStatus: RefundDecision["status"];
   expectedTools: string[];
 };
+
+export const REFUND_MODEL = "claude-sonnet-4-5";
 
 const REFUND_SYSTEM_PROMPT = [
   "You are the demo refund operations agent.",
@@ -115,7 +118,7 @@ export const refundHarness = aiSdkHarness({
   },
   run: async ({ input, runtime }) =>
     generateText({
-      model: anthropic("claude-sonnet-4-5"),
+      model: anthropic(REFUND_MODEL),
       system: REFUND_SYSTEM_PROMPT,
       prompt: input,
       tools: runtime.tools,

--- a/apps/demo-openai-agents/README.md
+++ b/apps/demo-openai-agents/README.md
@@ -8,8 +8,9 @@ through the workspace packages:
 
 The passing live eval lives in `evals/refund.eval.ts`.
 It demonstrates a real OpenAI Agents `Agent`, `Runner`, local function tools,
-tool replay configured from the harness, and explicit Vitest assertions on
-`run.output` and the normalized session trace.
+tool replay configured from the harness, the built-in factuality judge over
+normalized harness output, and explicit Vitest assertions on `run.output` and
+the normalized session trace.
 
 The intentionally failing examples live in `evals/refund.fail.eval.ts`.
 One fails an automatic harness-backed judge, and one fails explicit assertions

--- a/apps/demo-openai-agents/evals/refund.eval.ts
+++ b/apps/demo-openai-agents/evals/refund.eval.ts
@@ -1,32 +1,44 @@
+import { openaiAgentsJudgeHarness } from "@vitest-evals/harness-openai-agents";
 import {
   describeEval,
+  FactualityJudge,
   StructuredOutputJudge,
   ToolCallJudge,
 } from "vitest-evals";
 import { expect } from "vitest";
 import { assertRefundCase, refundHarness } from "./shared";
-import type { RefundCase } from "../src/refundAgent";
+import { DEFAULT_REFUND_MODEL, type RefundCase } from "../src/refundAgent";
 
 const outputJudge = StructuredOutputJudge();
+const judgeHarness = openaiAgentsJudgeHarness({
+  model: DEFAULT_REFUND_MODEL,
+  temperature: 0,
+});
+const factualityJudge = FactualityJudge({ judgeHarness });
 
 describeEval(
   "demo openai agents refund agent",
   {
     skipIf: () => !process.env.OPENAI_API_KEY,
     harness: refundHarness,
-    judges: [ToolCallJudge()],
+    judges: [ToolCallJudge(), factualityJudge],
+    judgeThreshold: 0.6,
   },
   (it) => {
     it.for<RefundCase>([
       {
         name: "approves refundable invoice",
         input: "Refund invoice inv_123",
+        expected:
+          "Invoice inv_123 should be approved and refunded for the full 4200 cents.",
         expectedStatus: "approved",
         expectedTools: ["lookupInvoice", "createRefund"],
       },
       {
         name: "denies non-refundable invoice",
         input: "Refund invoice inv_404",
+        expected:
+          "Invoice inv_404 should be denied because it is not refundable.",
         expectedStatus: "denied",
         expectedTools: ["lookupInvoice"],
       },

--- a/apps/demo-openai-agents/src/refundAgent.ts
+++ b/apps/demo-openai-agents/src/refundAgent.ts
@@ -23,6 +23,7 @@ export type RefundDecision =
 
 export type RefundEvalMetadata = {
   name?: string;
+  expected?: unknown;
   expectedStatus: RefundDecision["status"];
   expectedTools: string[];
 };

--- a/apps/demo-pi/README.md
+++ b/apps/demo-pi/README.md
@@ -8,8 +8,8 @@ through the workspace packages:
 
 The passing live eval lives in `evals/refund.eval.ts`.
 It demonstrates an app-local refund agent, an automatic harness-backed tool
-judge, and explicit Vitest assertions on `run.output` and the normalized
-session trace.
+judge, the built-in factuality judge over normalized harness output, and
+explicit Vitest assertions on `run.output` and the normalized session trace.
 
 The intentionally failing examples live in `evals/refund.fail.eval.ts`.
 One fails an automatic harness-backed judge, and one fails explicit assertions

--- a/apps/demo-pi/evals/refund.eval.ts
+++ b/apps/demo-pi/evals/refund.eval.ts
@@ -1,7 +1,9 @@
+import { getModel } from "@mariozechner/pi-ai";
 import { expect } from "vitest";
-import { piAiHarness } from "@vitest-evals/harness-pi-ai";
+import { piAiHarness, piAiJudgeHarness } from "@vitest-evals/harness-pi-ai";
 import {
   describeEval,
+  FactualityJudge,
   StructuredOutputJudge,
   ToolCallJudge,
   toolCalls,
@@ -9,6 +11,11 @@ import {
 import { createRefundAgent, type RefundCase } from "../src/refundAgent";
 
 const outputJudge = StructuredOutputJudge();
+const judgeHarness = piAiJudgeHarness({
+  model: getModel("anthropic", "claude-sonnet-4-5"),
+  temperature: 0,
+});
+const factualityJudge = FactualityJudge({ judgeHarness });
 
 describeEval(
   "demo pi refund agent",
@@ -20,19 +27,24 @@ describeEval(
         lookupInvoice: true,
       },
     }),
-    judges: [ToolCallJudge()],
+    judges: [ToolCallJudge(), factualityJudge],
+    judgeThreshold: 0.6,
   },
   (it) => {
     it.for<RefundCase>([
       {
         name: "approves refundable invoice",
         input: "Refund invoice inv_123",
+        expected:
+          "Invoice inv_123 should be approved and refunded for the full 4200 cents.",
         expectedStatus: "approved",
         expectedTools: ["lookupInvoice", "createRefund"],
       },
       {
         name: "denies non-refundable invoice",
         input: "Refund invoice inv_404",
+        expected:
+          "Invoice inv_404 should be denied because it is not refundable.",
         expectedStatus: "denied",
         expectedTools: ["lookupInvoice"],
       },

--- a/apps/demo-pi/src/refundAgent.ts
+++ b/apps/demo-pi/src/refundAgent.ts
@@ -29,6 +29,7 @@ export type RefundDecision =
 
 export type RefundEvalMetadata = {
   name?: string;
+  expected?: unknown;
   expectedStatus: RefundDecision["status"];
   expectedTools: string[];
 };

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -75,20 +75,32 @@ run.
 
 Contains root judge helpers such as:
 
+- `FactualityJudge`
 - `ToolCallJudge`
 - `StructuredOutputJudge`
 
-These are judge-shaped adapters over the legacy comparison logic so new suites
-can stay on the harness-first surface while older matching behavior remains
-available.
+`FactualityJudge` is a factuality judge over normalized
+`input`/`output`/`expected` context. It uses the curried `runJudge` function
+from `JudgeContext` when it needs an LLM call, so provider configuration stays
+on the matcher, judge, or suite `judgeHarness`. The deterministic judges are
+judge-shaped adapters over the legacy comparison logic so new suites can stay
+on the harness-first surface while older matching behavior remains available.
+
+Dedicated judge harnesses are separate from the app harness under test. They
+adapt provider-specific judge-model configuration to the core judge prompt
+contract, which lets one judge implementation run across multiple app
+harnesses.
 
 All judges receive `JudgeContext`, which carries normalized run/session data,
-typed `input`, typed `output`, and the configured `harness`. The output is only
-optional when the harness output type includes `undefined`. LLM-backed judges own
-their prompt, rubric text, model call, and parser. Custom judges should use
-`createJudge("Name", assess)` for stable reporter labels; the provider-helper
-overload is for reusable judge-side setup that needs curried run-scoped options
-such as abort signals.
+typed `input`, typed `output`, the configured app `harness`, and `runJudge`
+when a judge harness is configured. The output is only optional when the
+harness output type includes `undefined`. LLM-backed judges own their prompt,
+rubric text, and parser; provider-specific model calls live in judge harness
+adapters. Custom judges should use `createJudge("Name", assess)` for stable
+reporter labels, or `createJudge({ name, judgeHarness, assess })` when the
+judge should carry a reusable judge-side harness default.
+`createJudgeHarness(...)` is the shared abstraction for judge-side provider
+shims.
 
 ### `packages/vitest-evals/src/legacy/*`
 
@@ -168,7 +180,8 @@ behavior only.
 Adapts `ai-sdk`-style results into the normalized run/session shape. It can
 derive output, usage, messages, tool calls, and errors from common AI SDK
 result objects, while still allowing a custom `run` entrypoint and typed
-`output` selector.
+`output` selector. It also exposes `aiSdkJudgeHarness(...)`, a thin adapter
+from AI SDK model configuration to the core judge harness interface.
 
 ### `@vitest-evals/harness-openai-agents`
 
@@ -176,12 +189,14 @@ Adapts `@openai/agents` `Runner.run(agent, input, options)` workflows into the
 normalized run/session shape. It accepts existing agents/runners or per-run
 `agent`/`runner` factories, supports custom app entrypoints, normalizes
 `RunResult` output, messages, usage, tool calls, tool results, errors, trace
-metadata, and records replay metadata for opt-in local function tools.
+metadata, and records replay metadata for opt-in local function tools. It also
+exposes `openaiAgentsJudgeHarness(...)` for judge-side model calls.
 
 ### `@vitest-evals/harness-pi-ai`
 
 Adapts `pi-ai` style agents into the same normalized shape. It also owns the
-standard tool replay/VCR behavior for opt-in tools, including:
+standard tool replay/VCR behavior for opt-in tools and exposes
+`piAiJudgeHarness(...)` for judge-side model calls. Replay modes include:
 
 - `auto`
 - `strict`

--- a/docs/custom-scorers.md
+++ b/docs/custom-scorers.md
@@ -80,7 +80,8 @@ output type cannot assess the received value. Inside an eval test, matcher
 calls on registered output objects or session objects reuse that exact run
 context; other raw values fall back to the current test's most recent `run(...)`
 context. Matcher calls outside that context, or on manually-created runs,
-should pass the context required by the judge in `toSatisfyJudge(...)` options.
+should pass every context field the judge reads in `toSatisfyJudge(...)`
+options.
 
 ## Built-In Root Judges
 

--- a/docs/custom-scorers.md
+++ b/docs/custom-scorers.md
@@ -11,11 +11,11 @@ scorer-first suite.
 ```ts
 import { createJudge } from "vitest-evals";
 
-export const FactualityJudge = createJudge(
-  "FactualityJudge",
+export const RefundRubricJudge = createJudge(
+  "RefundRubricJudge",
   async ({ output }) => {
     const answer = output;
-    const verdict = await judgeFactuality(answer);
+    const verdict = await judgeRefundRubric(answer);
 
     return {
       score: verdict.score,
@@ -30,13 +30,18 @@ export const FactualityJudge = createJudge(
 Use it as an automatic suite-level judge:
 
 ```ts
+import { piAiHarness } from "@vitest-evals/harness-pi-ai";
+import { describeEval } from "vitest-evals";
+import { createRefundAgent } from "../src/refundAgent";
+import { RefundRubricJudge } from "./judges";
+
 describeEval(
   "refund agent",
   {
     harness: piAiHarness({
       agent: () => createRefundAgent(),
     }),
-    judges: [FactualityJudge],
+    judges: [RefundRubricJudge],
   },
   (it) => {
     it("approves the refundable invoice", async ({ run }) => {
@@ -49,17 +54,20 @@ describeEval(
 Or run it explicitly inside a test:
 
 ```ts
-await expect(result).toSatisfyJudge(FactualityJudge);
+import { expect } from "vitest";
+import { RefundRubricJudge } from "./judges";
+
+await expect(result).toSatisfyJudge(RefundRubricJudge);
 ```
 
 For simple response-level checks, a judge can just score `output`. When a judge
 needs normalized run context, type it with `JudgeContext` and read `metadata`,
-`toolCalls`, `session`, or `harness` from there. LLM-backed judges should own
-their prompt, rubric text, model call, and parser. When multiple judges share a
-reusable judge-side provider helper, use the provider-helper overload of
-`createJudge(...)` so run-scoped options such as abort signals stay curried.
-Calling `harness.run(...)` inside a judge executes the app again, so reserve
-that for judges that intentionally need a second run.
+`toolCalls`, `session`, `harness`, or the curried `runJudge` helper from there.
+LLM-backed judges should own their prompt, rubric text, and parser, then call
+`ctx.runJudge(...)` for the provider-specific model request. Core curries the
+matcher, judge, or suite `judgeHarness` into that function with the current
+abort signal. Calling `harness.run(...)` inside a judge executes the app again,
+so reserve that for judges that intentionally need a second run.
 
 When rubric criteria are part of the scenario under test, keep them on
 `input`. Use per-run `metadata` for expectations or harness configuration
@@ -76,10 +84,11 @@ should pass the context required by the judge in `toSatisfyJudge(...)` options.
 
 ## Built-In Root Judges
 
-The root package still ships deterministic judge-shaped helpers such as
-`StructuredOutputJudge()` and `ToolCallJudge()`. They operate on normalized
-harness data instead of raw scorer inputs, but new docs should keep factuality
-or rubric judges as the primary examples.
+The root package ships `FactualityJudge()` for factuality grading and
+deterministic judge-shaped helpers such as `StructuredOutputJudge()` and
+`ToolCallJudge()`. LLM-backed judges use a matcher, judge, or suite
+`judgeHarness`, which keeps provider-specific model configuration outside the
+root judge.
 
 ## Legacy Scorer Example
 

--- a/docs/scorer-examples.md
+++ b/docs/scorer-examples.md
@@ -14,7 +14,7 @@ export const judgeHarness = aiSdkJudgeHarness({
   model: openai("gpt-4.1-mini"),
   temperature: 0,
 });
-export const factualityJudge = FactualityJudge();
+export const factualityJudge = FactualityJudge({ judgeHarness });
 ```
 
 For custom judge providers:
@@ -33,7 +33,7 @@ export const judgeHarness: JudgeHarness = createJudgeHarness({
     callJudgeModel({ system, prompt, signal }),
 });
 
-export const factualityJudge = FactualityJudge();
+export const factualityJudge = FactualityJudge({ judgeHarness });
 ```
 
 ## Tool Behavior Judge
@@ -64,11 +64,10 @@ export const LookupThenRefundJudge = createJudge(
 
 ```ts
 import { expect } from "vitest";
-import { factualityJudge, judgeHarness } from "./judges";
+import { factualityJudge } from "./judges";
 
 await expect(result).toSatisfyJudge(factualityJudge, {
   expected: "Paris is the capital of France.",
-  judgeHarness,
   threshold: 0.6,
 });
 ```

--- a/docs/scorer-examples.md
+++ b/docs/scorer-examples.md
@@ -6,22 +6,34 @@ For new suites, prefer judges over root-level scorers.
 ## Factuality Judge
 
 ```ts
-import { createJudge } from "vitest-evals";
+import { openai } from "@ai-sdk/openai";
+import { aiSdkJudgeHarness } from "@vitest-evals/harness-ai-sdk";
+import { FactualityJudge } from "vitest-evals";
 
-export const FactualityJudge = createJudge(
-  "FactualityJudge",
-  async ({ output }) => {
-    const answer = output;
-    const verdict = await judgeFactuality(answer);
+export const judgeHarness = aiSdkJudgeHarness({
+  model: openai("gpt-4.1-mini"),
+  temperature: 0,
+});
+export const factualityJudge = FactualityJudge();
+```
 
-    return {
-      score: verdict.score,
-      metadata: {
-        rationale: verdict.rationale,
-      },
-    };
-  },
-);
+For custom judge providers:
+
+```ts
+import {
+  createJudgeHarness,
+  FactualityJudge,
+  type JudgeHarness,
+} from "vitest-evals";
+import { callJudgeModel } from "./judgeModel";
+
+export const judgeHarness: JudgeHarness = createJudgeHarness({
+  name: "factuality-judge-model",
+  run: async ({ system, prompt }, { signal }) =>
+    callJudgeModel({ system, prompt, signal }),
+});
+
+export const factualityJudge = FactualityJudge();
 ```
 
 ## Tool Behavior Judge
@@ -51,7 +63,14 @@ export const LookupThenRefundJudge = createJudge(
 ## Explicit Judge Assertion
 
 ```ts
-await expect(result).toSatisfyJudge(FactualityJudge);
+import { expect } from "vitest";
+import { factualityJudge, judgeHarness } from "./judges";
+
+await expect(result).toSatisfyJudge(factualityJudge, {
+  expected: "Paris is the capital of France.",
+  judgeHarness,
+  threshold: 0.6,
+});
 ```
 
 ## Deterministic Helper Note

--- a/packages/docs/astro.config.mjs
+++ b/packages/docs/astro.config.mjs
@@ -45,6 +45,7 @@ export default defineConfig({
               label: "Judges",
               items: [
                 { label: "Overview", link: "/docs/judges" },
+                { label: "FactualityJudge", link: "/docs/judges/factuality" },
                 { label: "ToolCallJudge", link: "/docs/judges/tool-call" },
                 {
                   label: "StructuredOutputJudge",

--- a/packages/docs/src/content/docs/api.mdx
+++ b/packages/docs/src/content/docs/api.mdx
@@ -45,6 +45,10 @@ type parameters, options, and examples.
 ## Judges and Matchers
 
 <div class="api-link-grid">
+  <a class="api-link-card" href="/api/functions/factualityjudge/">
+    <strong>FactualityJudge</strong>
+    <span>Model-grade harness output against an expert answer.</span>
+  </a>
   <a class="api-link-card" href="/api/functions/toolcalljudge/">
     <strong>ToolCallJudge</strong>
     <span>Score expected tool names, order, and arguments from normalized calls.</span>

--- a/packages/docs/src/content/docs/docs/judges.mdx
+++ b/packages/docs/src/content/docs/docs/judges.mdx
@@ -15,6 +15,10 @@ explicit judge assertions when one case needs an extra check.
 ## Judge Types
 
 <div class="api-link-grid">
+  <a class="api-link-card" href="/docs/judges/factuality/">
+    <strong>FactualityJudge</strong>
+    <span>Use a grading model to compare output against an expert answer from normalized run context.</span>
+  </a>
   <a class="api-link-card" href="/docs/judges/tool-call/">
     <strong>ToolCallJudge</strong>
     <span>Check tool names, order, and arguments from normalized tool calls.</span>
@@ -29,36 +33,41 @@ explicit judge assertions when one case needs an extra check.
   </a>
 </div>
 
-## Suite Defaults
+## Usage
 
 Suite-level judges run after each `run(...)`. This example keeps the same Paris
-story as the harness pages and uses a tiny custom judge for the answer.
+story as the harness pages and uses the built-in factuality judge.
 
 ```ts title="evals/capital.eval.ts"
+import { openai } from "@ai-sdk/openai";
+import { aiSdkJudgeHarness } from "@vitest-evals/harness-ai-sdk";
 import { expect } from "vitest";
 import {
-  createJudge,
   describeEval,
-  type JudgeContext,
+  FactualityJudge,
 } from "vitest-evals";
 import { qaHarness } from "./qaHarness";
 
-const CapitalJudge = createJudge(
-  "CapitalJudge",
-  async ({ output }: JudgeContext<string, string>) => ({
-    score: output.toLowerCase().includes("paris") ? 1 : 0,
-  }),
-);
+const judgeHarness = aiSdkJudgeHarness({
+  model: openai("gpt-4.1-mini"),
+  temperature: 0,
+});
+const factualityJudge = FactualityJudge({ judgeHarness });
 
 describeEval(
   "capital questions",
   {
     harness: qaHarness,
-    judges: [CapitalJudge],
+    judges: [factualityJudge],
+    judgeThreshold: 0.6,
   },
   (it) => {
     it("knows the capital of France", async ({ run }) => {
-      const result = await run("What is the capital of France?");
+      const result = await run("What is the capital of France?", {
+        metadata: {
+          expected: "Paris is the capital of France.",
+        },
+      });
 
       expect(result.output).toContain("Paris");
     });

--- a/packages/docs/src/content/docs/docs/judges/_TEMPLATE.md
+++ b/packages/docs/src/content/docs/docs/judges/_TEMPLATE.md
@@ -7,7 +7,7 @@ editUrl: false
 Open with the behavior this judge protects and when it should be preferred over
 a plain Vitest assertion or a custom judge.
 
-## Configure
+## Usage
 
 Show the default suite-level configuration first. Add options only after the
 reader sees the recommended path.

--- a/packages/docs/src/content/docs/docs/judges/custom.mdx
+++ b/packages/docs/src/content/docs/docs/judges/custom.mdx
@@ -4,10 +4,15 @@ description: Create reusable rubrics and thresholds for domain-specific scoring.
 editUrl: false
 ---
 
-Use `createJudge()` when a rubric should be reused across suites. Keep the
-returned metadata JSON-safe so reports can render it.
+Use `createJudge()` when a rubric should be reused across suites. A custom
+judge receives the same normalized `JudgeContext` as built-ins: input, output,
+metadata, tool calls, session, run, app harness, and a curried `runJudge`
+function when the suite has a judge harness.
 
-## Configure
+## Usage
+
+Keep deterministic checks close to the normalized output. Return stable score
+units and JSON-safe metadata that explains the result.
 
 ```ts title="evals/judges/capitalJudge.ts"
 import { createJudge, type JudgeContext } from "vitest-evals";
@@ -29,37 +34,68 @@ export const CapitalJudge = createJudge(
 );
 ```
 
-Use stable score units. Prefer `0` to `1` for pass/fail checks and reserve
-intermediate values for true partial credit.
+Prefer `0` and `1` for pass/fail checks. Reserve intermediate values for true
+partial credit.
 
-### Thresholds
+## Suite Use
 
-Thresholds belong with the judge configuration when they should apply
-everywhere. Put thresholds on explicit judge assertions only when a single case
-needs a different bar.
+Attach reusable judges at the suite level when every case should satisfy the
+same contract.
 
 ```ts title="evals/capital.eval.ts"
+import { describeEval } from "vitest-evals";
+import { qaHarness } from "./qaHarness";
+import { CapitalJudge } from "./judges/capitalJudge";
+
 describeEval("capital questions", {
   harness: qaHarness,
-  judges: [
-    CapitalJudge.withOptions({
-      threshold: 1,
-    }),
-  ],
+  judges: [CapitalJudge],
+  judgeThreshold: 1,
 });
 ```
 
-Model-backed judges should include enough metadata for a reviewer to understand
-why a score changed without rerunning the model.
+Use explicit assertions when a single case needs an extra judge or a different
+threshold.
 
-## Metadata
+```ts title="evals/capital.eval.ts"
+await expect(result).toSatisfyJudge(CapitalJudge, {
+  threshold: null,
+});
+```
 
-Return metadata that explains the score in reviewable terms. Keep it
-JSON-serializable and focused on details a report can display without rerunning
-the judge.
+## Model-Backed Judges
+
+If a custom judge needs an LLM call, configure a `judgeHarness` on the matcher,
+the judge object, or the suite, then call `ctx.runJudge(...)` from the judge.
+Core curries the current abort signal into that function. Matcher options win
+over a judge default, and a judge default wins over the suite default. Explicit
+matcher calls can also reuse a single unambiguous judge-level harness from the
+suite's automatic judges, but automatic judges do not inherit inferred
+harnesses from sibling judges. Leave `judgeHarness` unset for suites that only
+use deterministic judges.
+
+```ts title="evals/judges/rubricJudge.ts"
+import { createJudge } from "vitest-evals";
+
+export const RubricJudge = createJudge({
+  name: "RubricJudge",
+  async assess(ctx) {
+    if (!ctx.runJudge) {
+      throw new Error("RubricJudge requires a configured judgeHarness.");
+    }
+
+    const verdict = await ctx.runJudge({
+      prompt: `Grade this answer: ${JSON.stringify(ctx.output)}`,
+      responseFormat: { type: "json" },
+    });
+
+    return parseRubricVerdict(verdict);
+  },
+});
+```
 
 ## Failure Behavior
 
-Custom judges fail when the returned score falls below the configured
-threshold. Use explicit thresholds for domain rubrics so a future reader can
-see whether a score is advisory or blocking.
+Custom judges fail when the returned score falls below the active threshold.
+Use explicit thresholds for domain rubrics so a future reader can see whether a
+score is advisory or blocking.

--- a/packages/docs/src/content/docs/docs/judges/factuality.mdx
+++ b/packages/docs/src/content/docs/docs/judges/factuality.mdx
@@ -1,0 +1,123 @@
+---
+title: FactualityJudge
+description: Model-grade harness output against an expert answer.
+editUrl: false
+---
+
+`FactualityJudge()` compares the normalized run `input`, `output`, and
+`expected` answer. The judge owns the rubric and parser. A separate
+`judgeHarness` owns the provider-specific model call, so the same judge works
+with AI SDK, Pi, OpenAI Agents, or custom app harnesses.
+
+The built-in rubric gives partial credit for consistent subsets and supersets,
+full credit for exact factual matches or irrelevant differences, and zero credit
+for contradictions.
+
+## Usage
+
+Pick the judge harness from the provider package you already use for the
+judge-side model. The app harness still runs the app under test; the judge
+harness only grades the captured result. You only need `judgeHarness` when a
+judge calls `ctx.runJudge(...)`; deterministic judges can omit it.
+
+```ts title="evals/capital.eval.ts"
+import { openai } from "@ai-sdk/openai";
+import { aiSdkJudgeHarness } from "@vitest-evals/harness-ai-sdk";
+import { describeEval, FactualityJudge } from "vitest-evals";
+import { qaHarness } from "./qaHarness";
+
+const judgeHarness = aiSdkJudgeHarness({
+  model: openai("gpt-4.1-mini"),
+  temperature: 0,
+});
+const factualityJudge = FactualityJudge({ judgeHarness });
+
+describeEval("capital questions", {
+  harness: qaHarness,
+  judges: [factualityJudge],
+  judgeThreshold: 0.6,
+});
+```
+
+You can also put `judgeHarness` on `describeEval(...)` when several
+LLM-backed judges should share the same judge-side model. Matcher options are
+the most specific override, followed by a judge-level default, then the suite
+default. Explicit matcher calls can also reuse a single unambiguous
+judge-level harness from the suite's automatic judges. Automatic judges only
+inherit an explicit suite default or their own judge-level harness; they do not
+inherit inferred harnesses from sibling judges.
+
+For Pi or OpenAI Agents suites, use the matching adapter instead of pulling in
+the AI SDK adapter:
+
+```ts title="evals/piJudges.ts"
+import { getModel } from "@mariozechner/pi-ai";
+import { piAiJudgeHarness } from "@vitest-evals/harness-pi-ai";
+import { FactualityJudge } from "vitest-evals";
+
+export const judgeHarness = piAiJudgeHarness({
+  model: getModel("anthropic", "claude-sonnet-4-5"),
+  temperature: 0,
+});
+export const factualityJudge = FactualityJudge({ judgeHarness });
+```
+
+## Expected Answer
+
+Put the expert answer in run metadata when every suite-level factuality judge
+should read it.
+
+```ts title="evals/capital.eval.ts"
+await run("What is the capital of France?", {
+  metadata: {
+    expected: "Paris is the capital of France.",
+  },
+});
+```
+
+The judge formats structured harness output as JSON before sending it to the
+grading model, so it can assess text or domain-object outputs.
+
+## Explicit Assertion
+
+Inside a `describeEval(...)` suite, explicit assertions reuse the suite's
+`judgeHarness`. Pass `expected` and any threshold override like normal Vitest
+matcher options.
+
+```ts title="evals/capital.eval.ts"
+import { expect } from "vitest";
+import { FactualityJudge } from "vitest-evals";
+
+const result = await run("What is the capital of France?");
+
+await expect(result).toSatisfyJudge(FactualityJudge(), {
+  expected: "Paris is the capital of France.",
+  threshold: 0.6,
+});
+```
+
+Outside a suite, or when one assertion should use a different judge-side model,
+pass `judgeHarness` directly in matcher options. That matcher-level value wins
+over a judge-level or suite-level default.
+
+## Custom Provider
+
+Use `createJudgeHarness()` when no first-party adapter matches your judge-side
+provider. Return JSON-safe output or a string containing JSON.
+
+```ts title="evals/judgeHarness.ts"
+import { createJudgeHarness, type JudgeHarness } from "vitest-evals";
+import { callJudgeModel } from "./judgeModel";
+
+export const judgeHarness: JudgeHarness = createJudgeHarness({
+  name: "factuality-judge-model",
+  run: async ({ system, prompt }, { signal }) =>
+    callJudgeModel({ system, prompt, signal }),
+});
+```
+
+## Failure Behavior
+
+The default threshold is `1`, so partial-credit factuality scores fail unless
+you lower the suite or matcher threshold. When `expected` is missing, `null`, or
+a blank string, the judge records a zero score without making a model call.

--- a/packages/docs/src/content/docs/docs/judges/structured-output.mdx
+++ b/packages/docs/src/content/docs/docs/judges/structured-output.mdx
@@ -8,7 +8,7 @@ editUrl: false
 metadata or matcher options. Use it for deterministic checks when the harness
 returns a parsed domain object instead of raw provider text.
 
-## Configure
+## Usage
 
 ```ts title="evals/capital.eval.ts"
 import { StructuredOutputJudge } from "vitest-evals";
@@ -21,7 +21,7 @@ describeEval("capital questions", {
 });
 ```
 
-### Explicit Assertions
+## Explicit Assertion
 
 Use explicit assertions when a case needs an extra check or when you want to
 record a score separately from the suite defaults.
@@ -42,7 +42,7 @@ it("records a structured output score", async ({ run }) => {
 
 `threshold: null` records the score without turning it into a failure.
 
-## Metadata
+## Expected Output
 
 Put the expected value in run metadata.
 

--- a/packages/docs/src/content/docs/docs/judges/tool-call.mdx
+++ b/packages/docs/src/content/docs/docs/judges/tool-call.mdx
@@ -7,7 +7,7 @@ editUrl: false
 `ToolCallJudge()` reads normalized tool calls from the harness run. Use it when
 the sequence of tools is part of the behavior you want to preserve.
 
-## Configure
+## Usage
 
 ```ts title="evals/capital.eval.ts"
 import { ToolCallJudge } from "vitest-evals";
@@ -22,7 +22,7 @@ describeEval("capital questions", {
 });
 ```
 
-### Arguments
+## Arguments
 
 Use matcher options when a tool argument is the important assertion.
 
@@ -39,7 +39,7 @@ ToolCallJudge({
 });
 ```
 
-## Metadata
+## Expected Tools
 
 Pass expected tool names through metadata on each run.
 

--- a/packages/harness-ai-sdk/README.md
+++ b/packages/harness-ai-sdk/README.md
@@ -89,24 +89,24 @@ const harness = aiSdkHarness({
 ```
 
 `run` executes the system under test. Judges are created separately; keep judge
-prompts and model calls in the judge instead of putting a judge model call on
-the app harness.
+prompts and model calls on a judge harness instead of putting them on the app
+harness.
 
 ```ts
-const FactualityJudge = createJudge(
-  "FactualityJudge",
-  async (ctx: JudgeContext<string, RefundDecision>) => {
-    const verdict = await generateText({
-      model: openai("gpt-4o-mini"),
-      prompt: formatJudgePrompt({
-        input: ctx.input,
-        output: ctx.output,
-      }),
-    }).then((result) => result.text);
+import { openai } from "@ai-sdk/openai";
+import { aiSdkJudgeHarness } from "@vitest-evals/harness-ai-sdk";
+import { describeEval, FactualityJudge } from "vitest-evals";
 
-    return parseJudgeVerdict(verdict);
-  },
-);
+const judgeHarness = aiSdkJudgeHarness({
+  model: openai("gpt-4.1-mini"),
+  temperature: 0,
+});
+const factualityJudge = FactualityJudge({ judgeHarness });
+
+describeEval("refund agent", {
+  harness,
+  judges: [factualityJudge],
+});
 ```
 
 The adapter infers:

--- a/packages/harness-ai-sdk/src/index.ts
+++ b/packages/harness-ai-sdk/src/index.ts
@@ -22,6 +22,11 @@ import type {
   ToolCallRecord,
   UsageSummary,
 } from "vitest-evals/harness";
+import { generateObject, generateText, jsonSchema } from "ai";
+import {
+  createJudgeHarness,
+  type JudgeHarnessInput,
+} from "vitest-evals/judges";
 import {
   executeWithReplay,
   getReplayMetadataFromError,
@@ -36,6 +41,7 @@ import type {
 import type {
   InferToolInput,
   InferToolOutput,
+  LanguageModel,
   LanguageModelUsage,
   StepResult,
   Tool,
@@ -45,6 +51,9 @@ import type {
 } from "ai";
 
 type MaybePromise<T> = T | Promise<T>;
+type AiSdkProviderOptions = Parameters<
+  typeof generateText
+>[0]["providerOptions"];
 type JsonOutput<TValue> = [TValue] extends [JsonValue | undefined]
   ? TValue
   : undefined;
@@ -67,6 +76,118 @@ type AnyAiSdkToolset<
   TInput = string,
   TMetadata extends HarnessMetadata = HarnessMetadata,
 > = Record<string, AiSdkToolDefinition<any, any, TInput, TMetadata>>;
+
+/**
+ * Configuration for adapting an AI SDK language model into a judge harness.
+ *
+ * @example
+ * ```ts
+ * import { anthropic } from "@ai-sdk/anthropic";
+ * import { aiSdkJudgeHarness } from "@vitest-evals/harness-ai-sdk";
+ *
+ * const judgeHarness = aiSdkJudgeHarness({
+ *   model: anthropic("claude-sonnet-4-5"),
+ *   temperature: 0,
+ * });
+ * ```
+ */
+export interface AiSdkJudgeHarnessConfig {
+  /** AI SDK language model used for judge prompts. */
+  model: LanguageModel;
+  /** Optional display name for diagnostics. */
+  name?: string;
+  /** Optional judge-model temperature. */
+  temperature?: number;
+  /** Optional judge-model token cap. */
+  maxOutputTokens?: number;
+  /** Optional provider-specific options forwarded to the AI SDK. */
+  providerOptions?: AiSdkProviderOptions;
+}
+
+/**
+ * Adapts an AI SDK language model into the provider-neutral judge harness API.
+ *
+ * @example
+ * ```ts
+ * import { anthropic } from "@ai-sdk/anthropic";
+ * import { aiSdkJudgeHarness } from "@vitest-evals/harness-ai-sdk";
+ * import { describeEval, FactualityJudge } from "vitest-evals";
+ *
+ * const judgeHarness = aiSdkJudgeHarness({
+ *   model: anthropic("claude-sonnet-4-5"),
+ *   temperature: 0,
+ * });
+ *
+ * describeEval("qa agent", {
+ *   harness: qaHarness,
+ *   judgeHarness,
+ *   judges: [FactualityJudge()],
+ * }, (it) => {});
+ * ```
+ */
+export function aiSdkJudgeHarness(config: AiSdkJudgeHarnessConfig) {
+  return createJudgeHarness({
+    name: config.name ?? "ai-sdk",
+    run: (input, options) => runAiSdkJudgeHarness(config, input, options),
+  });
+}
+
+async function runAiSdkJudgeHarness(
+  config: AiSdkJudgeHarnessConfig,
+  input: JudgeHarnessInput,
+  options: { signal?: AbortSignal },
+) {
+  const system = formatAiSdkJudgeSystemPrompt(
+    input.system,
+    input.responseFormat,
+  );
+  const requestOptions = {
+    model: config.model,
+    prompt: input.prompt,
+    ...(system !== undefined ? { system } : {}),
+    ...(config.temperature !== undefined
+      ? { temperature: config.temperature }
+      : {}),
+    ...(config.maxOutputTokens !== undefined
+      ? { maxOutputTokens: config.maxOutputTokens }
+      : {}),
+    ...(config.providerOptions !== undefined
+      ? { providerOptions: config.providerOptions }
+      : {}),
+    ...(options.signal ? { abortSignal: options.signal } : {}),
+  };
+
+  if (
+    input.responseFormat?.type === "json" &&
+    input.responseFormat.schema !== undefined
+  ) {
+    const { object } = await generateObject({
+      ...requestOptions,
+      schema: jsonSchema(
+        input.responseFormat.schema as Parameters<typeof jsonSchema>[0],
+      ),
+    });
+
+    return object;
+  }
+
+  const { text } = await generateText(requestOptions);
+  return text;
+}
+
+function formatAiSdkJudgeSystemPrompt(
+  system: string | undefined,
+  responseFormat: JudgeHarnessInput["responseFormat"],
+) {
+  if (responseFormat?.type !== "json" || responseFormat.schema !== undefined) {
+    return system;
+  }
+
+  const jsonInstruction =
+    "Return only valid JSON. Do not include markdown fences or explanatory prose.";
+
+  return system ? `${system}\n\n${jsonInstruction}` : jsonInstruction;
+}
 
 type StepLike = Pick<
   StepResult<ToolSet>,

--- a/packages/harness-ai-sdk/src/judgeHarness.test.ts
+++ b/packages/harness-ai-sdk/src/judgeHarness.test.ts
@@ -1,0 +1,112 @@
+import { generateObject, generateText, jsonSchema } from "ai";
+import type { LanguageModel } from "ai";
+import { beforeEach, expect, test, vi } from "vitest";
+import { aiSdkJudgeHarness } from "./index";
+
+vi.mock("ai", () => ({
+  generateObject: vi.fn(),
+  generateText: vi.fn(),
+  jsonSchema: vi.fn((schema) => ({ jsonSchema: schema })),
+}));
+
+const generateObjectMock = vi.mocked(generateObject);
+const generateTextMock = vi.mocked(generateText);
+const jsonSchemaMock = vi.mocked(jsonSchema);
+const mockModel = "judge-model" as unknown as LanguageModel;
+
+beforeEach(() => {
+  generateObjectMock.mockReset();
+  generateTextMock.mockReset();
+  jsonSchemaMock.mockClear();
+});
+
+test("aiSdkJudgeHarness uses generateObject for JSON response formats", async () => {
+  const signal = new AbortController().signal;
+  const judgeHarness = aiSdkJudgeHarness({
+    model: mockModel,
+    temperature: 0,
+    maxOutputTokens: 256,
+  });
+  const schema = {
+    type: "object",
+    properties: {
+      choice: {
+        enum: ["A", "B"],
+      },
+    },
+  };
+  generateObjectMock.mockResolvedValueOnce({
+    object: {
+      choice: "A",
+    },
+  } as any);
+
+  const result = await judgeHarness.run(
+    {
+      system: "Grade factuality.",
+      prompt: "Compare the answers.",
+      responseFormat: {
+        type: "json",
+        schema,
+      },
+    },
+    {
+      metadata: {},
+      signal,
+      artifacts: {},
+      setArtifact: () => {},
+    },
+  );
+
+  expect(result.output).toEqual({ choice: "A" });
+  expect(jsonSchemaMock).toHaveBeenCalledWith(schema);
+  expect(generateObjectMock).toHaveBeenCalledWith(
+    expect.objectContaining({
+      model: mockModel,
+      system: "Grade factuality.",
+      prompt: "Compare the answers.",
+      temperature: 0,
+      maxOutputTokens: 256,
+      abortSignal: signal,
+      schema: expect.objectContaining({
+        jsonSchema: schema,
+      }),
+    }),
+  );
+  expect(generateTextMock).not.toHaveBeenCalled();
+});
+
+test("aiSdkJudgeHarness uses generateText without a JSON schema", async () => {
+  const judgeHarness = aiSdkJudgeHarness({
+    model: mockModel,
+    name: "test-judge",
+  });
+  generateTextMock.mockResolvedValueOnce({
+    text: "plain verdict",
+  } as any);
+
+  const result = await judgeHarness.run(
+    {
+      prompt: "Grade this.",
+      responseFormat: {
+        type: "json",
+      },
+    },
+    {
+      metadata: {},
+      artifacts: {},
+      setArtifact: () => {},
+    },
+  );
+
+  expect(judgeHarness.name).toBe("test-judge");
+  expect(result.output).toBe("plain verdict");
+  expect(generateTextMock).toHaveBeenCalledWith(
+    expect.objectContaining({
+      model: mockModel,
+      prompt: "Grade this.",
+      system: expect.stringContaining("Return only valid JSON"),
+    }),
+  );
+  expect(generateObjectMock).not.toHaveBeenCalled();
+});

--- a/packages/harness-openai-agents/README.md
+++ b/packages/harness-openai-agents/README.md
@@ -89,20 +89,23 @@ const harness = openaiAgentsHarness({
 ```
 
 `run` executes the OpenAI agent under test. Judges are created separately; keep
-judge prompts and model calls in the judge instead of putting a judge model
-call on the app harness.
+judge prompts on the judge and model calls on a judge harness instead of
+putting a judge model call on the app harness.
 
 ```ts
-const ClassificationJudge = createJudge(
-  "ClassificationJudge",
-  async (ctx: JudgeContext<string, Classification>) => {
-    const result = await judgeRunner
-      .run(judgeAgent, formatJudgePrompt(ctx))
-      .then((result) => resolveResultText(result));
+import { openaiAgentsJudgeHarness } from "@vitest-evals/harness-openai-agents";
+import { describeEval, FactualityJudge } from "vitest-evals";
 
-    return parseJudgeVerdict(result);
-  },
-);
+const judgeHarness = openaiAgentsJudgeHarness({
+  model: "gpt-4.1-mini",
+  temperature: 0,
+});
+const factualityJudge = FactualityJudge({ judgeHarness });
+
+describeEval("classifier agent", {
+  harness,
+  judges: [factualityJudge],
+});
 ```
 
 The adapter provides:

--- a/packages/harness-openai-agents/src/index.ts
+++ b/packages/harness-openai-agents/src/index.ts
@@ -32,6 +32,14 @@ import type {
   ToolRecording,
   ToolReplayConfig,
 } from "vitest-evals/replay";
+import { createJudgeHarness } from "vitest-evals/judges";
+import type { JudgeHarnessInput } from "vitest-evals/judges";
+import { Agent, Runner } from "@openai/agents";
+import type {
+  JsonSchemaDefinition,
+  Model,
+  ModelSettings,
+} from "@openai/agents";
 
 type MaybePromise<T> = T | Promise<T>;
 type JsonOutput<TValue> = [TValue] extends [JsonValue | undefined]
@@ -256,6 +264,151 @@ export type OpenAiAgentsToolReplayPolicies<
 > = Record<string, OpenAiAgentsToolReplayPolicy<TInput, TMetadata>>;
 
 type OpenAiAgentsInvoke = (...args: unknown[]) => unknown;
+
+/**
+ * Configuration for adapting OpenAI Agents into a judge harness.
+ *
+ * @example
+ * ```ts
+ * import { openaiAgentsJudgeHarness } from "@vitest-evals/harness-openai-agents";
+ *
+ * const judgeHarness = openaiAgentsJudgeHarness({
+ *   model: "gpt-4.1-mini",
+ *   temperature: 0,
+ * });
+ * ```
+ */
+export interface OpenAiAgentsJudgeHarnessConfig {
+  /** OpenAI Agents model used for judge prompts. */
+  model: string | Model;
+  /** Optional display name for diagnostics. */
+  name?: string;
+  /** Optional judge-model temperature. */
+  temperature?: number;
+  /** Optional judge-model token cap. */
+  maxOutputTokens?: number;
+  /** Additional model settings for the judge agent. */
+  modelSettings?: ModelSettings;
+  /** Optional runner override for tests or custom runner configuration. */
+  runner?: Runner;
+}
+
+/**
+ * Adapts OpenAI Agents into the provider-neutral judge harness API.
+ *
+ * @example
+ * ```ts
+ * import { openaiAgentsJudgeHarness } from "@vitest-evals/harness-openai-agents";
+ * import { describeEval, FactualityJudge } from "vitest-evals";
+ *
+ * const judgeHarness = openaiAgentsJudgeHarness({
+ *   model: "gpt-4.1-mini",
+ *   temperature: 0,
+ * });
+ *
+ * describeEval("qa agent", {
+ *   harness: qaHarness,
+ *   judgeHarness,
+ *   judges: [FactualityJudge()],
+ * }, (it) => {});
+ * ```
+ */
+export function openaiAgentsJudgeHarness(
+  config: OpenAiAgentsJudgeHarnessConfig,
+) {
+  return createJudgeHarness({
+    name: config.name ?? "openai-agents",
+    run: async ({ responseFormat, system, prompt }, { signal }) => {
+      const outputType = createOpenAiAgentsOutputType(responseFormat);
+      const runner =
+        config.runner ??
+        new Runner({
+          tracingDisabled: true,
+        });
+      const agent = new Agent({
+        name: "vitest_evals_judge",
+        instructions: formatOpenAiAgentsJudgeInstructions(
+          system,
+          responseFormat,
+        ),
+        model: config.model,
+        modelSettings: {
+          ...(config.modelSettings ?? {}),
+          ...(config.temperature !== undefined
+            ? { temperature: config.temperature }
+            : {}),
+          ...(config.maxOutputTokens !== undefined
+            ? { maxTokens: config.maxOutputTokens }
+            : {}),
+        },
+        ...(outputType ? { outputType } : {}),
+      });
+      const result = await runner.run(agent, prompt, { signal });
+
+      return resolveOpenAiAgentsJudgeOutput(result);
+    },
+  });
+}
+
+function formatOpenAiAgentsJudgeInstructions(
+  system: string | undefined,
+  responseFormat: JudgeHarnessInput["responseFormat"],
+) {
+  if (responseFormat?.type !== "json") {
+    return system ?? "";
+  }
+
+  const jsonInstruction = [
+    "Return only valid JSON. Do not include markdown fences or explanatory prose.",
+    responseFormat.schema
+      ? `JSON Schema:\n${JSON.stringify(responseFormat.schema, null, 2)}`
+      : undefined,
+  ]
+    .filter(Boolean)
+    .join("\n\n");
+
+  return system ? `${system}\n\n${jsonInstruction}` : jsonInstruction;
+}
+
+function createOpenAiAgentsOutputType(
+  responseFormat: JudgeHarnessInput["responseFormat"],
+): JsonSchemaDefinition | undefined {
+  const schema = responseFormat?.schema;
+  if (!isOpenAiAgentsJsonSchema(schema)) {
+    return undefined;
+  }
+
+  return {
+    type: "json_schema",
+    name: "judge_response",
+    strict: schema.additionalProperties === false,
+    schema,
+  };
+}
+
+function isOpenAiAgentsJsonSchema(
+  schema: unknown,
+): schema is JsonSchemaDefinition["schema"] {
+  return (
+    isJsonRecord(schema) &&
+    schema.type === "object" &&
+    isJsonRecord(schema.properties) &&
+    Array.isArray(schema.required) &&
+    typeof schema.additionalProperties === "boolean"
+  );
+}
+
+function isJsonRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function resolveOpenAiAgentsJudgeOutput(result: unknown) {
+  if (!result || typeof result !== "object") {
+    return result;
+  }
+
+  return (result as { finalOutput?: unknown }).finalOutput ?? result;
+}
 
 /** Minimal OpenAI Agents tool shape instrumented by the harness. */
 export type OpenAiAgentsTool<

--- a/packages/harness-openai-agents/src/index.ts
+++ b/packages/harness-openai-agents/src/index.ts
@@ -407,7 +407,11 @@ function resolveOpenAiAgentsJudgeOutput(result: unknown) {
     return result;
   }
 
-  return (result as { finalOutput?: unknown }).finalOutput ?? result;
+  if (Object.prototype.hasOwnProperty.call(result, "finalOutput")) {
+    return (result as { finalOutput: unknown }).finalOutput;
+  }
+
+  return result;
 }
 
 /** Minimal OpenAI Agents tool shape instrumented by the harness. */

--- a/packages/harness-openai-agents/src/judgeHarness.test.ts
+++ b/packages/harness-openai-agents/src/judgeHarness.test.ts
@@ -67,3 +67,28 @@ test("openaiAgentsJudgeHarness runs judge prompts through OpenAI Agents", async 
     expect.objectContaining({ signal }),
   );
 });
+
+test("openaiAgentsJudgeHarness preserves null judge output", async () => {
+  const runner = {
+    run: vi.fn(async () => ({
+      finalOutput: null,
+    })),
+  };
+  const judgeHarness = openaiAgentsJudgeHarness({
+    model: "gpt-4.1-mini",
+    runner: runner as any,
+  });
+
+  const result = await judgeHarness.run(
+    {
+      prompt: "Return null.",
+    },
+    {
+      metadata: {},
+      artifacts: {},
+      setArtifact: () => {},
+    },
+  );
+
+  expect(result.output).toBeNull();
+});

--- a/packages/harness-openai-agents/src/judgeHarness.test.ts
+++ b/packages/harness-openai-agents/src/judgeHarness.test.ts
@@ -1,0 +1,69 @@
+import { expect, test, vi } from "vitest";
+import { openaiAgentsJudgeHarness } from "./index";
+
+test("openaiAgentsJudgeHarness runs judge prompts through OpenAI Agents", async () => {
+  const signal = new AbortController().signal;
+  const runner = {
+    run: vi.fn(async () => ({
+      finalOutput: '{"choice":"C","rationale":"Matches."}',
+    })),
+  };
+  const judgeHarness = openaiAgentsJudgeHarness({
+    model: "gpt-4.1-mini",
+    temperature: 0,
+    maxOutputTokens: 256,
+    runner: runner as any,
+  });
+
+  const result = await judgeHarness.run(
+    {
+      system: "Grade factuality.",
+      prompt: "Compare the answers.",
+      responseFormat: {
+        type: "json",
+        schema: {
+          type: "object",
+          additionalProperties: false,
+          required: ["choice", "rationale"],
+          properties: {
+            choice: {
+              enum: ["A", "B", "C", "D", "E"],
+            },
+            rationale: {
+              type: "string",
+            },
+          },
+        },
+      },
+    },
+    {
+      metadata: {},
+      signal,
+      artifacts: {},
+      setArtifact: () => {},
+    },
+  );
+
+  expect(result.output).toBe('{"choice":"C","rationale":"Matches."}');
+  expect(runner.run).toHaveBeenCalledWith(
+    expect.objectContaining({
+      name: "vitest_evals_judge",
+      instructions: expect.stringContaining("Return only valid JSON"),
+      model: "gpt-4.1-mini",
+      modelSettings: expect.objectContaining({
+        temperature: 0,
+        maxTokens: 256,
+      }),
+      outputType: expect.objectContaining({
+        type: "json_schema",
+        strict: true,
+        schema: expect.objectContaining({
+          type: "object",
+          additionalProperties: false,
+        }),
+      }),
+    }),
+    "Compare the answers.",
+    expect.objectContaining({ signal }),
+  );
+});

--- a/packages/harness-pi-ai/README.md
+++ b/packages/harness-pi-ai/README.md
@@ -43,23 +43,24 @@ describeEval("refund agent", { harness }, (it) => {
 ```
 
 `run` executes the Pi agent under test. Judges are created separately; keep
-judge prompts and model calls in the judge instead of putting a judge model
-call on the app harness.
+judge prompts on the judge and model calls on a judge harness instead of
+putting a judge model call on the app harness.
 
 ```ts
-const RefundRubricJudge = createJudge(
-  "RefundRubricJudge",
-  async (ctx: JudgeContext<string, RefundDecision>) => {
-    const verdict = await queryRefundJudgeModel({
-      prompt: formatJudgePrompt({
-        input: ctx.input,
-        output: ctx.output,
-      }),
-    });
+import { getModel } from "@mariozechner/pi-ai";
+import { piAiJudgeHarness } from "@vitest-evals/harness-pi-ai";
+import { describeEval, FactualityJudge } from "vitest-evals";
 
-    return parseJudgeVerdict(verdict);
-  },
-);
+const judgeHarness = piAiJudgeHarness({
+  model: getModel("anthropic", "claude-sonnet-4-5"),
+  temperature: 0,
+});
+const factualityJudge = FactualityJudge({ judgeHarness });
+
+describeEval("refund agent", {
+  harness,
+  judges: [factualityJudge],
+});
 ```
 
 If the agent already exposes its own tools, the adapter will infer them from

--- a/packages/harness-pi-ai/src/index.ts
+++ b/packages/harness-pi-ai/src/index.ts
@@ -30,6 +30,17 @@ import type {
   ToolRecording,
   ToolReplayConfig,
 } from "vitest-evals/replay";
+import {
+  createJudgeHarness,
+  type JudgeHarnessInput,
+} from "vitest-evals/judges";
+import { completeSimple } from "@mariozechner/pi-ai";
+import type {
+  Api,
+  AssistantMessage,
+  Model,
+  SimpleStreamOptions,
+} from "@mariozechner/pi-ai";
 
 type MaybePromise<T> = T | Promise<T>;
 type JsonOutput<TValue> = [TValue] extends [JsonValue | undefined]
@@ -54,6 +65,122 @@ type AnyPiAiToolset<
   TInput = string,
   TMetadata extends HarnessMetadata = HarnessMetadata,
 > = Record<string, PiAiToolDefinition<any, any, TInput, TMetadata>>;
+
+/**
+ * Configuration for adapting a Pi AI model into a judge harness.
+ *
+ * @example
+ * ```ts
+ * import { getModel } from "@mariozechner/pi-ai";
+ * import { piAiJudgeHarness } from "@vitest-evals/harness-pi-ai";
+ *
+ * const judgeHarness = piAiJudgeHarness({
+ *   model: getModel("anthropic", "claude-sonnet-4-5"),
+ *   temperature: 0,
+ * });
+ * ```
+ */
+export interface PiAiJudgeHarnessConfig<TApi extends Api = Api> {
+  /** Pi AI model used for judge prompts. */
+  model: Model<TApi>;
+  /** Optional display name for diagnostics. */
+  name?: string;
+  /** Optional judge-model temperature. */
+  temperature?: number;
+  /** Optional judge-model token cap. */
+  maxOutputTokens?: number;
+  /** Additional Pi AI stream options forwarded to `completeSimple(...)`. */
+  options?: Omit<SimpleStreamOptions, "signal" | "temperature" | "maxTokens">;
+}
+
+/**
+ * Adapts a Pi AI model into the provider-neutral judge harness API.
+ *
+ * @example
+ * ```ts
+ * import { getModel } from "@mariozechner/pi-ai";
+ * import { piAiJudgeHarness } from "@vitest-evals/harness-pi-ai";
+ * import { describeEval, FactualityJudge } from "vitest-evals";
+ *
+ * const judgeHarness = piAiJudgeHarness({
+ *   model: getModel("anthropic", "claude-sonnet-4-5"),
+ *   temperature: 0,
+ * });
+ *
+ * describeEval("qa agent", {
+ *   harness: qaHarness,
+ *   judgeHarness,
+ *   judges: [FactualityJudge()],
+ * }, (it) => {});
+ * ```
+ */
+export function piAiJudgeHarness<TApi extends Api>(
+  config: PiAiJudgeHarnessConfig<TApi>,
+) {
+  return createJudgeHarness({
+    name: config.name ?? "pi-ai",
+    run: async ({ responseFormat, system, prompt }, { signal }) => {
+      const message = await completeSimple(
+        config.model,
+        {
+          systemPrompt: formatPiAiJudgeSystemPrompt(system, responseFormat),
+          messages: [
+            {
+              role: "user",
+              content: prompt,
+              timestamp: Date.now(),
+            },
+          ],
+        },
+        {
+          ...(config.options ?? {}),
+          ...(config.temperature !== undefined
+            ? { temperature: config.temperature }
+            : {}),
+          ...(config.maxOutputTokens !== undefined
+            ? { maxTokens: config.maxOutputTokens }
+            : {}),
+          ...(signal ? { signal } : {}),
+        },
+      );
+
+      return resolvePiAiJudgeText(message);
+    },
+  });
+}
+
+function formatPiAiJudgeSystemPrompt(
+  system: string | undefined,
+  responseFormat: JudgeHarnessInput["responseFormat"],
+) {
+  if (responseFormat?.type !== "json") {
+    return system;
+  }
+
+  const jsonInstruction = [
+    "Return only valid JSON. Do not include markdown fences or explanatory prose.",
+    responseFormat.schema
+      ? `JSON Schema:\n${JSON.stringify(responseFormat.schema, null, 2)}`
+      : undefined,
+  ]
+    .filter(Boolean)
+    .join("\n\n");
+
+  return system ? `${system}\n\n${jsonInstruction}` : jsonInstruction;
+}
+
+function resolvePiAiJudgeText(message: AssistantMessage) {
+  if (message.stopReason === "error" || message.stopReason === "aborted") {
+    throw new Error(message.errorMessage ?? "Pi AI judge harness failed.");
+  }
+
+  return message.content
+    .filter((part) => part.type === "text")
+    .map((part) => part.text)
+    .join("")
+    .trim();
+}
+
 type InferredPiAiToolset<
   TInput = string,
   TMetadata extends HarnessMetadata = HarnessMetadata,

--- a/packages/harness-pi-ai/src/judgeHarness.test.ts
+++ b/packages/harness-pi-ai/src/judgeHarness.test.ts
@@ -1,0 +1,99 @@
+import { completeSimple } from "@mariozechner/pi-ai";
+import type { Model } from "@mariozechner/pi-ai";
+import { beforeEach, expect, test, vi } from "vitest";
+import { piAiJudgeHarness } from "./index";
+
+vi.mock("@mariozechner/pi-ai", () => ({
+  completeSimple: vi.fn(),
+}));
+
+const completeSimpleMock = vi.mocked(completeSimple);
+const mockModel = {
+  id: "claude-sonnet-4-5",
+  name: "Claude Sonnet",
+  api: "anthropic-messages",
+  provider: "anthropic",
+} as Model<"anthropic-messages">;
+
+beforeEach(() => {
+  completeSimpleMock.mockReset();
+});
+
+test("piAiJudgeHarness runs judge prompts through Pi AI", async () => {
+  const signal = new AbortController().signal;
+  const judgeHarness = piAiJudgeHarness({
+    model: mockModel,
+    temperature: 0,
+    maxOutputTokens: 256,
+  });
+  completeSimpleMock.mockResolvedValueOnce({
+    role: "assistant",
+    content: [
+      {
+        type: "text",
+        text: '{"choice":"C","rationale":"Matches."}',
+      },
+    ],
+    api: "anthropic-messages",
+    provider: "anthropic",
+    model: "claude-sonnet-4-5",
+    usage: {
+      input: 1,
+      output: 1,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 2,
+      cost: {
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        total: 0,
+      },
+    },
+    stopReason: "stop",
+    timestamp: Date.now(),
+  });
+
+  const result = await judgeHarness.run(
+    {
+      system: "Grade factuality.",
+      prompt: "Compare the answers.",
+      responseFormat: {
+        type: "json",
+      },
+    },
+    {
+      metadata: {},
+      signal,
+      artifacts: {},
+      setArtifact: () => {},
+    },
+  );
+
+  expect(result.output).toBe('{"choice":"C","rationale":"Matches."}');
+  expect(completeSimpleMock).toHaveBeenCalledWith(
+    mockModel,
+    {
+      systemPrompt: expect.stringContaining("Return only valid JSON"),
+      messages: [
+        expect.objectContaining({
+          role: "user",
+          content: "Compare the answers.",
+        }),
+      ],
+    },
+    expect.objectContaining({
+      temperature: 0,
+      maxTokens: 256,
+      signal,
+    }),
+  );
+  expect(completeSimpleMock).toHaveBeenCalledWith(
+    expect.anything(),
+    expect.objectContaining({
+      systemPrompt: expect.stringContaining("Grade factuality."),
+    }),
+    expect.anything(),
+  );
+});

--- a/packages/vitest-evals/README.md
+++ b/packages/vitest-evals/README.md
@@ -339,7 +339,8 @@ await expect(result).toSatisfyJudge(factualityJudge, {
 ```
 
 For lower-level cases, the matcher also accepts raw values and synthetic judge
-context:
+context. Pass every context field the judge needs when the value did not come
+from eval fixture `run(...)`:
 
 ```ts
 await expect({ status: "approved" }).toSatisfyJudge(MyJudge, {
@@ -412,7 +413,8 @@ current run's abort signal. Matcher options win over a judge default, and a
 judge default wins over the suite default. Explicit matcher calls can also
 reuse a single unambiguous judge-level harness from the suite's automatic
 judges, but automatic judges do not inherit inferred harnesses from sibling
-judges. Leave `judgeHarness` unset for suites that only use deterministic
+judges. That inference requires those judges to share the same judge harness
+instance. Leave `judgeHarness` unset for suites that only use deterministic
 judges. Calling `harness.run(...)` from a judge executes the application again,
 so use that only when a second run is intentional.
 

--- a/packages/vitest-evals/README.md
+++ b/packages/vitest-evals/README.md
@@ -44,55 +44,28 @@ workflow.
 - every judge receives `JudgeContext` with typed `input`, typed `output`, the
   normalized run/session, tool calls, and metadata; `output` is only optional
   when the harness output type includes `undefined`
-- judges own their prompt, rubric, model call, and parsing; use
-  `createJudge(...)` for custom judges and its provider-helper overload only
-  when multiple judges share setup
+- judges own their prompt, rubric, and parsing; LLM-backed judges use
+  `ctx.runJudge(...)` from a configured `judgeHarness`
 - explicit judge assertions use
   `await expect(result).toSatisfyJudge(judge, context)`
 
 ## Explicit Run Example
 
 ```ts
+import { getModel } from "@mariozechner/pi-ai";
 import { expect } from "vitest";
-import { piAiHarness } from "@vitest-evals/harness-pi-ai";
+import { piAiHarness, piAiJudgeHarness } from "@vitest-evals/harness-pi-ai";
 import {
-  createJudge,
   describeEval,
+  FactualityJudge,
   toolCalls,
-  type JudgeContext,
 } from "vitest-evals";
 import { createRefundAgent } from "../src/refundAgent";
 
-type RefundEvalMetadata = {
-  expectedStatus: "approved" | "denied";
-  expectedTools: string[];
-};
-
-type RefundOutput = {
-  status: "approved" | "denied";
-};
-
-const FactualityJudge = createJudge(
-  "FactualityJudge",
-  async ({
-    input,
-    output,
-    metadata,
-  }: JudgeContext<string, RefundOutput, RefundEvalMetadata>) => {
-    const verdict = await judgeFactuality({
-      question: input,
-      answer: output,
-      expectedStatus: metadata.expectedStatus,
-    });
-
-    return {
-      score: verdict.score,
-      metadata: {
-        rationale: verdict.rationale,
-      },
-    };
-  },
-);
+const judgeHarness = piAiJudgeHarness({
+  model: getModel("anthropic", "claude-sonnet-4-5"),
+  temperature: 0,
+});
 
 describeEval(
   "refund agent",
@@ -100,12 +73,15 @@ describeEval(
     harness: piAiHarness({
       agent: () => createRefundAgent(),
     }),
-    judges: [FactualityJudge],
+    judgeHarness,
+    judges: [FactualityJudge()],
+    judgeThreshold: 0.6,
   },
   (it) => {
     it("approves a refundable invoice", async ({ run }) => {
       const result = await run("Refund invoice inv_123", {
         metadata: {
+          expected: "The refund request is approved.",
           expectedStatus: "approved",
           expectedTools: ["lookupInvoice", "createRefund"],
         },
@@ -214,6 +190,7 @@ When generics are needed, use `createHarness<Input, Output, Metadata>(...)`.
 import {
   createHarness,
   createJudge,
+  createJudgeHarness,
   describeEval,
   type JudgeContext,
 } from "vitest-evals";
@@ -259,14 +236,25 @@ const appHarness = createHarness<AppEvalInput, AppOutput, AppEvalMetadata>({
   },
 });
 
+const judgeHarness = createJudgeHarness({
+  name: "app-rubric-judge-model",
+  run: async ({ prompt }, { signal }) =>
+    promptJudgeModel({ prompt, signal }),
+});
+
 const AppRubricJudge = createJudge(
   "AppRubricJudge",
   async (ctx: JudgeContext<AppEvalInput, AppOutput, AppEvalMetadata>) => {
-    const verdict = await promptJudgeModel({
+    if (!ctx.runJudge) {
+      throw new Error("AppRubricJudge requires a configured judgeHarness.");
+    }
+
+    const verdict = await ctx.runJudge({
       prompt: formatRubricPrompt({
         output: ctx.output,
         criteria: ctx.input.criteria,
       }),
+      responseFormat: { type: "json" },
     });
 
     return parseRubricVerdict(verdict);
@@ -277,6 +265,7 @@ describeEval(
   "app behavior",
   {
     harness: appHarness,
+    judgeHarness,
     judges: [AppRubricJudge],
     judgeThreshold: 0.75,
   },
@@ -332,7 +321,21 @@ In practice, this is usually most useful for factuality, rubric, or grounded
 answer checks:
 
 ```ts
-await expect(result).toSatisfyJudge(FactualityJudge);
+import { openai } from "@ai-sdk/openai";
+import { aiSdkJudgeHarness } from "@vitest-evals/harness-ai-sdk";
+import { expect } from "vitest";
+import { FactualityJudge } from "vitest-evals";
+
+const judgeHarness = aiSdkJudgeHarness({
+  model: openai("gpt-4.1-mini"),
+  temperature: 0,
+});
+const factualityJudge = FactualityJudge({ judgeHarness });
+
+await expect(result).toSatisfyJudge(factualityJudge, {
+  expected: "Paris is the capital of France.",
+  threshold: 0.6,
+});
 ```
 
 For lower-level cases, the matcher also accepts raw values and synthetic judge
@@ -344,35 +347,74 @@ await expect({ status: "approved" }).toSatisfyJudge(MyJudge, {
 });
 ```
 
-Use `createJudge(...)` for custom judges so reporter output gets a stable
-label:
+Use the built-in factuality judge when you want a model-backed factuality grade
+over the normalized run:
 
 ```ts
-import { createJudge } from "vitest-evals";
+import { openai } from "@ai-sdk/openai";
+import { aiSdkJudgeHarness } from "@vitest-evals/harness-ai-sdk";
+import { FactualityJudge } from "vitest-evals";
 
-const FactualityJudge = createJudge(
-  "FactualityJudge",
-  async ({ output }) => {
-    const answer = output;
-    const verdict = await judgeFactuality(answer);
-
-    return {
-      score: verdict.score,
-      metadata: {
-        rationale: verdict.rationale,
-      },
-    };
-  },
-);
+export const judgeHarness = aiSdkJudgeHarness({
+  model: openai("gpt-4.1-mini"),
+  temperature: 0,
+});
+export const factualityJudge = FactualityJudge({ judgeHarness });
 ```
 
-LLM-backed judges should provide their own judge prompt and rubric text.
-`vitest-evals` does not prescribe a rubric schema, scoring scale, model
-provider, or parser; those stay in the judge. When multiple judges share a
-reusable judge-side provider helper, use the provider-helper overload of
-`createJudge(...)` so run-scoped options such as abort signals stay curried.
-Calling `harness.run(...)` from a judge executes the application again, so use
-that only when a second run is intentional.
+For custom judge providers, create a dedicated judge harness with the same
+prompt contract:
+
+```ts
+import {
+  createJudgeHarness,
+  FactualityJudge,
+  type JudgeHarness,
+} from "vitest-evals";
+import { callJudgeModel } from "./judgeModel";
+
+export const judgeHarness: JudgeHarness = createJudgeHarness({
+  name: "factuality-judge-model",
+  run: async ({ system, prompt }, { signal }) =>
+    callJudgeModel({ system, prompt, signal }),
+});
+
+export const factualityJudge = FactualityJudge({ judgeHarness });
+```
+
+Configure that judge harness once and reuse the same judge with any app
+harness:
+
+```ts
+import { describeEval } from "vitest-evals";
+import { aiSdkRefundHarness } from "./aiSdkRefundHarness";
+import { piRefundHarness } from "./piRefundHarness";
+import { factualityJudge } from "./sharedJudges";
+
+describeEval("ai sdk refund agent", {
+  harness: aiSdkRefundHarness,
+  judges: [factualityJudge],
+});
+
+describeEval("pi refund agent", {
+  harness: piRefundHarness,
+  judges: [factualityJudge],
+});
+```
+
+Use `createJudge(...)` for custom judges so reporter output gets a stable
+label. Custom LLM-backed judges should provide their own judge prompt, rubric
+text, and parser, then call `ctx.runJudge(...)` for the provider-specific model
+request. Bind a reusable default with `createJudge({ name, judgeHarness,
+assess })` or pass `judgeHarness` on the matcher or suite. Core curries the
+matcher, judge, or explicit suite `judgeHarness` into that function with the
+current run's abort signal. Matcher options win over a judge default, and a
+judge default wins over the suite default. Explicit matcher calls can also
+reuse a single unambiguous judge-level harness from the suite's automatic
+judges, but automatic judges do not inherit inferred harnesses from sibling
+judges. Leave `judgeHarness` unset for suites that only use deterministic
+judges. Calling `harness.run(...)` from a judge executes the application again,
+so use that only when a second run is intentional.
 
 For an `EvalHarnessRun` returned by fixture `run(...)`,
 `toSatisfyJudge(...)` uses the run's typed `output` and reuses the registered
@@ -390,6 +432,4 @@ When a judge needs richer normalized context or the configured suite harness,
 type it with `JudgeContext`.
 
 When you only need deterministic contract checks, built-ins such as
-`StructuredOutputJudge()` and `ToolCallJudge()` are still available. The primary
-documentation examples intentionally use factuality/rubric judges because those
-match the product's LLM-as-a-judge direction.
+`StructuredOutputJudge()` and `ToolCallJudge()` are still available.

--- a/packages/vitest-evals/src/harness.test.ts
+++ b/packages/vitest-evals/src/harness.test.ts
@@ -2,12 +2,14 @@ import { beforeEach, expect, test, vi } from "vitest";
 import {
   assistantMessages,
   createJudge,
+  createJudgeHarness,
   createHarness,
   describeEval,
   type JudgeContext,
   type JudgeAssertionOptions,
   type JudgeOptions,
   type JudgeAssessorOptions,
+  type JudgeHarness,
   StructuredOutputJudge,
   ToolCallJudge,
   toolCalls,
@@ -96,6 +98,27 @@ const stringOutputJudge = createJudge(
     score: output.length > 0 ? 1 : 0,
   }),
 );
+const typedJudgeHarness = {} as JudgeHarness;
+const requiredParamJudgeWithHarness = {
+  ...requiredParamJudge,
+  judgeHarness: typedJudgeHarness,
+};
+const stringOutputJudgeWithHarness = {
+  ...stringOutputJudge,
+  judgeHarness: typedJudgeHarness,
+};
+const configObjectJudgeWithHarness = createJudge({
+  name: "ConfigObjectJudge",
+  judgeHarness: typedJudgeHarness,
+  async assess({
+    expectedStatus,
+    output,
+  }: JudgeOptions<{ expectedStatus: string }, unknown, RefundOutput>) {
+    return {
+      score: output.status === expectedStatus ? 1 : 0,
+    };
+  },
+});
 
 async function assertMatcherTypes(result: HarnessRun<RefundOutput>) {
   await expect(result).toSatisfyJudge(requiredParamJudge, {
@@ -105,8 +128,17 @@ async function assertMatcherTypes(result: HarnessRun<RefundOutput>) {
   // @ts-expect-error required custom judge params must be provided explicitly.
   await expect(result).toSatisfyJudge(requiredParamJudge);
 
+  // @ts-expect-error default judge harnesses must not erase required custom params.
+  await expect(result).toSatisfyJudge(requiredParamJudgeWithHarness);
+
+  // @ts-expect-error object-form judge harnesses must not erase required custom params.
+  await expect(result).toSatisfyJudge(configObjectJudgeWithHarness);
+
   // @ts-expect-error the matcher output type must satisfy the judge output type.
   await expect(result).toSatisfyJudge(stringOutputJudge);
+
+  // @ts-expect-error default judge harnesses must not erase output constraints.
+  await expect(result).toSatisfyJudge(stringOutputJudgeWithHarness);
 }
 
 void assertMatcherTypes;
@@ -1269,6 +1301,39 @@ test("createJudge assigns a stable custom name", async () => {
   await expect({
     status: "approved",
   }).toSatisfyJudge(judge);
+});
+
+test("createJudge accepts a default judge harness in object form", async () => {
+  const judgeHarnessRun = vi.fn(async () => "approved");
+  const judgeHarness = createJudgeHarness({
+    name: "object-form-judge-harness",
+    run: judgeHarnessRun,
+  });
+  const judge = createJudge({
+    name: "ObjectFormJudge",
+    judgeHarness,
+    async assess(ctx: JudgeContext<unknown, RefundOutput>) {
+      const verdict = await ctx.runJudge?.({
+        prompt: `Judge refund status ${ctx.output.status}`,
+      });
+
+      return {
+        score: verdict === ctx.output.status ? 1 : 0,
+      };
+    },
+  });
+
+  await expect({
+    status: "approved",
+  }).toSatisfyJudge(judge);
+
+  expect(judge.name).toBe("ObjectFormJudge");
+  expect(judgeHarnessRun).toHaveBeenCalledWith(
+    expect.objectContaining({
+      prompt: "Judge refund status approved",
+    }),
+    expect.any(Object),
+  );
 });
 
 test("ToolCallJudge accepts string expected tools", async () => {

--- a/packages/vitest-evals/src/harness.ts
+++ b/packages/vitest-evals/src/harness.ts
@@ -709,6 +709,13 @@ export function messagesByRole(
   return session.messages.filter((message) => message.role === role);
 }
 
+function hasNonEmptyMessageContent(message: NormalizedMessage) {
+  return (
+    message.content !== undefined &&
+    (typeof message.content !== "string" || message.content.trim().length > 0)
+  );
+}
+
 /**
  * Returns every normalized system message from a session.
  *
@@ -749,6 +756,22 @@ export function userMessages(session: NormalizedSession) {
  */
 export function assistantMessages(session: NormalizedSession) {
   return messagesByRole(session, "assistant");
+}
+
+/**
+ * Returns the latest assistant message content, ignoring empty text messages.
+ *
+ * @param session - Normalized session produced by a harness run.
+ *
+ * @example
+ * ```ts
+ * const finalAnswer = latestAssistantMessageContent(result.session);
+ * ```
+ */
+export function latestAssistantMessageContent(session: NormalizedSession) {
+  return [...assistantMessages(session)]
+    .reverse()
+    .find(hasNonEmptyMessageContent)?.content;
 }
 
 /**

--- a/packages/vitest-evals/src/index.ts
+++ b/packages/vitest-evals/src/index.ts
@@ -19,6 +19,7 @@ import {
   userMessages,
 } from "./harness";
 import type {
+  CreateJudgeConfig,
   JudgeContext,
   Judge,
   JudgeAssessFn,
@@ -27,6 +28,8 @@ import type {
   JudgeOptions,
   JudgeResult,
 } from "./judges/types";
+import type { JudgeHarness } from "./judges/judgeHarness";
+import { createRunJudge } from "./judges/judgeHarness";
 import { wrapText } from "./wrapText";
 
 type EvalTaskMeta = {
@@ -50,6 +53,7 @@ type EvalTaskLike = {
 type RegisteredJudgeRunContext = {
   harness: Harness<any, any, any>;
   input: unknown;
+  judgeHarness?: JudgeHarness;
   metadata: HarnessMetadata;
   run: HarnessRun;
   signal?: AbortSignal;
@@ -58,7 +62,9 @@ type RegisteredJudgeRunContext = {
 type InternalEvalFixtures = {
   harness: Harness<any, any, any>;
   automaticJudges: Array<Judge<JudgeContext<any, any, any, any>>>;
+  judgeHarness?: JudgeHarness;
   judgeThreshold: number | null | undefined;
+  explicitJudgeHarness?: JudgeHarness;
   run: EvalRun<any, any, any>;
 };
 
@@ -220,6 +226,8 @@ export interface DescribeEvalOptions<
   harness: THarness;
   /** Automatic judges applied after each successful `run(...)`. */
   judges?: Array<Judge<JudgeContext<TInput, TOutput, TMetadata, THarness>>>;
+  /** Optional judge-side harness used only by judges that call `ctx.runJudge(...)`. */
+  judgeHarness?: JudgeHarness;
   /** Passing threshold for automatic suite-level judges. `null` disables fail-on-score. */
   judgeThreshold?: number | null;
   /** Skips the entire eval suite when the predicate returns true. */
@@ -254,6 +262,7 @@ type JudgeAssertionHarness<
 
 type JudgeAssertionReservedKey =
   | keyof JudgeContext<any, any, any, any>
+  | "judgeHarness"
   | "signal"
   | "threshold";
 
@@ -320,6 +329,8 @@ export type JudgeAssertionOptions<
   session?: HarnessRun["session"];
   /** Override or provide the harness associated with the judge context. */
   harness?: JudgeAssertionHarness<TJudgeOptions>;
+  /** Override or provide the judge harness for judges that call `ctx.runJudge(...)`. */
+  judgeHarness?: JudgeHarness;
   /** Passing threshold for the explicit matcher. `null` records the score without failing. */
   threshold?: number | null;
 };
@@ -367,9 +378,19 @@ const evalTest = test
     [] as Array<Judge<JudgeContext<any, any, any, any>>>,
   )
   .extend("judgeThreshold", undefined as number | null | undefined)
+  .extend("judgeHarness", undefined as JudgeHarness | undefined)
+  .extend("explicitJudgeHarness", undefined as JudgeHarness | undefined)
   .extend(
     "run",
-    async ({ automaticJudges, harness, judgeThreshold, signal, task }) => {
+    async ({
+      automaticJudges,
+      explicitJudgeHarness,
+      harness,
+      judgeHarness,
+      judgeThreshold,
+      signal,
+      task,
+    }) => {
       return async (input: unknown, options?: EvalRunOptions) => {
         const resolvedHarness = harness as Harness<
           unknown,
@@ -404,6 +425,7 @@ const evalTest = test
               partialRun,
               resolvedHarness,
               input,
+              explicitJudgeHarness,
               metadata,
               signal,
             );
@@ -417,7 +439,14 @@ const evalTest = test
         }
 
         setHarnessMeta(task, resolvedHarness.name, run);
-        recordJudgeRunContext(run, resolvedHarness, input, metadata, signal);
+        recordJudgeRunContext(
+          run,
+          resolvedHarness,
+          input,
+          explicitJudgeHarness,
+          metadata,
+          signal,
+        );
 
         if (automaticJudges.length > 0) {
           await applyAutomaticJudges(
@@ -426,6 +455,7 @@ const evalTest = test
             judgeThreshold,
             resolvedHarness,
             input,
+            judgeHarness,
             metadata,
             run,
             signal,
@@ -454,6 +484,7 @@ expect.extend({
       {}) as JudgeAssertionOptions<TJudgeOptions>;
     const judgeOptions = buildJudgeAssertionOptions(
       received,
+      judge,
       context,
       isEvalTaskLike(this.task) ? this.task : undefined,
     );
@@ -511,18 +542,42 @@ function formatJudgeOutputForMessage(output: JsonValue | undefined) {
  *
  * @example
  * ```ts
+ * import { piAiHarness } from "@vitest-evals/harness-pi-ai";
+ * import { getModel } from "@mariozechner/pi-ai";
+ * import { piAiJudgeHarness } from "@vitest-evals/harness-pi-ai";
+ * import { expect } from "vitest";
+ * import {
+ *   describeEval,
+ *   FactualityJudge,
+ *   ToolCallJudge,
+ *   toolCalls,
+ * } from "vitest-evals";
+ * import { createRefundAgent } from "../src/refundAgent";
+ *
+ * const judgeHarness = piAiJudgeHarness({
+ *   model: getModel("anthropic", "claude-sonnet-4-5"),
+ *   temperature: 0,
+ * });
+ *
  * describeEval("refund agent", {
  *   harness: piAiHarness({
  *     agent: () => createRefundAgent(),
  *   }),
+ *   judgeHarness,
  *   judges: [ToolCallJudge()],
  * }, (it) => {
  *   it("approves a refundable invoice", async ({ run }) => {
- *     const result = await run("Refund invoice inv_123");
+ *     const result = await run("Refund invoice inv_123", {
+ *       metadata: {
+ *         expected: "Invoice inv_123 should be refunded.",
+ *       },
+ *     });
  *
  *     expect(result.output).toMatchObject({ status: "approved" });
  *     expect(toolCalls(result.session)).toHaveLength(2);
- *     await expect(result).toSatisfyJudge(FactualityJudge);
+ *     await expect(result).toSatisfyJudge(FactualityJudge(), {
+ *       threshold: 0.6,
+ *     });
  *   });
  * });
  * ```
@@ -547,11 +602,16 @@ export function describeEval<THarness extends Harness<any, any, any>>(
   const suite = options.skipIf ? describe.skipIf(options.skipIf()) : describe;
 
   return suite(name, () => {
+    const automaticJudges = (options.judges ?? []) as Array<
+      Judge<JudgeContext<any, any, any, any>>
+    >;
+    const explicitJudgeHarness =
+      options.judgeHarness ?? resolveDefaultJudgeHarness(automaticJudges);
     const it = evalTest.override({
       harness: options.harness,
-      automaticJudges: (options.judges ?? []) as Array<
-        Judge<JudgeContext<any, any, any, any>>
-      >,
+      automaticJudges,
+      judgeHarness: options.judgeHarness,
+      explicitJudgeHarness,
       judgeThreshold: options.judgeThreshold,
     }) as unknown as EvalTestAPI<
       HarnessInput<THarness>,
@@ -581,6 +641,7 @@ async function applyAutomaticJudges<
   threshold: number | null | undefined,
   harness: THarness,
   input: TInput,
+  judgeHarness: JudgeHarness | undefined,
   metadata: TMetadata,
   run: HarnessRun<TOutput>,
   signal?: AbortSignal,
@@ -588,6 +649,10 @@ async function applyAutomaticJudges<
   const runToolCalls = toolCalls(run.session);
   const scores = await Promise.all(
     judges.map((judge) => {
+      const runJudge = createRunJudge(
+        resolveJudgeHarnessForJudge(judge, judgeHarness),
+        signal,
+      );
       const judgeOptions = {
         input,
         output: run.output,
@@ -597,6 +662,7 @@ async function applyAutomaticJudges<
         session: run.session,
         signal,
         harness,
+        runJudge,
       } as unknown as JudgeContext<TInput, TOutput, TMetadata, THarness>;
 
       return Promise.resolve(judge.assess(judgeOptions));
@@ -652,12 +718,14 @@ function recordJudgeRunContext<
   run: HarnessRun<TOutput>,
   harness: Harness<TInput, TOutput, TMetadata>,
   input: TInput,
+  judgeHarness: JudgeHarness | undefined,
   metadata: TMetadata,
   signal?: AbortSignal,
 ) {
   const context = {
     harness,
     input,
+    judgeHarness,
     metadata,
     run,
     signal,
@@ -756,6 +824,7 @@ function buildJudgeAssertionOptions<
   TJudgeOptions extends JudgeContext<any, any, any, any> = JudgeContext,
 >(
   received: unknown,
+  judge: Judge<TJudgeOptions>,
   options: Omit<JudgeAssertionOptions<TJudgeOptions>, "threshold">,
   task?: EvalTaskLike,
 ): TJudgeOptions {
@@ -765,6 +834,10 @@ function buildJudgeAssertionOptions<
     task,
   );
   const harness = options.harness ?? registeredContext?.harness;
+  const judgeHarness =
+    options.judgeHarness ??
+    resolveJudgeHarnessForJudge(judge, registeredContext?.judgeHarness);
+  const runJudge = createRunJudge(judgeHarness, registeredContext?.signal);
   const signal = registeredContext?.signal;
   const metadata = (options.metadata ??
     registeredContext?.metadata ??
@@ -797,8 +870,13 @@ function buildJudgeAssertionOptions<
   );
   const resolvedToolCalls = options.toolCalls ?? toolCalls(run.session);
 
+  const { judgeHarness: _judgeHarness, ...judgeParams } = options as Record<
+    string,
+    unknown
+  >;
+
   return {
-    ...(options as Record<string, unknown>),
+    ...judgeParams,
     input: resolvedInput,
     output,
     metadata,
@@ -807,7 +885,32 @@ function buildJudgeAssertionOptions<
     signal,
     toolCalls: resolvedToolCalls,
     harness,
+    runJudge,
   } as unknown as TJudgeOptions;
+}
+
+function resolveJudgeHarnessForJudge(
+  judge: Pick<Judge<any>, "judgeHarness">,
+  fallback: JudgeHarness | undefined,
+) {
+  return judge.judgeHarness ?? fallback;
+}
+
+function resolveDefaultJudgeHarness(
+  judges: Array<Pick<Judge<any>, "judgeHarness">>,
+) {
+  const configured = judges
+    .map((judge) => judge.judgeHarness)
+    .filter((judgeHarness): judgeHarness is JudgeHarness =>
+      Boolean(judgeHarness),
+    );
+  const [first] = configured;
+
+  if (!first || configured.some((judgeHarness) => judgeHarness !== first)) {
+    return undefined;
+  }
+
+  return first;
 }
 
 function resolveRegisteredJudgeRunContext<
@@ -1060,25 +1163,15 @@ export function formatScores(scores: (JudgeResult & { name: string })[]) {
  * );
  * ```
  *
- * @example
- * ```ts
- * const ModelRubricJudge = createJudge(
- *   "ModelRubricJudge",
- *   openAiRubricAssessor,
- *   async ({ output }, assessor) => {
- *     const verdict = await assessor.assess(JSON.stringify(output));
- *
- *     return {
- *       score: verdict.passed ? 1 : 0,
- *       metadata: { rationale: verdict.rationale },
- *     };
- *   },
- * );
- * ```
+ * For LLM-backed judges, prefer the object form with `ctx.runJudge(...)` so
+ * provider-specific model configuration stays in the judge harness.
  */
 export function createJudge<TOptions extends JudgeContext<any, any, any, any>>(
   name: string,
   assess: JudgeAssessFn<TOptions>,
+): Judge<TOptions>;
+export function createJudge<TOptions extends JudgeContext<any, any, any, any>>(
+  config: CreateJudgeConfig<TOptions>,
 ): Judge<TOptions>;
 export function createJudge<
   TOptions extends JudgeContext<any, any, any, any>,
@@ -1094,10 +1187,20 @@ export function createJudge<
   TInput,
   TOutput,
 >(
-  name: string,
-  assessOrAssessor: JudgeAssessFn<TOptions> | JudgeAssessor<TInput, TOutput>,
+  nameOrConfig: string | CreateJudgeConfig<TOptions>,
+  assessOrAssessor?: JudgeAssessFn<TOptions> | JudgeAssessor<TInput, TOutput>,
   assess?: JudgeAssessWithAssessorFn<TOptions, TInput, TOutput>,
 ): Judge<TOptions> {
+  if (typeof nameOrConfig !== "string") {
+    return {
+      name: nameOrConfig.name,
+      judgeHarness: nameOrConfig.judgeHarness,
+      assess: nameOrConfig.assess,
+    };
+  }
+
+  const name = nameOrConfig;
+
   if (!assess) {
     return {
       name,
@@ -1154,6 +1257,22 @@ export {
 } from "./harness";
 
 export {
+  FactualityJudge,
+  type FactualityJudgeChoice,
+  type FactualityJudgeConfig,
+  type FactualityJudgeExpected,
+  type FactualityJudgeOptions,
+  type FactualityJudgePrompt,
+  type FactualityJudgeVerdict,
+  createJudgeHarness,
+  runJudgeHarness,
+  type CreateJudgeHarnessOptions,
+  type CreateJudgeHarnessRunOptions,
+  type JudgeHarness,
+  type JudgeHarnessInput,
+  type JudgeHarnessOutput,
+  type RunJudge,
+  type RunJudgeOptions,
   StructuredOutputJudge,
   type StructuredOutputJudgeConfig,
   type StructuredOutputJudgeExpected,
@@ -1165,6 +1284,7 @@ export {
 } from "./judges";
 export type {
   BoundJudgeAssessor,
+  CreateJudgeConfig,
   Judge,
   JudgeAssessFn,
   JudgeAssessWithAssessorFn,

--- a/packages/vitest-evals/src/index.ts
+++ b/packages/vitest-evals/src/index.ts
@@ -19,7 +19,6 @@ import {
   userMessages,
 } from "./harness";
 import type {
-  CreateJudgeConfig,
   JudgeContext,
   Judge,
   JudgeAssessFn,
@@ -80,6 +79,14 @@ type HarnessOutput<THarness extends Harness<any, any, any>> =
   THarness extends Harness<any, infer TOutput, any>
     ? TOutput
     : JsonValue | undefined;
+
+type CreateJudgeConfig<
+  TOptions extends JudgeContext<any, any, any, any> = JudgeContext,
+> = {
+  name: string;
+  judgeHarness?: JudgeHarness;
+  assess: JudgeAssessFn<TOptions>;
+};
 
 declare const evalHarnessRunBrand: unique symbol;
 
@@ -1288,7 +1295,6 @@ export {
 } from "./judges";
 export type {
   BoundJudgeAssessor,
-  CreateJudgeConfig,
   Judge,
   JudgeAssessFn,
   JudgeAssessWithAssessorFn,

--- a/packages/vitest-evals/src/index.ts
+++ b/packages/vitest-evals/src/index.ts
@@ -10,10 +10,10 @@ import type {
   ToolCallRecord,
 } from "./harness";
 import {
-  assistantMessages,
   getHarnessRunFromError,
   isHarnessRun,
   isNormalizedSession,
+  latestAssistantMessageContent,
   normalizeContent,
   toolCalls,
   userMessages,
@@ -1075,21 +1075,10 @@ function inferJudgeOutputValue(
 }
 
 function resolveAssistantOutput(session: NormalizedSession) {
-  const assistantContent = [...assistantMessages(session)]
-    .reverse()
-    .find(hasAssistantOutputContent);
-  return assistantContent?.content !== undefined
-    ? normalizeContent(assistantContent.content)
+  const assistantContent = latestAssistantMessageContent(session);
+  return assistantContent !== undefined
+    ? normalizeContent(assistantContent)
     : undefined;
-}
-
-function hasAssistantOutputContent(
-  message: NormalizedSession["messages"][number],
-) {
-  return (
-    message.content !== undefined &&
-    (typeof message.content !== "string" || message.content.trim().length > 0)
-  );
 }
 
 function normalizeJudgeJsonValue(value: unknown): JsonValue | undefined {
@@ -1241,6 +1230,7 @@ export {
   attachHarnessRunToError,
   createHarness,
   getHarnessRunFromError,
+  latestAssistantMessageContent,
   messagesByRole,
   normalizeHarnessRun,
   systemMessages,

--- a/packages/vitest-evals/src/index.ts
+++ b/packages/vitest-evals/src/index.ts
@@ -1173,6 +1173,10 @@ export function createJudge<TOptions extends JudgeContext<any, any, any, any>>(
 export function createJudge<TOptions extends JudgeContext<any, any, any, any>>(
   config: CreateJudgeConfig<TOptions>,
 ): Judge<TOptions>;
+/**
+ * @deprecated Prefer `createJudge({ name, judgeHarness, assess })` and call
+ * `ctx.runJudge(...)` from LLM-backed judges.
+ */
 export function createJudge<
   TOptions extends JudgeContext<any, any, any, any>,
   TInput,

--- a/packages/vitest-evals/src/internal/scoring.ts
+++ b/packages/vitest-evals/src/internal/scoring.ts
@@ -1,11 +1,11 @@
-import type { ToolCallRecord } from "../harness";
+import type { JsonValue, ToolCallRecord } from "../harness";
 
 export type ToolCallLike = ToolCallRecord;
 
 export type ScoreMetadata = {
   rationale?: string;
-  output?: unknown;
-} & Record<string, unknown>;
+  output?: JsonValue;
+} & Record<string, JsonValue | undefined>;
 
 export type ScoredResult = {
   score: number | null;

--- a/packages/vitest-evals/src/internal/toolCallScorer.ts
+++ b/packages/vitest-evals/src/internal/toolCallScorer.ts
@@ -116,7 +116,10 @@ function evaluateOrderedTools(
           metadata: {
             rationale: `Tool '${expectedTool.name}' called with incorrect arguments at position ${expectedIndex + 1} (${expectedIndex}/${expected.length} tools matched correctly)`,
             expected: normalizeContent(expectedTool.arguments),
-            actual: normalizeContent(actualTool.arguments),
+            actual:
+              actualTool.arguments === undefined
+                ? undefined
+                : normalizeContent(actualTool.arguments),
             matched: expectedIndex,
             total: expected.length,
           },

--- a/packages/vitest-evals/src/internal/toolCallScorer.ts
+++ b/packages/vitest-evals/src/internal/toolCallScorer.ts
@@ -1,4 +1,5 @@
 import type { BaseScorerOptions, ScoredResult, ToolCallLike } from "./scoring";
+import { normalizeContent } from "../harness";
 import {
   createMatcher,
   type BaseMatcherConfig,
@@ -114,8 +115,8 @@ function evaluateOrderedTools(
           score: expectedIndex / expected.length,
           metadata: {
             rationale: `Tool '${expectedTool.name}' called with incorrect arguments at position ${expectedIndex + 1} (${expectedIndex}/${expected.length} tools matched correctly)`,
-            expected: expectedTool.arguments,
-            actual: actualTool.arguments,
+            expected: normalizeContent(expectedTool.arguments),
+            actual: normalizeContent(actualTool.arguments),
             matched: expectedIndex,
             total: expected.length,
           },

--- a/packages/vitest-evals/src/judges/factualityJudge.test.ts
+++ b/packages/vitest-evals/src/judges/factualityJudge.test.ts
@@ -1,0 +1,625 @@
+import { beforeEach, expect, test, vi } from "vitest";
+import {
+  createHarness,
+  createJudge,
+  createJudgeHarness,
+  describeEval,
+  FactualityJudge,
+  type CreateJudgeHarnessOptions,
+  type HarnessRun,
+  type JsonValue,
+  type RunJudge,
+} from "../index";
+
+const factualityHarness = createHarness<string, string, { expected?: string }>({
+  name: "qa-harness",
+  run: async () => ({
+    output: "Paris is the capital of France.",
+  }),
+});
+
+const automaticJudgeHarnessRun = vi.fn();
+const contextualJudgeHarnessRun = vi.fn();
+const configuredJudgeHarnessRun = vi.fn();
+const suiteDefaultJudgeHarnessRun = vi.fn();
+const judgeOverrideHarnessRun = vi.fn();
+const inferredSuiteJudgeHarnessRun = vi.fn();
+const automaticJudgeHarness = createMockJudgeHarness(automaticJudgeHarnessRun);
+const contextualJudgeHarness = createMockJudgeHarness(
+  contextualJudgeHarnessRun,
+);
+const configuredJudgeHarness = createMockJudgeHarness(
+  configuredJudgeHarnessRun,
+);
+const suiteDefaultJudgeHarness = createMockJudgeHarness(
+  suiteDefaultJudgeHarnessRun,
+);
+const judgeOverrideHarness = createMockJudgeHarness(judgeOverrideHarnessRun);
+const inferredSuiteJudgeHarness = createMockJudgeHarness(
+  inferredSuiteJudgeHarnessRun,
+);
+const leakedAutomaticJudgeRunJudge = vi.fn();
+
+beforeEach(() => {
+  automaticJudgeHarnessRun.mockReset();
+  automaticJudgeHarnessRun.mockResolvedValue({
+    choice: "C",
+    rationale: "The submitted answer matches the expert answer.",
+  });
+  contextualJudgeHarnessRun.mockReset();
+  contextualJudgeHarnessRun.mockResolvedValue({
+    choice: "C",
+    rationale: "The submitted answer matches the expert answer.",
+  });
+  configuredJudgeHarnessRun.mockReset();
+  configuredJudgeHarnessRun.mockResolvedValue({
+    choice: "C",
+    rationale: "The submitted answer matches the expert answer.",
+  });
+  suiteDefaultJudgeHarnessRun.mockReset();
+  suiteDefaultJudgeHarnessRun.mockResolvedValue({
+    choice: "D",
+    rationale: "The suite default should not be used.",
+  });
+  judgeOverrideHarnessRun.mockReset();
+  judgeOverrideHarnessRun.mockResolvedValue({
+    choice: "C",
+    rationale: "The per-judge harness is used.",
+  });
+  inferredSuiteJudgeHarnessRun.mockReset();
+  inferredSuiteJudgeHarnessRun.mockResolvedValue({
+    choice: "C",
+    rationale: "The inferred suite harness is used.",
+  });
+  leakedAutomaticJudgeRunJudge.mockReset();
+});
+
+describeEval(
+  "factuality judge",
+  {
+    harness: factualityHarness,
+    judgeHarness: automaticJudgeHarness,
+    judges: [FactualityJudge()],
+  },
+  (it) => {
+    it("uses metadata expected values with any harness output", async ({
+      run,
+      task,
+    }) => {
+      await run("What is the capital of France?", {
+        metadata: {
+          expected: "Paris is the capital of France.",
+        },
+      });
+
+      expect(automaticJudgeHarnessRun).toHaveBeenCalledWith(
+        expect.objectContaining({
+          system: expect.stringContaining("comparing factual content"),
+          prompt: expect.stringContaining("What is the capital of France?"),
+          responseFormat: expect.objectContaining({
+            type: "json",
+            schema: expect.objectContaining({
+              type: "object",
+            }),
+          }),
+        }),
+        expect.objectContaining({
+          signal: expect.any(AbortSignal),
+        }),
+      );
+      expect(task.meta.eval?.scores).toEqual([
+        {
+          name: "FactualityJudge",
+          score: 1,
+          metadata: {
+            rationale: "The submitted answer matches the expert answer.",
+            choice: "C",
+          },
+        },
+      ]);
+    });
+  },
+);
+
+describeEval(
+  "factuality judge configured harness",
+  {
+    harness: factualityHarness,
+    judges: [FactualityJudge({ judgeHarness: configuredJudgeHarness })],
+  },
+  (it) => {
+    it("uses a judge-level judge harness for automatic assertions", async ({
+      run,
+    }) => {
+      await run("What is the capital of France?", {
+        metadata: {
+          expected: "Paris is the capital of France.",
+        },
+      });
+
+      expect(configuredJudgeHarnessRun).toHaveBeenCalledTimes(1);
+    });
+  },
+);
+
+describeEval(
+  "factuality judge configured harness precedence",
+  {
+    harness: factualityHarness,
+    judgeHarness: suiteDefaultJudgeHarness,
+    judges: [FactualityJudge({ judgeHarness: judgeOverrideHarness })],
+  },
+  (it) => {
+    it("uses a judge-level judge harness before the suite default", async ({
+      run,
+    }) => {
+      await run("What is the capital of France?", {
+        metadata: {
+          expected: "Paris is the capital of France.",
+        },
+      });
+
+      expect(judgeOverrideHarnessRun).toHaveBeenCalledTimes(1);
+      expect(suiteDefaultJudgeHarnessRun).not.toHaveBeenCalled();
+    });
+  },
+);
+
+describeEval(
+  "factuality judge inferred suite harness",
+  {
+    harness: factualityHarness,
+    judges: [
+      FactualityJudge({ judgeHarness: inferredSuiteJudgeHarness }),
+      createJudge("NoInferredAutomaticJudgeHarness", (ctx) => {
+        leakedAutomaticJudgeRunJudge(ctx.runJudge);
+
+        return {
+          score: ctx.runJudge ? 0 : 1,
+          metadata: {
+            rationale:
+              "Automatic judges do not inherit inferred harnesses from sibling judges.",
+          },
+        };
+      }),
+    ],
+  },
+  (it) => {
+    it("reuses an unambiguous automatic judge harness for explicit assertions", async ({
+      run,
+      task,
+    }) => {
+      const result = await run("What is the capital of France?", {
+        metadata: {
+          expected: "Paris is the capital of France.",
+        },
+      });
+
+      await expect(result).toSatisfyJudge(FactualityJudge(), {
+        expected: "Paris is the capital of France.",
+        threshold: 0.5,
+      });
+
+      expect(inferredSuiteJudgeHarnessRun).toHaveBeenCalledTimes(2);
+      expect(leakedAutomaticJudgeRunJudge).toHaveBeenCalledWith(undefined);
+      expect(task.meta.eval?.scores).toEqual([
+        expect.objectContaining({
+          name: "FactualityJudge",
+          score: 1,
+        }),
+        expect.objectContaining({
+          name: "NoInferredAutomaticJudgeHarness",
+          score: 1,
+        }),
+        expect.objectContaining({
+          name: "FactualityJudge",
+          score: 1,
+        }),
+      ]);
+    });
+  },
+);
+
+describeEval(
+  "factuality judge context",
+  {
+    harness: factualityHarness,
+    judgeHarness: contextualJudgeHarness,
+  },
+  (it) => {
+    it("reuses the suite judge harness for explicit assertions", async ({
+      run,
+    }) => {
+      const result = await run("What is the capital of France?");
+
+      await expect(result).toSatisfyJudge(FactualityJudge(), {
+        expected: "Paris is the capital of France.",
+        threshold: 0.5,
+      });
+
+      expect(contextualJudgeHarnessRun).toHaveBeenCalledTimes(1);
+    });
+  },
+);
+
+test("FactualityJudge accepts a configured judge harness for explicit matchers", async () => {
+  const judgeHarnessRun = vi.fn(async () => ({
+    choice: "C",
+    rationale: "The submitted answer matches.",
+  }));
+  const judgeHarness = createMockJudgeHarness(judgeHarnessRun);
+
+  await expect("Paris").toSatisfyJudge(FactualityJudge({ judgeHarness }), {
+    input: "What is the capital of France?",
+    expected: "Paris is the capital of France.",
+    threshold: 0.5,
+  });
+
+  expect(judgeHarnessRun).toHaveBeenCalledTimes(1);
+});
+
+test("FactualityJudge matcher options override a configured judge harness", async () => {
+  const configuredRun = vi.fn(async () => ({
+    choice: "D",
+    rationale: "The configured harness should not be used.",
+  }));
+  const explicitRun = vi.fn(async () => ({
+    choice: "C",
+    rationale: "The explicit harness is used.",
+  }));
+  const configuredHarness = createMockJudgeHarness(configuredRun);
+  const explicitHarness = createMockJudgeHarness(explicitRun);
+
+  await expect("Paris").toSatisfyJudge(
+    FactualityJudge({ judgeHarness: configuredHarness }),
+    {
+      input: "What is the capital of France?",
+      expected: "Paris is the capital of France.",
+      judgeHarness: explicitHarness,
+      threshold: 0.5,
+    },
+  );
+
+  expect(explicitRun).toHaveBeenCalledTimes(1);
+  expect(configuredRun).not.toHaveBeenCalled();
+});
+
+test("FactualityJudge accepts explicit matcher expected values and judge harness", async () => {
+  const judgeHarnessRun = vi.fn(async () => ({
+    choice: "B",
+    rationale: "The submitted answer is a supported superset.",
+  }));
+  const judgeHarness = createMockJudgeHarness(judgeHarnessRun);
+
+  await expect({
+    answer: "Paris",
+  }).toSatisfyJudge(FactualityJudge(), {
+    input: "What is the capital of France?",
+    expected: {
+      answer: "Paris",
+    },
+    judgeHarness,
+    threshold: 0.5,
+  });
+
+  expect(judgeHarnessRun).toHaveBeenCalledWith(
+    expect.objectContaining({
+      prompt: expect.stringContaining(
+        '"expert_answer": {\n    "answer": "Paris"\n  }',
+      ),
+    }),
+    expect.objectContaining({ signal: undefined }),
+  );
+});
+
+test("FactualityJudge requires a judge harness when expected values are present", async () => {
+  const run = createRun("Paris");
+
+  await expect(
+    FactualityJudge().assess({
+      input: "What is the capital of France?",
+      output: run.output,
+      expected: "Paris is the capital of France.",
+      metadata: {},
+      run,
+      session: run.session,
+      toolCalls: [],
+      harness: factualityHarness,
+    }),
+  ).rejects.toThrow("FactualityJudge requires a judgeHarness");
+});
+
+test("FactualityJudge uses a configured judge harness when assess is called directly", async () => {
+  const judgeHarnessRun = vi.fn(async () => ({
+    choice: "C",
+    rationale: "The submitted answer matches.",
+  }));
+  const run = createRun("Paris");
+
+  const result = await FactualityJudge({
+    judgeHarness: createMockJudgeHarness(judgeHarnessRun),
+  }).assess({
+    input: "What is the capital of France?",
+    output: run.output,
+    expected: "Paris is the capital of France.",
+    metadata: {},
+    run,
+    session: run.session,
+    toolCalls: [],
+    harness: factualityHarness,
+  });
+
+  expect(result.score).toBe(1);
+  expect(judgeHarnessRun).toHaveBeenCalledTimes(1);
+});
+
+test("FactualityJudge can be shared across different app harnesses and judge harnesses", async () => {
+  const textJudgeHarnessRun = vi.fn(async () => ({
+    choice: "C",
+    rationale: "The submitted answer matches.",
+  }));
+  const objectJudgeHarnessRun = vi.fn(async () => ({
+    choice: "B",
+    rationale: "The submitted answer is a supported superset.",
+  }));
+  const factualityJudge = FactualityJudge();
+  const objectHarness = createHarness<
+    { question: string },
+    { answer: string },
+    { expected?: string }
+  >({
+    name: "object-qa-harness",
+    run: async () => ({
+      output: {
+        answer: "Paris",
+      },
+    }),
+  });
+  const textRun = createRun("Paris is the capital of France.");
+  const objectRun = createRun({ answer: "Paris" });
+
+  const textResult = await factualityJudge.assess({
+    input: "What is the capital of France?",
+    output: textRun.output,
+    metadata: {
+      expected: "Paris is the capital of France.",
+    },
+    run: textRun,
+    session: textRun.session,
+    toolCalls: [],
+    harness: factualityHarness,
+    runJudge: createMockRunJudge(textJudgeHarnessRun),
+  });
+  const objectResult = await factualityJudge.assess({
+    input: {
+      question: "What is the capital of France?",
+    },
+    output: objectRun.output,
+    metadata: {
+      expected: "Paris is the capital of France.",
+    },
+    run: objectRun,
+    session: objectRun.session,
+    toolCalls: [],
+    harness: objectHarness,
+    runJudge: createMockRunJudge(objectJudgeHarnessRun),
+  });
+
+  expect(textResult.score).toBe(1);
+  expect(objectResult.score).toBe(0.6);
+  expect(textJudgeHarnessRun).toHaveBeenCalledTimes(1);
+  expect(objectJudgeHarnessRun).toHaveBeenCalledTimes(1);
+});
+
+test("FactualityJudge parses JSON text returned by the judge harness", async () => {
+  const runJudge = createMockRunJudge(
+    async () =>
+      '```json\n{"choice":"C","rationale":"The submitted answer matches."}\n```',
+  );
+  const run = createRun("Paris is the capital of France.");
+
+  const result = await FactualityJudge().assess({
+    input: "What is the capital of France?",
+    output: run.output,
+    expected: "Paris is the capital of France.",
+    metadata: {},
+    run,
+    session: run.session,
+    toolCalls: [],
+    harness: factualityHarness,
+    runJudge,
+  });
+
+  expect(result).toEqual({
+    score: 1,
+    metadata: {
+      rationale: "The submitted answer matches.",
+      choice: "C",
+    },
+  });
+});
+
+test("FactualityJudge skips blank assistant transcript output", async () => {
+  const judgeHarnessRun = vi.fn(async () => ({
+    choice: "C",
+    rationale: "The submitted answer matches the expert answer.",
+  }));
+  const run = {
+    output: undefined,
+    session: {
+      messages: [
+        {
+          role: "user",
+          content: "What is the capital of France?",
+        },
+        {
+          role: "assistant",
+          content: "Paris is the capital of France.",
+        },
+        {
+          role: "assistant",
+          content: "   ",
+        },
+      ],
+    },
+    usage: {},
+    errors: [],
+  } satisfies HarnessRun<undefined>;
+
+  const result = await FactualityJudge().assess({
+    input: "What is the capital of France?",
+    output: run.output,
+    expected: "Paris is the capital of France.",
+    metadata: {},
+    run,
+    session: run.session,
+    toolCalls: [],
+    harness: factualityHarness,
+    runJudge: createMockRunJudge(judgeHarnessRun),
+  });
+
+  expect(result.score).toBe(1);
+  expect(judgeHarnessRun).toHaveBeenCalledWith(
+    expect.objectContaining({
+      prompt: expect.stringContaining(
+        '"submitted_answer": "Paris is the capital of France."',
+      ),
+    }),
+    undefined,
+  );
+});
+
+test("FactualityJudge fails closed when no expected value is provided", async () => {
+  const run = createRun("Paris");
+
+  const result = await FactualityJudge().assess({
+    input: "What is the capital of France?",
+    output: run.output,
+    metadata: {},
+    run,
+    session: run.session,
+    toolCalls: [],
+    harness: factualityHarness,
+  });
+
+  expect(result).toEqual({
+    score: 0,
+    metadata: {
+      rationale:
+        "FactualityJudge requires a non-empty expert answer in `expected` or `metadata.expected`.",
+    },
+  });
+});
+
+test("FactualityJudge fails closed when expected is null", async () => {
+  const run = createRun("Paris");
+
+  const result = await FactualityJudge().assess({
+    input: "What is the capital of France?",
+    output: run.output,
+    metadata: {
+      expected: null,
+    },
+    run,
+    session: run.session,
+    toolCalls: [],
+    harness: factualityHarness,
+  });
+
+  expect(result).toEqual({
+    score: 0,
+    metadata: {
+      rationale:
+        "FactualityJudge requires a non-empty expert answer in `expected` or `metadata.expected`.",
+    },
+  });
+});
+
+test("FactualityJudge treats explicit null expected as missing", async () => {
+  const runJudge = vi.fn();
+  const run = createRun("Paris");
+  const metadata = {
+    expected: "Paris is the capital of France.",
+  };
+
+  const result = await FactualityJudge().assess({
+    input: "What is the capital of France?",
+    output: run.output,
+    expected: null,
+    metadata,
+    run,
+    session: run.session,
+    toolCalls: [],
+    harness: factualityHarness,
+    runJudge: createMockRunJudge(runJudge),
+  });
+
+  expect(result).toEqual({
+    score: 0,
+    metadata: {
+      rationale:
+        "FactualityJudge requires a non-empty expert answer in `expected` or `metadata.expected`.",
+    },
+  });
+  expect(runJudge).not.toHaveBeenCalled();
+});
+
+test("FactualityJudge fails closed when expected is blank", async () => {
+  const runJudge = vi.fn();
+  const run = createRun("Paris");
+
+  const result = await FactualityJudge().assess({
+    input: "What is the capital of France?",
+    output: run.output,
+    expected: "   ",
+    metadata: {},
+    run,
+    session: run.session,
+    toolCalls: [],
+    harness: factualityHarness,
+    runJudge: createMockRunJudge(runJudge),
+  });
+
+  expect(result).toEqual({
+    score: 0,
+    metadata: {
+      rationale:
+        "FactualityJudge requires a non-empty expert answer in `expected` or `metadata.expected`.",
+    },
+  });
+  expect(runJudge).not.toHaveBeenCalled();
+});
+
+function createMockJudgeHarness(run: CreateJudgeHarnessOptions["run"]) {
+  return createJudgeHarness({
+    name: "mock-judge-harness",
+    run,
+  });
+}
+
+function createMockRunJudge(
+  run: (
+    input: Parameters<RunJudge>[0],
+    options: Parameters<RunJudge>[1],
+  ) => JsonValue | undefined | Promise<JsonValue | undefined>,
+): RunJudge {
+  return (input, options) => Promise.resolve(run(input, options));
+}
+
+function createRun<TOutput extends JsonValue | undefined>(
+  output: TOutput,
+): HarnessRun<TOutput> {
+  return {
+    output,
+    session: {
+      messages: [
+        {
+          role: "assistant",
+          content: output,
+        },
+      ],
+    },
+    usage: {},
+    errors: [],
+  } satisfies HarnessRun<TOutput>;
+}

--- a/packages/vitest-evals/src/judges/factualityJudge.ts
+++ b/packages/vitest-evals/src/judges/factualityJudge.ts
@@ -1,7 +1,7 @@
 import {
-  assistantMessages,
   type Harness,
   type HarnessMetadata,
+  latestAssistantMessageContent,
 } from "../harness";
 import type { JsonValue } from "../harness";
 import { createRunJudge } from "./judgeHarness";
@@ -264,20 +264,7 @@ function resolveJudgeOutput(opts: FactualityJudgeOptions) {
     return opts.output;
   }
 
-  const assistantContent = [...assistantMessages(opts.session)]
-    .reverse()
-    .find(hasAssistantOutputContent)?.content;
-
-  return assistantContent ?? "";
-}
-
-function hasAssistantOutputContent(
-  message: FactualityJudgeOptions["session"]["messages"][number],
-) {
-  return (
-    message.content !== undefined &&
-    (typeof message.content !== "string" || message.content.trim().length > 0)
-  );
+  return latestAssistantMessageContent(opts.session) ?? "";
 }
 
 function parseFactualityJudgeVerdict(value: unknown): FactualityJudgeVerdict {

--- a/packages/vitest-evals/src/judges/factualityJudge.ts
+++ b/packages/vitest-evals/src/judges/factualityJudge.ts
@@ -165,7 +165,7 @@ export interface FactualityJudgeOptions<
  * harness. Configure the LLM used for grading with `judgeHarness` on the
  * judge, suite, or matcher options.
  *
- * @param config - Optional judge naming configuration.
+ * @param config - Optional judge name and reusable judge harness default.
  *
  * @example
  * ```ts

--- a/packages/vitest-evals/src/judges/factualityJudge.ts
+++ b/packages/vitest-evals/src/judges/factualityJudge.ts
@@ -96,7 +96,7 @@ const FACTUALITY_RESPONSE_SCHEMA = {
  *   "Paris is the capital of France.";
  * ```
  */
-export type FactualityJudgeExpected = unknown;
+export type FactualityJudgeExpected = JsonValue;
 
 /**
  * Configuration for the factuality judge.
@@ -145,17 +145,17 @@ type FactualityJudgeMetadata = HarnessMetadata & {
  * });
  * ```
  */
-export interface FactualityJudgeOptions<
+export type FactualityJudgeOptions<
   TInput = any,
   TOutput extends JsonValue | undefined = JsonValue | undefined,
   TMetadata extends HarnessMetadata = HarnessMetadata,
   THarness extends Harness<TInput, TOutput, TMetadata> | undefined =
     | Harness<TInput, TOutput, TMetadata>
     | undefined,
-> extends JudgeContext<TInput, TOutput, TMetadata, THarness> {
+> = JudgeContext<TInput, TOutput, TMetadata, THarness> & {
   /** Expert answer or reference facts. Defaults to `metadata.expected`. */
   expected?: FactualityJudgeExpected;
-}
+};
 
 /**
  * Creates a factuality judge over normalized harness output.
@@ -253,7 +253,7 @@ async function assessFactuality(
   return formatJudgeResult(parseFactualityJudgeVerdict(verdict));
 }
 
-function isMissingExpectedAnswer(value: FactualityJudgeExpected) {
+function isMissingExpectedAnswer(value: FactualityJudgeExpected | undefined) {
   return (
     value == null || (typeof value === "string" && value.trim().length === 0)
   );

--- a/packages/vitest-evals/src/judges/factualityJudge.ts
+++ b/packages/vitest-evals/src/judges/factualityJudge.ts
@@ -1,0 +1,396 @@
+import {
+  assistantMessages,
+  type Harness,
+  type HarnessMetadata,
+} from "../harness";
+import type { JsonValue } from "../harness";
+import { createRunJudge } from "./judgeHarness";
+import type { JudgeHarness } from "./judgeHarness";
+import type { Judge, JudgeContext, JudgeResult } from "./types";
+
+/**
+ * Rubric choice returned by a factuality judge model call.
+ *
+ * @example
+ * ```ts
+ * import type { FactualityJudgeChoice } from "vitest-evals";
+ *
+ * const choice: FactualityJudgeChoice = "C";
+ * ```
+ */
+export type FactualityJudgeChoice = "A" | "B" | "C" | "D" | "E";
+
+/**
+ * Prompt payload sent to the configured judge harness.
+ *
+ * @example
+ * ```ts
+ * import type { FactualityJudgePrompt } from "vitest-evals";
+ *
+ * const payload: FactualityJudgePrompt = {
+ *   system: "Grade factual consistency.",
+ *   prompt: "Compare these answers.",
+ * };
+ * ```
+ */
+export type FactualityJudgePrompt = {
+  /** System prompt for the judge model. */
+  system: string;
+  /** User prompt containing the question, expert answer, submitted answer, and rubric. */
+  prompt: string;
+};
+
+/**
+ * Parsed verdict returned by a factuality judge model call.
+ *
+ * @example
+ * ```ts
+ * import type { FactualityJudgeVerdict } from "vitest-evals";
+ *
+ * const verdict: FactualityJudgeVerdict = {
+ *   choice: "C",
+ *   rationale: "The submitted answer matches the expert answer.",
+ * };
+ * ```
+ */
+export type FactualityJudgeVerdict = {
+  /** Rubric choice selected by the judge model. */
+  choice: FactualityJudgeChoice;
+  /** Human-readable explanation for the selected choice. */
+  rationale: string;
+};
+
+const FACTUALITY_CHOICE_SCORES: Record<FactualityJudgeChoice, number> = {
+  A: 0.4,
+  B: 0.6,
+  C: 1,
+  D: 0,
+  E: 1,
+};
+
+const FACTUALITY_SYSTEM =
+  "You are comparing factual content. Ignore differences in style, grammar, punctuation, and formatting.";
+
+const FACTUALITY_RESPONSE_SCHEMA = {
+  type: "object",
+  additionalProperties: false,
+  required: ["choice", "rationale"],
+  properties: {
+    choice: {
+      enum: ["A", "B", "C", "D", "E"],
+    },
+    rationale: {
+      type: "string",
+    },
+  },
+} as const satisfies JsonValue;
+
+/**
+ * Expert answer or reference facts accepted by `FactualityJudge()`.
+ *
+ * @example
+ * ```ts
+ * import type { FactualityJudgeExpected } from "vitest-evals";
+ *
+ * const expected: FactualityJudgeExpected =
+ *   "Paris is the capital of France.";
+ * ```
+ */
+export type FactualityJudgeExpected = unknown;
+
+/**
+ * Configuration for the factuality judge.
+ *
+ * The judge harness can be supplied here, by `describeEval({ judgeHarness })`,
+ * or by `expect(...).toSatisfyJudge(..., { judgeHarness })`. Passing it here
+ * keeps the judge self-contained while preserving provider neutrality.
+ *
+ * @example
+ * ```ts
+ * import { FactualityJudge, type JudgeHarness } from "vitest-evals";
+ *
+ * declare const judgeHarness: JudgeHarness;
+ *
+ * const judge = FactualityJudge({ name: "FactJudge", judgeHarness });
+ * ```
+ */
+export type FactualityJudgeConfig = {
+  /** Stable judge name used in assertion messages and reports. */
+  name?: string;
+  /** Default judge-side harness used when matcher options do not provide one. */
+  judgeHarness?: JudgeHarness;
+};
+
+type FactualityJudgeMetadata = HarnessMetadata & {
+  expected?: FactualityJudgeExpected;
+};
+
+/**
+ * Matcher context accepted by `FactualityJudge()`.
+ *
+ * @example
+ * ```ts
+ * import { aiSdkJudgeHarness } from "@vitest-evals/harness-ai-sdk";
+ * import { openai } from "@ai-sdk/openai";
+ * import { expect } from "vitest";
+ * import { FactualityJudge } from "vitest-evals";
+ *
+ * const judgeHarness = aiSdkJudgeHarness({
+ *   model: openai("gpt-4.1-mini"),
+ * });
+ *
+ * await expect(result).toSatisfyJudge(FactualityJudge(), {
+ *   expected: "Paris is the capital of France.",
+ *   judgeHarness,
+ * });
+ * ```
+ */
+export interface FactualityJudgeOptions<
+  TInput = any,
+  TOutput extends JsonValue | undefined = JsonValue | undefined,
+  TMetadata extends HarnessMetadata = HarnessMetadata,
+  THarness extends Harness<TInput, TOutput, TMetadata> | undefined =
+    | Harness<TInput, TOutput, TMetadata>
+    | undefined,
+> extends JudgeContext<TInput, TOutput, TMetadata, THarness> {
+  /** Expert answer or reference facts. Defaults to `metadata.expected`. */
+  expected?: FactualityJudgeExpected;
+}
+
+/**
+ * Creates a factuality judge over normalized harness output.
+ *
+ * `FactualityJudge()` compares `input`, `output`, and `expected` from the
+ * current `JudgeContext`, so the same judge can run against any application
+ * harness. Configure the LLM used for grading with `judgeHarness` on the
+ * judge, suite, or matcher options.
+ *
+ * @param config - Optional judge naming configuration.
+ *
+ * @example
+ * ```ts
+ * import { anthropic } from "@ai-sdk/anthropic";
+ * import { aiSdkJudgeHarness } from "@vitest-evals/harness-ai-sdk";
+ * import { describeEval, FactualityJudge } from "vitest-evals";
+ * import { qaHarness } from "./qaHarness";
+ *
+ * const judgeHarness = aiSdkJudgeHarness({
+ *   model: anthropic("claude-sonnet-4-5"),
+ *   temperature: 0,
+ * });
+ * const factualityJudge = FactualityJudge({ judgeHarness });
+ *
+ * describeEval("qa agent", {
+ *   harness: qaHarness,
+ *   judges: [factualityJudge],
+ * }, (it) => {
+ *   it("answers a geography question", async ({ run }) => {
+ *     await run("What is the capital of France?", {
+ *       metadata: {
+ *         expected: "Paris is the capital of France.",
+ *       },
+ *     });
+ *   });
+ * });
+ * ```
+ */
+export function FactualityJudge(
+  config: FactualityJudgeConfig = {},
+): Judge<FactualityJudgeOptions> {
+  const judgeHarness = config.judgeHarness;
+
+  return {
+    name: config.name ?? "FactualityJudge",
+    judgeHarness,
+    assess: (opts) => assessFactuality(opts, judgeHarness),
+  };
+}
+
+async function assessFactuality(
+  opts: FactualityJudgeOptions,
+  configuredJudgeHarness: JudgeHarness | undefined,
+) {
+  const metadata = opts.metadata as FactualityJudgeMetadata;
+  const expected =
+    opts.expected === undefined ? metadata.expected : opts.expected;
+
+  if (isMissingExpectedAnswer(expected)) {
+    return {
+      score: 0,
+      metadata: {
+        rationale:
+          "FactualityJudge requires a non-empty expert answer in `expected` or `metadata.expected`.",
+      },
+    };
+  }
+
+  const runJudge =
+    opts.runJudge ??
+    createRunJudge(
+      configuredJudgeHarness,
+      (opts as { signal?: AbortSignal }).signal,
+    );
+
+  if (!runJudge) {
+    throw new Error(
+      "FactualityJudge requires a judgeHarness in FactualityJudge(...) config, describeEval(...) options, toSatisfyJudge(...) options, or JudgeContext.runJudge.",
+    );
+  }
+
+  const verdict = await runJudge({
+    system: FACTUALITY_SYSTEM,
+    prompt: formatFactualityPrompt({
+      input: opts.input,
+      expected,
+      output: resolveJudgeOutput(opts),
+    }),
+    responseFormat: {
+      type: "json",
+      schema: FACTUALITY_RESPONSE_SCHEMA,
+    },
+  });
+
+  return formatJudgeResult(parseFactualityJudgeVerdict(verdict));
+}
+
+function isMissingExpectedAnswer(value: FactualityJudgeExpected) {
+  return (
+    value == null || (typeof value === "string" && value.trim().length === 0)
+  );
+}
+
+function resolveJudgeOutput(opts: FactualityJudgeOptions) {
+  if (opts.output !== undefined) {
+    return opts.output;
+  }
+
+  const assistantContent = [...assistantMessages(opts.session)]
+    .reverse()
+    .find(hasAssistantOutputContent)?.content;
+
+  return assistantContent ?? "";
+}
+
+function hasAssistantOutputContent(
+  message: FactualityJudgeOptions["session"]["messages"][number],
+) {
+  return (
+    message.content !== undefined &&
+    (typeof message.content !== "string" || message.content.trim().length > 0)
+  );
+}
+
+function parseFactualityJudgeVerdict(value: unknown): FactualityJudgeVerdict {
+  const parsed = typeof value === "string" ? parseJsonObject(value) : value;
+
+  if (!parsed || typeof parsed !== "object") {
+    throw new Error(
+      "FactualityJudge judgeHarness must return an object with `choice` and `rationale`.",
+    );
+  }
+
+  const verdict = parsed as Record<string, unknown>;
+  if (!isFactualityChoice(verdict.choice)) {
+    throw new Error(
+      "FactualityJudge judgeHarness must return choice A, B, C, D, or E.",
+    );
+  }
+
+  if (typeof verdict.rationale !== "string") {
+    throw new Error(
+      "FactualityJudge judgeHarness must return a string `rationale`.",
+    );
+  }
+
+  return {
+    choice: verdict.choice,
+    rationale: verdict.rationale,
+  };
+}
+
+function parseJsonObject(value: string) {
+  try {
+    return JSON.parse(value);
+  } catch {
+    const fencedJson = value.match(/```(?:json)?\s*([\s\S]*?)\s*```/i);
+    if (!fencedJson) {
+      throw new Error(
+        "FactualityJudge judgeHarness must return JSON with `choice` and `rationale`.",
+      );
+    }
+
+    return JSON.parse(fencedJson[1]);
+  }
+}
+
+function isFactualityChoice(value: unknown): value is FactualityJudgeChoice {
+  return (
+    value === "A" ||
+    value === "B" ||
+    value === "C" ||
+    value === "D" ||
+    value === "E"
+  );
+}
+
+function formatFactualityPrompt({
+  input,
+  expected,
+  output,
+}: {
+  input: unknown;
+  expected: unknown;
+  output: unknown;
+}) {
+  const comparison = formatJudgeValue({
+    question: input ?? "",
+    expert_answer: expected,
+    submitted_answer: output ?? "",
+  });
+
+  return `Compare the submitted answer with the expert answer.
+
+Comparison payload:
+${comparison}
+
+Select exactly one option:
+A: The submission is a fully consistent subset of the expert answer.
+B: The submission is a fully consistent superset of the expert answer.
+C: The submission contains the same factual details as the expert answer.
+D: The submission disagrees with the expert answer.
+E: The answers differ only in ways that do not affect factuality.
+
+Return JSON with exactly these fields:
+{
+  "choice": "C",
+  "rationale": "Brief explanation for the selected choice"
+}
+
+The choice value must be one of A, B, C, D, or E.`;
+}
+
+function formatJudgeValue(value: unknown) {
+  if (typeof value === "string") {
+    return value;
+  }
+
+  if (value === undefined) {
+    return "";
+  }
+
+  try {
+    return JSON.stringify(value, null, 2) ?? String(value);
+  } catch {
+    return String(value);
+  }
+}
+
+function formatJudgeResult(object: FactualityJudgeVerdict): JudgeResult {
+  return {
+    score: FACTUALITY_CHOICE_SCORES[object.choice],
+    metadata: {
+      rationale: object.rationale,
+      choice: object.choice,
+    },
+  };
+}

--- a/packages/vitest-evals/src/judges/index.ts
+++ b/packages/vitest-evals/src/judges/index.ts
@@ -36,7 +36,6 @@ export {
 
 export type {
   BoundJudgeAssessor,
-  CreateJudgeConfig,
   Judge,
   JudgeAssessFn,
   JudgeAssessWithAssessorFn,

--- a/packages/vitest-evals/src/judges/index.ts
+++ b/packages/vitest-evals/src/judges/index.ts
@@ -1,4 +1,26 @@
 export {
+  FactualityJudge,
+  type FactualityJudgeChoice,
+  type FactualityJudgeConfig,
+  type FactualityJudgeExpected,
+  type FactualityJudgeOptions,
+  type FactualityJudgePrompt,
+  type FactualityJudgeVerdict,
+} from "./factualityJudge";
+
+export {
+  createJudgeHarness,
+  runJudgeHarness,
+  type CreateJudgeHarnessOptions,
+  type CreateJudgeHarnessRunOptions,
+  type JudgeHarness,
+  type JudgeHarnessInput,
+  type JudgeHarnessOutput,
+  type RunJudge,
+  type RunJudgeOptions,
+} from "./judgeHarness";
+
+export {
   StructuredOutputJudge,
   type StructuredOutputJudgeConfig,
   type StructuredOutputJudgeExpected,
@@ -14,6 +36,7 @@ export {
 
 export type {
   BoundJudgeAssessor,
+  CreateJudgeConfig,
   Judge,
   JudgeAssessFn,
   JudgeAssessWithAssessorFn,

--- a/packages/vitest-evals/src/judges/judgeHarness.test.ts
+++ b/packages/vitest-evals/src/judges/judgeHarness.test.ts
@@ -1,0 +1,39 @@
+import { expect, test } from "vitest";
+import { createJudgeHarness, runJudgeHarness } from "./judgeHarness";
+
+test("runJudgeHarness preserves null output values", async () => {
+  const judgeHarness = createJudgeHarness({
+    run: async () => ({
+      output: null,
+    }),
+  });
+
+  const result = await runJudgeHarness(judgeHarness, {
+    prompt: "Return JSON.",
+  });
+
+  expect(result).toBeNull();
+});
+
+test("runJudgeHarness falls back to assistant content when output is missing", async () => {
+  const judgeHarness = createJudgeHarness({
+    run: async () => ({
+      session: {
+        messages: [
+          {
+            role: "assistant",
+            content: '{"choice":"C"}',
+          },
+        ],
+      },
+      usage: {},
+      errors: [],
+    }),
+  });
+
+  const result = await runJudgeHarness(judgeHarness, {
+    prompt: "Return JSON.",
+  });
+
+  expect(result).toBe('{"choice":"C"}');
+});

--- a/packages/vitest-evals/src/judges/judgeHarness.test.ts
+++ b/packages/vitest-evals/src/judges/judgeHarness.test.ts
@@ -37,3 +37,21 @@ test("runJudgeHarness falls back to assistant content when output is missing", a
 
   expect(result).toBe('{"choice":"C"}');
 });
+
+test("runJudgeHarness preserves structured values with an output field", async () => {
+  const judgeHarness = createJudgeHarness({
+    run: async () => ({
+      output: "approved",
+      confidence: 0.95,
+    }),
+  });
+
+  const result = await runJudgeHarness(judgeHarness, {
+    prompt: "Return JSON.",
+  });
+
+  expect(result).toEqual({
+    output: "approved",
+    confidence: 0.95,
+  });
+});

--- a/packages/vitest-evals/src/judges/judgeHarness.ts
+++ b/packages/vitest-evals/src/judges/judgeHarness.ts
@@ -1,5 +1,4 @@
 import {
-  assistantMessages,
   createHarness,
   type Harness,
   type HarnessContext,
@@ -7,6 +6,7 @@ import {
   type HarnessResultLike,
   type HarnessRun,
   isHarnessRun,
+  latestAssistantMessageContent,
   type JsonValue,
   type MaybePromise,
   normalizeContent,
@@ -228,18 +228,5 @@ function normalizeJudgeHarnessOutput(value: unknown): JudgeHarnessOutput {
 function resolveJudgeHarnessAssistantOutput(
   run: HarnessRun<JudgeHarnessOutput>,
 ): JudgeHarnessOutput {
-  const assistantContent = [...assistantMessages(run.session)]
-    .reverse()
-    .find(hasAssistantOutputContent)?.content;
-
-  return assistantContent ?? "";
-}
-
-function hasAssistantOutputContent(
-  message: HarnessRun<JudgeHarnessOutput>["session"]["messages"][number],
-) {
-  return (
-    message.content !== undefined &&
-    (typeof message.content !== "string" || message.content.trim().length > 0)
-  );
+  return latestAssistantMessageContent(run.session) ?? "";
 }

--- a/packages/vitest-evals/src/judges/judgeHarness.ts
+++ b/packages/vitest-evals/src/judges/judgeHarness.ts
@@ -213,6 +213,7 @@ function hasOutputField(value: unknown): value is { output?: unknown } {
     value !== null &&
     typeof value === "object" &&
     !Array.isArray(value) &&
+    Object.keys(value).length === 1 &&
     "output" in value
   );
 }

--- a/packages/vitest-evals/src/judges/judgeHarness.ts
+++ b/packages/vitest-evals/src/judges/judgeHarness.ts
@@ -1,0 +1,245 @@
+import {
+  assistantMessages,
+  createHarness,
+  type Harness,
+  type HarnessContext,
+  type HarnessMetadata,
+  type HarnessResultLike,
+  type HarnessRun,
+  isHarnessRun,
+  type JsonValue,
+  type MaybePromise,
+  normalizeContent,
+} from "../harness";
+
+/**
+ * Provider-neutral prompt request issued by an LLM-backed judge.
+ *
+ * @example
+ * ```ts
+ * const input: JudgeHarnessInput = {
+ *   system: "Grade factual consistency.",
+ *   prompt: "Compare the submitted answer with the reference answer.",
+ *   responseFormat: {
+ *     type: "json",
+ *   },
+ * };
+ * ```
+ */
+export type JudgeHarnessInput = {
+  /** Optional system prompt for the judge model. */
+  system?: string;
+  /** User prompt or instruction payload for the judge model. */
+  prompt: string;
+  /** Optional response-format hint for adapters that support structured output. */
+  responseFormat?: {
+    /** Requests a JSON-compatible response. */
+    type: "json";
+    /** Optional JSON Schema passed through to provider-specific adapters. */
+    schema?: JsonValue;
+  };
+};
+
+/** JSON-safe output returned by a judge harness. */
+export type JudgeHarnessOutput = JsonValue | undefined;
+
+/**
+ * Harness used by LLM-backed judges to issue judge-side prompts.
+ *
+ * This is separate from the application harness under test.
+ *
+ * @example
+ * ```ts
+ * const judgeHarness: JudgeHarness = createJudgeHarness({
+ *   name: "judge-model",
+ *   run: async ({ prompt }, { signal }) => {
+ *     return callJudgeModel({ prompt, signal });
+ *   },
+ * });
+ * ```
+ */
+export type JudgeHarness = Harness<
+  JudgeHarnessInput,
+  JudgeHarnessOutput,
+  HarnessMetadata
+>;
+
+/** Runtime options supplied when a judge calls `runJudge(...)`. */
+export type RunJudgeOptions = {
+  /** Optional metadata forwarded to the judge harness run. */
+  metadata?: HarnessMetadata;
+};
+
+/**
+ * Curried judge-harness runner available inside `JudgeContext`.
+ *
+ * @example
+ * ```ts
+ * const verdict = await ctx.runJudge?.({
+ *   prompt: "Return a JSON verdict.",
+ *   responseFormat: { type: "json" },
+ * });
+ * ```
+ */
+export type RunJudge = (
+  input: JudgeHarnessInput,
+  options?: RunJudgeOptions,
+) => Promise<JudgeHarnessOutput>;
+
+/** Runtime options passed to `createJudgeHarness(...)` callbacks. */
+export type CreateJudgeHarnessRunOptions = {
+  /** Abort signal from the current eval run when available. */
+  signal?: AbortSignal;
+  /** Metadata for this judge-harness run. */
+  metadata: Readonly<HarnessMetadata>;
+};
+
+/**
+ * Configuration for `createJudgeHarness(...)`.
+ *
+ * @example
+ * ```ts
+ * const judgeHarness = createJudgeHarness({
+ *   name: "custom-judge",
+ *   run: async ({ system, prompt }, { signal }) => {
+ *     return callProvider({ system, prompt, signal });
+ *   },
+ * });
+ * ```
+ */
+export type CreateJudgeHarnessOptions = {
+  /** Stable harness name used in diagnostics. */
+  name?: string;
+  /**
+   * Runs one provider-specific judge prompt.
+   *
+   * Return a JSON-safe value, a raw provider value to normalize, a lightweight
+   * `{ output }` result, or a full normalized `HarnessRun`.
+   */
+  run: (
+    input: JudgeHarnessInput,
+    options: CreateJudgeHarnessRunOptions,
+  ) => MaybePromise<unknown>;
+};
+
+/**
+ * Creates a judge harness from a provider-specific prompt callback.
+ *
+ * @param options - Harness name plus the callback that issues the judge prompt.
+ *
+ * @example
+ * ```ts
+ * const judgeHarness = createJudgeHarness({
+ *   run: async ({ prompt }) => callJudgeModel(prompt),
+ * });
+ * ```
+ */
+export function createJudgeHarness(
+  options: CreateJudgeHarnessOptions,
+): JudgeHarness {
+  return createHarness({
+    name: options.name ?? "judge-harness",
+    run: async ({ input, signal, metadata }) => {
+      return normalizeJudgeHarnessResult(
+        await options.run(input, { signal, metadata }),
+      );
+    },
+  });
+}
+
+/**
+ * Runs a judge harness with eval-scoped context already supplied.
+ *
+ * @param judgeHarness - Judge-side harness configured on the matcher, judge, or suite.
+ * @param input - Provider-neutral judge prompt request.
+ * @param options - Run-scoped metadata and abort signal.
+ */
+export async function runJudgeHarness(
+  judgeHarness: JudgeHarness,
+  input: JudgeHarnessInput,
+  options: RunJudgeOptions & { signal?: AbortSignal } = {},
+): Promise<JudgeHarnessOutput> {
+  const artifacts: HarnessContext["artifacts"] = {};
+  const run = await judgeHarness.run(input, {
+    metadata: options.metadata ?? {},
+    signal: options.signal,
+    artifacts,
+    setArtifact: (name, value) => {
+      artifacts[name] = value;
+    },
+  });
+
+  return run.output !== undefined
+    ? run.output
+    : resolveJudgeHarnessAssistantOutput(run);
+}
+
+/** Binds a judge harness to the current eval run context. */
+export function createRunJudge(
+  judgeHarness: JudgeHarness | undefined,
+  signal?: AbortSignal,
+): RunJudge | undefined {
+  if (!judgeHarness) {
+    return undefined;
+  }
+
+  return (input, options) =>
+    runJudgeHarness(judgeHarness, input, {
+      metadata: options?.metadata,
+      signal,
+    });
+}
+
+function normalizeJudgeHarnessResult(
+  result: Awaited<ReturnType<CreateJudgeHarnessOptions["run"]>>,
+): HarnessResultLike<JudgeHarnessOutput> {
+  if (isHarnessRun(result)) {
+    return result as HarnessRun<JudgeHarnessOutput>;
+  }
+
+  if (hasOutputField(result)) {
+    return {
+      output: normalizeJudgeHarnessOutput(result.output),
+    };
+  }
+
+  return {
+    output: normalizeJudgeHarnessOutput(result),
+  };
+}
+
+function hasOutputField(value: unknown): value is { output?: unknown } {
+  return (
+    value !== null &&
+    typeof value === "object" &&
+    !Array.isArray(value) &&
+    "output" in value
+  );
+}
+
+function normalizeJudgeHarnessOutput(value: unknown): JudgeHarnessOutput {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  return normalizeContent(value);
+}
+
+function resolveJudgeHarnessAssistantOutput(
+  run: HarnessRun<JudgeHarnessOutput>,
+): JudgeHarnessOutput {
+  const assistantContent = [...assistantMessages(run.session)]
+    .reverse()
+    .find(hasAssistantOutputContent)?.content;
+
+  return assistantContent ?? "";
+}
+
+function hasAssistantOutputContent(
+  message: HarnessRun<JudgeHarnessOutput>["session"]["messages"][number],
+) {
+  return (
+    message.content !== undefined &&
+    (typeof message.content !== "string" || message.content.trim().length > 0)
+  );
+}

--- a/packages/vitest-evals/src/judges/types.ts
+++ b/packages/vitest-evals/src/judges/types.ts
@@ -104,7 +104,16 @@ export type JudgeAssessorOptions = {
 };
 
 /**
- * Provider/model helper that a judge can use without running the app harness.
+ * Legacy provider/model helper that a judge can use without running the app
+ * harness.
+ *
+ * New LLM-backed judges should use `createJudgeHarness(...)` plus
+ * `ctx.runJudge(...)` instead. The judge harness path supports response
+ * formats, matcher/suite/judge-level configuration, and keeps provider
+ * adapters outside core judge implementations.
+ *
+ * @deprecated Prefer `createJudgeHarness(...)` and `ctx.runJudge(...)` for
+ * LLM-backed judges.
  *
  * @example
  * ```ts
@@ -121,13 +130,22 @@ export type JudgeAssessor<TInput = string, TOutput = string> = {
   ) => Promise<TOutput> | TOutput;
 };
 
-/** Judge-side assessor after core binds run-scoped options such as abort signal. */
+/**
+ * Legacy judge-side assessor after core binds run-scoped options such as abort
+ * signal.
+ *
+ * @deprecated Prefer `RunJudge` from `ctx.runJudge(...)` for LLM-backed judges.
+ */
 export type BoundJudgeAssessor<TInput = string, TOutput = string> = {
   /** Runs the judge-side model/provider call with run-scoped options already bound. */
   assess: (input: TInput) => Promise<TOutput>;
 };
 
-/** Function that assesses a context with a prebound judge-side assessor. */
+/**
+ * Legacy function that assesses a context with a prebound judge-side assessor.
+ *
+ * @deprecated Prefer `JudgeAssessFn` with `ctx.runJudge(...)`.
+ */
 export type JudgeAssessWithAssessorFn<
   TOptions extends JudgeContext<any, any, any, any> = JudgeContext,
   TInput = string,

--- a/packages/vitest-evals/src/judges/types.ts
+++ b/packages/vitest-evals/src/judges/types.ts
@@ -5,6 +5,7 @@ import type {
   JsonValue,
   ToolCallRecord,
 } from "../harness";
+import type { JudgeHarness, RunJudge } from "./judgeHarness";
 
 /**
  * Score payload returned by a judge.
@@ -76,6 +77,8 @@ export interface JudgeContext<
   session: HarnessRun<TOutput>["session"];
   /** Harness associated with this judge context. */
   harness: THarness;
+  /** Runs the optional matcher, judge, or suite judge harness with run-scoped context. */
+  runJudge?: RunJudge;
 }
 
 /** Convenience helper for judges that accept explicit per-call params. */
@@ -155,6 +158,25 @@ export interface Judge<
 > {
   /** Stable judge name used in assertion messages and reports. */
   name: string;
+  /** Default judge-side harness used when matcher options do not provide one. */
+  judgeHarness?: JudgeHarness;
   /** Scores one normalized judge context. */
   assess: JudgeAssessFn<TOptions>;
 }
+
+/**
+ * Object-form configuration accepted by `createJudge(...)`.
+ *
+ * Use this form when a judge should carry a default judge harness while still
+ * letting matcher options override it.
+ */
+export type CreateJudgeConfig<
+  TOptions extends JudgeContext<any, any, any, any> = JudgeContext,
+> = {
+  /** Stable judge name used in assertion messages and reports. */
+  name: string;
+  /** Default judge-side harness used when matcher options do not provide one. */
+  judgeHarness?: JudgeHarness;
+  /** Scores one normalized judge context. */
+  assess: JudgeAssessFn<TOptions>;
+};

--- a/packages/vitest-evals/src/judges/types.ts
+++ b/packages/vitest-evals/src/judges/types.ts
@@ -185,20 +185,3 @@ export interface Judge<
   /** Scores one normalized judge context. */
   assess: JudgeAssessFn<TOptions>;
 }
-
-/**
- * Object-form configuration accepted by `createJudge(...)`.
- *
- * Use this form when a judge should carry a default judge harness while still
- * letting matcher options override it.
- */
-export type CreateJudgeConfig<
-  TOptions extends JudgeContext<any, any, any, any> = JudgeContext,
-> = {
-  /** Stable judge name used in assertion messages and reports. */
-  name: string;
-  /** Default judge-side harness used when matcher options do not provide one. */
-  judgeHarness?: JudgeHarness;
-  /** Scores one normalized judge context. */
-  assess: JudgeAssessFn<TOptions>;
-};

--- a/packages/vitest-evals/src/judges/types.ts
+++ b/packages/vitest-evals/src/judges/types.ts
@@ -77,7 +77,7 @@ export interface JudgeContext<
   session: HarnessRun<TOutput>["session"];
   /** Harness associated with this judge context. */
   harness: THarness;
-  /** Runs the optional matcher, judge, or suite judge harness with run-scoped context. */
+  /** Runs the configured matcher, judge, or suite judge harness with run-scoped context. */
   runJudge?: RunJudge;
 }
 
@@ -97,7 +97,11 @@ export type JudgeAssessFn<
   TOptions extends JudgeContext<any, any, any, any> = JudgeContext,
 > = (opts: TOptions) => Promise<JudgeResult> | JudgeResult;
 
-/** Runtime options supplied by core when calling a judge-side assessor. */
+/**
+ * Runtime options supplied by core when calling a legacy judge-side assessor.
+ *
+ * @deprecated Prefer `RunJudgeOptions` with `ctx.runJudge(...)`.
+ */
 export type JudgeAssessorOptions = {
   /** Abort signal from the current eval run when available. */
   signal?: AbortSignal;

--- a/packages/vitest-evals/src/judges/types.ts
+++ b/packages/vitest-evals/src/judges/types.ts
@@ -28,8 +28,8 @@ export type JudgeResult = {
     /** Human-readable explanation for the score. */
     rationale?: string;
     /** Optional judge-side output or diagnostic payload. */
-    output?: unknown;
-  } & Record<string, unknown>;
+    output?: JsonValue;
+  } & Record<string, JsonValue | undefined>;
 };
 
 /**

--- a/packages/vitest-evals/src/legacy.ts
+++ b/packages/vitest-evals/src/legacy.ts
@@ -13,6 +13,7 @@ import {
   test,
 } from "vitest";
 import "vitest";
+import { normalizeMetadata } from "./harness";
 export { configure, evaluate } from "./legacy/evaluate";
 import { formatScores, wrapText } from "./legacy/format";
 import type {
@@ -139,6 +140,12 @@ export function describeEval(name: string, options: LegacyDescribeEvalOptions) {
             ...score,
             name: options.scorers[index].name,
           }));
+          const normalizedScoresWithName = scoresWithName.map(
+            ({ metadata, ...score }) => ({
+              ...score,
+              ...(metadata ? { metadata: normalizeMetadata(metadata) } : {}),
+            }),
+          );
 
           const avgScore =
             scores.reduce((acc, score) => acc + (score.score ?? 0), 0) /
@@ -146,7 +153,7 @@ export function describeEval(name: string, options: LegacyDescribeEvalOptions) {
           const thresholdFailed = threshold !== null && avgScore < threshold;
 
           testTask.meta.eval = {
-            scores: scoresWithName,
+            scores: normalizedScoresWithName,
             avgScore,
             output,
             ...(toolCalls && { toolCalls }),

--- a/packages/vitest-evals/src/legacy/scorers/toolCallScorer.test.ts
+++ b/packages/vitest-evals/src/legacy/scorers/toolCallScorer.test.ts
@@ -246,6 +246,21 @@ describe("ToolCallScorer", () => {
       expect(result.metadata?.rationale).toContain("incorrect arguments");
     });
 
+    test("ordered argument mismatch preserves missing actual arguments", async () => {
+      const scorer = ToolCallScorer({ ordered: true, params: "strict" });
+      const toolCalls: ToolCall[] = [{ name: "search" }];
+      const result = await scorer({
+        input: "test",
+        output: "result",
+        expectedTools: [{ name: "search", arguments: { query: "weather" } }],
+        toolCalls,
+      });
+
+      expect(result.score).toBe(0.0);
+      expect(result.metadata?.expected).toEqual({ query: "weather" });
+      expect(result.metadata?.actual).toBeUndefined();
+    });
+
     test("strict params pass with exact match", async () => {
       const scorer = ToolCallScorer({ params: "strict" });
       const toolCalls: ToolCall[] = [

--- a/scripts/check-public-docs.mjs
+++ b/scripts/check-public-docs.mjs
@@ -290,7 +290,7 @@ function collectStructuredDocsErrors() {
       label: "judge",
       dir: join(root, "packages/docs/src/content/docs/docs/judges"),
       template: "_TEMPLATE.md",
-      requiredHeadings: ["Configure", "Metadata", "Failure Behavior"],
+      requiredHeadings: ["Usage", "Failure Behavior"],
     },
   ];
   const errors = [];

--- a/skills/vitest-evals/references/judges-and-assertions.md
+++ b/skills/vitest-evals/references/judges-and-assertions.md
@@ -24,8 +24,8 @@ import {
   type JudgeContext,
 } from "vitest-evals";
 
-const FactualityJudge = createJudge(
-  "FactualityJudge",
+const RefundRubricJudge = createJudge(
+  "RefundRubricJudge",
   async (ctx: JudgeContext<string, RefundOutput, CaseMeta>) => {
     const verdict = await callJudgeModel({
       prompt: formatRubric({
@@ -56,6 +56,7 @@ const FactualityJudge = createJudge(
 
 | Judge | Use |
 |-------|-----|
+| `FactualityJudge({ model })` | Model-grade normalized output against `metadata.expected` or explicit `expected`. |
 | `ToolCallJudge()` | Check expected tool names or arguments from `metadata.expectedTools` or explicit options. |
 | `StructuredOutputJudge()` | Check expected fields from `metadata.expected` or explicit options against `run.output`. |
 


### PR DESCRIPTION
Adds a provider-neutral judge harness API and uses it to implement the new
`FactualityJudge()`. The main change is the judge boundary: model-backed judges
now call `ctx.runJudge(...)`, and provider/model configuration lives in a
`judgeHarness` that can be bound per matcher, per judge, or per suite.

This keeps exported judges independent of AI SDK, Pi, OpenAI Agents, or any
other model framework. The factuality judge is the first built-in example of
that pattern.

**Public API Before And After**

Before, factuality-style judging had to put provider-shaped model config
directly on the exported judge API:

```ts
import { openai } from "@ai-sdk/openai";
import { describeEval, FactualityJudge } from "vitest-evals";

const factualityJudge = FactualityJudge({
  model: openai("gpt-4.1-mini"),
  temperature: 0,
});

describeEval("qa agent", {
  harness: qaHarness,
  judges: [factualityJudge],
  judgeThreshold: 0.6,
});
```

After, provider config is adapted once into a judge harness. The common reusable
path binds that harness to the judge:

```ts
import { openai } from "@ai-sdk/openai";
import { aiSdkJudgeHarness } from "@vitest-evals/harness-ai-sdk";
import { describeEval, FactualityJudge } from "vitest-evals";

const judgeHarness = aiSdkJudgeHarness({
  model: openai("gpt-4.1-mini"),
  temperature: 0,
});

const factualityJudge = FactualityJudge({ judgeHarness });

describeEval("qa agent", {
  harness: qaHarness,
  judges: [factualityJudge],
  judgeThreshold: 0.6,
});
```

The same judge can be reused with a different provider by swapping only the
adapter:

```ts
import { piAiJudgeHarness } from "@vitest-evals/harness-pi-ai";
import { FactualityJudge } from "vitest-evals";

const judgeHarness = piAiJudgeHarness({
  apiKey: process.env.PI_API_KEY!,
  model: "gpt-4.1-mini",
});

export const factualityJudge = FactualityJudge({ judgeHarness });
```

For suites with several model-backed judges, the harness can live on the suite:

```ts
describeEval("qa agent", {
  harness: qaHarness,
  judgeHarness,
  judges: [FactualityJudge()],
});
```

Explicit matchers can also provide or override the judge harness, matching
Vitest-style assertion ergonomics:

```ts
await expect(result).toSatisfyJudge(FactualityJudge(), {
  expected: "Paris is the capital of France.",
  judgeHarness,
  threshold: 0.6,
});
```

Custom model-backed judges use the same core path:

```ts
import { createJudge } from "vitest-evals";

const RubricJudge = createJudge({
  name: "RubricJudge",
  judgeHarness,
  async assess(ctx) {
    if (!ctx.runJudge) {
      throw new Error("RubricJudge requires a configured judgeHarness.");
    }

    const verdict = await ctx.runJudge({
      prompt: `Grade this answer: ${JSON.stringify(ctx.output)}`,
      responseFormat: { type: "json" },
    });

    return parseRubricVerdict(verdict);
  },
});
```

**Judge Harness Boundary**

`judgeHarness` is optional everywhere. Core curries the matcher, judge, or suite
harness into `JudgeContext.runJudge` with this precedence:

1. matcher `judgeHarness`
2. judge-bound `judgeHarness`
3. explicit suite `judgeHarness`
4. an unambiguous shared judge harness from automatic suite judges, for explicit
   matchers only

Deterministic judges never need it. LLM-backed judges such as
`FactualityJudge()` enforce the requirement only when they are about to call
`runJudge`.

Raw matcher assertions still work like normal Vitest helpers: branded eval runs
carry registered context, while manually-created values should pass any context
fields the judge reads. The older `JudgeAssessor` overload remains available for
compatibility but is marked legacy; new model-backed judges should use
`createJudgeHarness(...)` and `ctx.runJudge(...)`.

**Adapter Coverage**

Adds thin adapters on top of `createJudgeHarness(...)`:

- `aiSdkJudgeHarness(...)`
- `piAiJudgeHarness(...)`
- `openaiAgentsJudgeHarness(...)`

The Pi demo uses `piAiJudgeHarness(...)` directly and binds it to
`FactualityJudge({ judgeHarness })`, so it does not need
`@vitest-evals/harness-ai-sdk` or AI SDK package dependencies.

**Docs And Compatibility**

The judge docs now tell the usage story around suite-level judges, explicit
assertions, per-judge harness binding, and custom model-backed judges. The
Autoevals compatibility suite remains in place while factuality is reimplemented
on the harness-first API.
