### PR TITLE
feat(evals)!: Remove run metadata from eval authoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,17 +197,19 @@ describeEval(
         expectedStatus: "approved",
         expectedTools: ["lookupInvoice", "createRefund"],
       },
-    ])("$name", async ({ input, ...metadata }, { run }) => {
-      const result = await run(input, {
-        metadata,
-      });
+    ])("$name", async ({ input, ...expected }, { run }) => {
+      const result = await run(input);
 
       expect(result.output).toMatchObject({
-        status: metadata.expectedStatus,
+        status: expected.expectedStatus,
       });
       expect(toolCalls(result.session).map((call) => call.name)).toEqual(
-        metadata.expectedTools,
+        expected.expectedTools,
       );
+      await expect(result).toSatisfyJudge(factualityJudge, {
+        expected: expected.expected,
+        threshold: 0.6,
+      });
     });
   },
 );
@@ -221,13 +223,12 @@ Harness-backed suites stay close to plain Vitest:
 - judges layer in through `expect(...).toSatisfyJudge(...)`
 - every judge is a named object with `assess(ctx)`
 - every judge receives `JudgeContext` with typed `input`, typed `output`, the
-  normalized run/session, tool calls, and metadata; `output` is only optional
+  normalized run/session, and tool calls; `output` is only optional
   when the harness output type includes `undefined`
 - judges own their prompt, rubric, and parsing; LLM-backed judges use
   `ctx.runJudge(...)` from a configured `judgeHarness`
-- scenario-specific judge criteria can live in `input`; use `metadata` for
-  per-run expectations or harness configuration that are not part of the
-  scenario payload
+- pass scenario-specific judge criteria explicitly to matcher options, or bind
+  suite-wide criteria on the judge instance
 - reporter output, replay, usage, tool calls, and spans come from the
   normalized run. First-party harnesses attach native run, model, and tool
   spans automatically; `createHarness(...)` attaches fallback run and tool spans

--- a/apps/demo-ai-sdk/evals/refund.eval.ts
+++ b/apps/demo-ai-sdk/evals/refund.eval.ts
@@ -1,5 +1,6 @@
 import { anthropic } from "@ai-sdk/anthropic";
 import { aiSdkJudgeHarness } from "@vitest-evals/harness-ai-sdk";
+import { expect } from "vitest";
 import { describeEval, FactualityJudge } from "vitest-evals";
 import {
   assertRefundCase,
@@ -19,36 +20,38 @@ describeEval(
   {
     skipIf: () => !process.env.ANTHROPIC_API_KEY,
     harness: refundHarness,
-    judges: [factualityJudge],
-    judgeThreshold: 0.6,
   },
   (it) => {
     it("approves refundable invoice", async ({ run }) => {
-      const metadata: Omit<RefundCase, "input"> = {
+      const expected: Omit<RefundCase, "input"> = {
         expected:
           "Invoice inv_123 should be approved and refunded for the full 4200 cents.",
         expectedStatus: "approved",
         expectedTools: ["lookupInvoice", "createRefund"],
       };
+      const result = await run("Refund invoice inv_123");
 
-      await assertRefundCase(
-        await run("Refund invoice inv_123", { metadata }),
-        metadata,
-      );
+      await assertRefundCase(result, expected);
+      await expect(result).toSatisfyJudge(factualityJudge, {
+        expected: expected.expected,
+        threshold: 0.6,
+      });
     });
 
     it("denies non-refundable invoice", async ({ run }) => {
-      const metadata: Omit<RefundCase, "input"> = {
+      const expected: Omit<RefundCase, "input"> = {
         expected:
           "Invoice inv_404 should be denied because it is not refundable.",
         expectedStatus: "denied",
         expectedTools: ["lookupInvoice"],
       };
+      const result = await run("Refund invoice inv_404");
 
-      await assertRefundCase(
-        await run("Refund invoice inv_404", { metadata }),
-        metadata,
-      );
+      await assertRefundCase(result, expected);
+      await expect(result).toSatisfyJudge(factualityJudge, {
+        expected: expected.expected,
+        threshold: 0.6,
+      });
     });
   },
 );

--- a/apps/demo-ai-sdk/evals/refund.fail.eval.ts
+++ b/apps/demo-ai-sdk/evals/refund.fail.eval.ts
@@ -10,17 +10,11 @@ describeEval(
   {
     skipIf: skipUnlessRunningFailureExamples,
     harness: refundHarness,
-    judges: [StructuredOutputJudge()],
+    judges: [StructuredOutputJudge({ expected: { status: "approved" } })],
   },
   (it) => {
     it("judge expects approval for a denied invoice", async ({ run }) => {
-      await run("Refund invoice inv_404", {
-        metadata: {
-          expected: {
-            status: "approved",
-          },
-        },
-      });
+      await run("Refund invoice inv_404");
     });
   },
 );

--- a/apps/demo-ai-sdk/evals/shared.ts
+++ b/apps/demo-ai-sdk/evals/shared.ts
@@ -27,7 +27,7 @@ type RefundDecision =
 
 export type RefundCase = {
   input: string;
-  expected?: unknown;
+  expected?: string;
   expectedStatus: RefundDecision["status"];
   expectedTools: string[];
 };
@@ -109,7 +109,7 @@ const refundTools = {
     }),
     execute: createRefund,
   },
-} satisfies AiSdkToolset<string, RefundCase>;
+} satisfies AiSdkToolset<string>;
 
 export const refundHarness = aiSdkHarness({
   tools: refundTools,

--- a/apps/demo-openai-agents/evals/refund.eval.ts
+++ b/apps/demo-openai-agents/evals/refund.eval.ts
@@ -21,8 +21,6 @@ describeEval(
   {
     skipIf: () => !process.env.OPENAI_API_KEY,
     harness: refundHarness,
-    judges: [ToolCallJudge(), factualityJudge],
-    judgeThreshold: 0.6,
   },
   (it) => {
     it.for<RefundCase>([
@@ -42,17 +40,21 @@ describeEval(
         expectedStatus: "denied",
         expectedTools: ["lookupInvoice"],
       },
-    ])("$name", async ({ input, ...metadata }, { run }) => {
-      const result = await run(input, {
-        metadata,
-      });
+    ])("$name", async ({ input, ...expected }, { run }) => {
+      const result = await run(input);
 
-      await assertRefundCase(result, metadata);
+      await assertRefundCase(result, expected);
       await expect(result).toSatisfyJudge(outputJudge, {
-        metadata,
         expected: {
-          status: metadata.expectedStatus,
+          status: expected.expectedStatus,
         },
+      });
+      await expect(result).toSatisfyJudge(ToolCallJudge(), {
+        expectedTools: expected.expectedTools,
+      });
+      await expect(result).toSatisfyJudge(factualityJudge, {
+        expected: expected.expected,
+        threshold: 0.6,
       });
     });
   },

--- a/apps/demo-openai-agents/evals/refund.fail.eval.ts
+++ b/apps/demo-openai-agents/evals/refund.fail.eval.ts
@@ -4,9 +4,7 @@ import { refundHarness } from "./shared";
 import type { RefundCase } from "../src/refundAgent";
 
 type AssertionRefundCase = RefundCase;
-type ScoredRefundCase = RefundCase & {
-  expected: Record<string, unknown>;
-};
+type ScoredRefundCase = Omit<RefundCase, "expected">;
 
 const skipUnlessRunningFailureExamples = () =>
   !process.env.OPENAI_API_KEY || process.env.VITEST_EVALS_FAIL_MODE !== "1";
@@ -16,7 +14,7 @@ describeEval(
   {
     skipIf: skipUnlessRunningFailureExamples,
     harness: refundHarness,
-    judges: [StructuredOutputJudge()],
+    judges: [StructuredOutputJudge({ expected: { status: "approved" } })],
   },
   (it) => {
     it.for<ScoredRefundCase>([
@@ -25,14 +23,9 @@ describeEval(
         input: "Refund invoice inv_404",
         expectedStatus: "denied",
         expectedTools: ["lookupInvoice"],
-        expected: {
-          status: "approved",
-        },
       },
-    ])("$name", async ({ input, ...metadata }, { run }) => {
-      await run(input, {
-        metadata,
-      });
+    ])("$name", async ({ input }, { run }) => {
+      await run(input);
     });
   },
 );
@@ -51,10 +44,8 @@ describeEval(
         expectedStatus: "approved",
         expectedTools: ["lookupInvoice", "createRefund"],
       },
-    ])("$name", async ({ input, ...metadata }, { run }) => {
-      const result = await run(input, {
-        metadata,
-      });
+    ])("$name", async ({ input }, { run }) => {
+      const result = await run(input);
 
       expect(result.output).toMatchObject({
         status: "approved",

--- a/apps/demo-openai-agents/src/refundAgent.ts
+++ b/apps/demo-openai-agents/src/refundAgent.ts
@@ -21,14 +21,14 @@ export type RefundDecision =
       reason: string;
     };
 
-export type RefundEvalMetadata = {
+export type RefundCaseCriteria = {
   name?: string;
-  expected?: unknown;
+  expected?: string;
   expectedStatus: RefundDecision["status"];
   expectedTools: string[];
 };
 
-export type RefundCase = RefundEvalMetadata & {
+export type RefundCase = RefundCaseCriteria & {
   input: string;
 };
 

--- a/apps/demo-pi/evals/refund.eval.ts
+++ b/apps/demo-pi/evals/refund.eval.ts
@@ -27,8 +27,6 @@ describeEval(
         lookupInvoice: true,
       },
     }),
-    judges: [ToolCallJudge(), factualityJudge],
-    judgeThreshold: 0.6,
   },
   (it) => {
     it.for<RefundCase>([
@@ -48,22 +46,26 @@ describeEval(
         expectedStatus: "denied",
         expectedTools: ["lookupInvoice"],
       },
-    ])("$name", async ({ input, ...metadata }, { run }) => {
-      const result = await run(input, {
-        metadata,
-      });
+    ])("$name", async ({ input, ...expected }, { run }) => {
+      const result = await run(input);
 
       expect(result.output).toMatchObject({
-        status: metadata.expectedStatus,
+        status: expected.expectedStatus,
       });
       await expect(result).toSatisfyJudge(outputJudge, {
-        metadata,
         expected: {
-          status: metadata.expectedStatus,
+          status: expected.expectedStatus,
         },
       });
+      await expect(result).toSatisfyJudge(ToolCallJudge(), {
+        expectedTools: expected.expectedTools,
+      });
+      await expect(result).toSatisfyJudge(factualityJudge, {
+        expected: expected.expected,
+        threshold: 0.6,
+      });
       expect(toolCalls(result.session).map((call) => call.name)).toEqual(
-        metadata.expectedTools,
+        expected.expectedTools,
       );
       expect(result.usage.provider).toBe("anthropic");
       expect(result.usage.model).toContain("claude");

--- a/apps/demo-pi/evals/refund.fail.eval.ts
+++ b/apps/demo-pi/evals/refund.fail.eval.ts
@@ -4,9 +4,7 @@ import { describeEval, StructuredOutputJudge } from "vitest-evals";
 import { createRefundAgent, type RefundCase } from "../src/refundAgent";
 
 type AssertionRefundCase = RefundCase;
-type ScoredRefundCase = RefundCase & {
-  expected: Record<string, unknown>;
-};
+type ScoredRefundCase = Omit<RefundCase, "expected">;
 
 const skipUnlessRunningFailureExamples = () =>
   !process.env.ANTHROPIC_API_KEY || process.env.VITEST_EVALS_FAIL_MODE !== "1";
@@ -23,7 +21,7 @@ describeEval(
   {
     skipIf: skipUnlessRunningFailureExamples,
     harness,
-    judges: [StructuredOutputJudge()],
+    judges: [StructuredOutputJudge({ expected: { status: "approved" } })],
   },
   (it) => {
     it.for<ScoredRefundCase>([
@@ -32,14 +30,9 @@ describeEval(
         input: "Refund invoice inv_404",
         expectedStatus: "denied",
         expectedTools: ["lookupInvoice"],
-        expected: {
-          status: "approved",
-        },
       },
-    ])("$name", async ({ input, ...metadata }, { run }) => {
-      await run(input, {
-        metadata,
-      });
+    ])("$name", async ({ input }, { run }) => {
+      await run(input);
     });
   },
 );
@@ -58,10 +51,8 @@ describeEval(
         expectedStatus: "denied",
         expectedTools: ["lookupInvoice"],
       },
-    ])("$name", async ({ input, ...metadata }, { run }) => {
-      const result = await run(input, {
-        metadata,
-      });
+    ])("$name", async ({ input }, { run }) => {
+      const result = await run(input);
 
       expect(result.output).toMatchObject({
         status: "denied",

--- a/apps/demo-pi/src/refundAgent.ts
+++ b/apps/demo-pi/src/refundAgent.ts
@@ -27,14 +27,14 @@ export type RefundDecision =
       reason: string;
     };
 
-export type RefundEvalMetadata = {
+export type RefundCaseCriteria = {
   name?: string;
-  expected?: unknown;
+  expected?: string;
   expectedStatus: RefundDecision["status"];
   expectedTools: string[];
 };
 
-export type RefundCase = RefundEvalMetadata & {
+export type RefundCase = RefundCaseCriteria & {
   input: string;
 };
 
@@ -114,13 +114,9 @@ const refundAgentTools = {
     description: CREATE_REFUND_DESCRIPTION,
     execute: createRefund,
   },
-} satisfies PiAiToolset<string, RefundEvalMetadata>;
+} satisfies PiAiToolset<string>;
 
-type RefundAgentRuntime = PiAiRuntime<
-  typeof refundAgentTools,
-  string,
-  RefundEvalMetadata
->;
+type RefundAgentRuntime = PiAiRuntime<typeof refundAgentTools, string>;
 type RefundAgentRuntimeTools = RefundAgentRuntime["tools"];
 
 const fallbackRuntimeTools: RefundAgentRuntimeTools = {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -282,11 +282,18 @@ Root-level custom evaluation logic should generally be written as judges over
 normalized run/session data:
 
 ```ts
-import { createJudge, type JudgeOptions } from "vitest-evals";
+import { createJudge, type JudgeOptions, type JsonValue } from "vitest-evals";
 
 export const RefundToolJudge = createJudge(
   "RefundToolJudge",
-  async ({ expectedTools, toolCalls }: JudgeOptions<{ expectedTools: string[] }>) => ({
+  async ({
+    expectedTools,
+    toolCalls,
+  }: JudgeOptions<
+    unknown,
+    JsonValue | undefined,
+    { expectedTools: string[] }
+  >) => ({
     score: expectedTools.every(
       (name, index) => toolCalls[index]?.name === name,
     )

--- a/docs/custom-scorers.md
+++ b/docs/custom-scorers.md
@@ -61,8 +61,8 @@ await expect(result).toSatisfyJudge(RefundRubricJudge);
 ```
 
 For simple response-level checks, a judge can just score `output`. When a judge
-needs normalized run context, type it with `JudgeContext` and read `metadata`,
-`toolCalls`, `session`, `harness`, or the curried `runJudge` helper from there.
+needs normalized run context, type it with `JudgeContext` and read `toolCalls`,
+`session`, `harness`, or the curried `runJudge` helper from there.
 LLM-backed judges should own their prompt, rubric text, and parser, then call
 `ctx.runJudge(...)` for the provider-specific model request. Core curries the
 matcher, judge, or suite `judgeHarness` into that function with the current
@@ -70,11 +70,11 @@ abort signal. Calling `harness.run(...)` inside a judge executes the app again,
 so reserve that for judges that intentionally need a second run.
 
 When rubric criteria are part of the scenario under test, keep them on
-`input`. Use per-run `metadata` for expectations or harness configuration
-that are not part of the scenario payload.
+`input`. Use explicit matcher options for case-specific judge criteria that are
+not part of the scenario payload.
 
 Explicit matcher calls on the branded result returned by fixture `run(...)`
-use the run's typed `output` and reuse registered input, metadata, and harness
+use the run's typed `output` and reuse registered input and harness
 context. The matcher requires any custom judge params and rejects judges whose
 output type cannot assess the received value. Inside an eval test, matcher
 calls on registered output objects or session objects reuse that exact run

--- a/docs/development-guide.md
+++ b/docs/development-guide.md
@@ -152,11 +152,18 @@ real package surfaces.
 Root-level evaluation logic should usually be implemented as a named judge:
 
 ```ts
-import { createJudge, type JudgeOptions } from "vitest-evals";
+import { createJudge, type JudgeOptions, type JsonValue } from "vitest-evals";
 
 export const DomainJudge = createJudge(
   "DomainJudge",
-  async ({ toolCalls, expectedTool }: JudgeOptions<{ expectedTool: string }>) => ({
+  async ({
+    toolCalls,
+    expectedTool,
+  }: JudgeOptions<
+    unknown,
+    JsonValue | undefined,
+    { expectedTool: string }
+  >) => ({
     score: toolCalls.some((call) => call.name === expectedTool) ? 1 : 0,
     metadata: {
       rationale: `Expected tool ${expectedTool}`,

--- a/docs/harness-first-rfc.md
+++ b/docs/harness-first-rfc.md
@@ -20,7 +20,7 @@ In the proposed model, the center of gravity becomes:
 
 - exactly one `harness` per suite
 - fixture-backed Vitest tests
-- explicit `run(input, { metadata? })`
+- explicit `run(input)`
 - normalized run/session artifacts
 - optional judges and explicit Vitest assertions
 
@@ -104,9 +104,8 @@ surface.
 
 1. `describeEval` selects one harness for the suite.
 2. Core overrides that harness onto a fixture-backed Vitest `it`.
-3. A test calls `run(input, { metadata? })`.
-4. Core creates a `HarnessContext` containing metadata, artifacts, and the test
-   signal.
+3. A test calls `run(input)`.
+4. Core creates a `HarnessContext` containing artifacts and the test signal.
 5. The harness creates or receives the existing agent/application instance.
 6. The harness runs the application with the provided input and injected test
    dependencies.

--- a/packages/docs/astro.config.mjs
+++ b/packages/docs/astro.config.mjs
@@ -17,44 +17,56 @@ export default defineConfig({
       title: "vitest-evals",
       description: "Harness-backed AI testing on top of Vitest.",
       pagination: false,
+      customCss: ["./src/styles/starlight.css"],
       sidebar: [
+        { label: "Getting Started", link: "/docs" },
+        { label: "Agent Skill", link: "/docs/agent-skill" },
         {
-          label: "Documentation",
+          label: "Harnesses",
           items: [
-            { label: "Overview", link: "/docs" },
-            { label: "Agent Skill", link: "/docs/agent-skill" },
+            { label: "Overview", link: "/docs/harnesses" },
+            { label: "AI SDK", link: "/docs/harnesses/ai-sdk" },
             {
-              label: "Harnesses",
-              items: [
-                { label: "Overview", link: "/docs/harnesses" },
-                { label: "AI SDK", link: "/docs/harnesses/ai-sdk" },
-                {
-                  label: "OpenAI Agents",
-                  link: "/docs/harnesses/openai-agents",
-                },
-                { label: "Pi", link: "/docs/harnesses/pi-ai" },
-                {
-                  label: "Custom Harnesses",
-                  link: "/docs/harnesses/custom",
-                },
-              ],
+              label: "OpenAI Agents",
+              link: "/docs/harnesses/openai-agents",
             },
+            { label: "Pi", link: "/docs/harnesses/pi-ai" },
             {
-              label: "Judges",
-              items: [
-                { label: "Overview", link: "/docs/judges" },
-                { label: "FactualityJudge", link: "/docs/judges/factuality" },
-                { label: "ToolCallJudge", link: "/docs/judges/tool-call" },
-                {
-                  label: "StructuredOutputJudge",
-                  link: "/docs/judges/structured-output",
-                },
-                { label: "Custom Judges", link: "/docs/judges/custom" },
-              ],
+              label: "Custom Harnesses",
+              link: "/docs/harnesses/custom",
             },
-            { label: "Tool Replay", link: "/docs/tool-replay" },
+          ],
+        },
+        {
+          label: "Judges",
+          items: [
+            { label: "Overview", link: "/docs/judges" },
+            { label: "FactualityJudge", link: "/docs/judges/factuality" },
+            { label: "ToolCallJudge", link: "/docs/judges/tool-call" },
+            {
+              label: "StructuredOutputJudge",
+              link: "/docs/judges/structured-output",
+            },
+            { label: "Custom Judges", link: "/docs/judges/custom" },
+          ],
+        },
+        { label: "Tool Replay", link: "/docs/tool-replay" },
+        {
+          label: "Reporting",
+          items: [
             { label: "Local Report UI", link: "/docs/report-ui" },
             { label: "GitHub Reporting", link: "/docs/github" },
+          ],
+        },
+        {
+          label: "Utilities",
+          items: [
+            { label: "Overview", link: "/docs/utilities" },
+            {
+              label: "Session Helpers",
+              link: "/docs/utilities/session-helpers",
+            },
+            { label: "Trace Helpers", link: "/docs/utilities/trace-helpers" },
           ],
         },
         {
@@ -88,12 +100,10 @@ export default defineConfig({
               "JudgeAssertionArgs",
               "JudgeAssertionHarness",
               "JudgeAssertionInput",
-              "JudgeAssertionMetadata",
               "JudgeAssertionOutput",
               "JudgeAssertionParams",
               "JudgeForReceived",
               "HarnessInput",
-              "HarnessMetadataFor",
               "HarnessOutput",
             ],
           },

--- a/packages/docs/public/llms.txt
+++ b/packages/docs/public/llms.txt
@@ -116,13 +116,13 @@ export default defineConfig({
 ## Core mental model
 
 An eval suite has one harness. A harness is an adapter around the system under
-test. It receives input and metadata, runs the application, and returns a
-normalized `HarnessRun`.
+test. It receives input, runs the application, and returns a normalized
+`HarnessRun`.
 
-Each eval test receives a `run(input, options?)` fixture from `describeEval`.
+Each eval test receives a `run(input)` fixture from `describeEval`.
 Calling `run(...)` executes the harness and returns an `EvalHarnessRun`, which
 is a `HarnessRun` with type information tying it back to the suite input,
-output, metadata, and harness.
+output, and harness.
 
 Judges inspect the same run. They should not re-run the app unless they are
 explicitly written to do so. Built-in judges are deterministic contract checks.
@@ -133,16 +133,12 @@ rules.
 
 ```ts
 import { expect } from "vitest";
-import {
-  createJudge,
-  describeEval,
-  type JudgeContext,
-} from "vitest-evals";
+import { createJudge, describeEval } from "vitest-evals";
 import { qaHarness } from "./qaHarness";
 
-const CapitalJudge = createJudge(
+const CapitalJudge = createJudge<string, string>(
   "CapitalJudge",
-  async ({ output }: JudgeContext<string, string>) => ({
+  async ({ output }) => ({
     score: output.toLowerCase().includes("paris") ? 1 : 0,
   }),
 );
@@ -165,8 +161,8 @@ describeEval(
 
 ## Table-driven evals
 
-Use Vitest's normal table APIs. Keep user-facing input in `input`, and put test
-criteria in `metadata`.
+Use Vitest's normal table APIs. Keep user-facing input in `input`, and keep
+expected values in the row that owns them.
 
 ```ts
 describeEval(
@@ -187,10 +183,10 @@ describeEval(
         input: "What is the capital of Japan?",
         expectedAnswer: "Tokyo",
       },
-    ])("$name", async ({ input, ...metadata }, { run }) => {
-      const result = await run(input, { metadata });
+    ])("$name", async ({ input, expectedAnswer }, { run }) => {
+      const result = await run(input);
 
-      expect(result.output).toContain(metadata.expectedAnswer);
+      expect(result.output).toContain(expectedAnswer);
     });
   },
 );
@@ -216,7 +212,6 @@ Import from `vitest-evals` for new suites.
 Important root types include:
 
 - `EvalRun`
-- `EvalRunOptions`
 - `EvalTestContext`
 - `EvalTestAPI`
 - `EvalHarnessRun`
@@ -250,18 +245,17 @@ Use these package subpaths when a module wants a narrower import surface.
 A harness owns execution and normalization. The root `Harness` interface is:
 
 ```ts
-type Harness<TInput, TOutput, TMetadata> = {
+type Harness<TInput, TOutput> = {
   name: string;
   run: (
     input: TInput,
-    context: HarnessContext<TMetadata>,
+    context: HarnessContext,
   ) => Promise<HarnessRun<TOutput>>;
 };
 ```
 
 The context includes:
 
-- `metadata`: per-run metadata from `run(input, { metadata })`
 - `signal`: optional abort signal
 - `artifacts`: mutable JSON-safe artifact record
 - `setArtifact(name, value)`: helper for storing JSON-safe artifacts
@@ -418,9 +412,9 @@ Key `toolReplay` by the Pi tool name.
 
 ### Custom harness
 
-Use `createHarness<Input, Output, Metadata>(...)` when the first-party adapters
-do not fit. This is appropriate for workflow engines, RAG pipelines, CLIs, or
-service functions that can return JSON-safe output, messages, tool calls, usage,
+Use `createHarness<Input, Output>(...)` when the first-party adapters do not
+fit. This is appropriate for workflow engines, RAG pipelines, CLIs, or service
+functions that can return JSON-safe output, messages, tool calls, usage,
 timings, artifacts, or errors without going through a supported SDK adapter.
 
 Return `output` for ordinary Vitest assertions and `toolCalls` for deterministic
@@ -455,11 +449,11 @@ The common judge context includes:
 Create a deterministic judge:
 
 ```ts
-import { createJudge, type JudgeContext } from "vitest-evals";
+import { createJudge } from "vitest-evals";
 
-export const CapitalJudge = createJudge(
+export const CapitalJudge = createJudge<string, string>(
   "CapitalJudge",
-  async ({ output }: JudgeContext<string, string>) => ({
+  async ({ output }) => ({
     score: output.toLowerCase().includes("paris") ? 1 : 0,
     metadata: {
       rationale: output.toLowerCase().includes("paris")
@@ -508,20 +502,17 @@ Built-ins are deterministic contract checks. For model-graded evals, put model
 selection, prompt text, rubrics, parsing, and thresholding inside a custom
 judge.
 
-## Metadata guidance
+## Case criteria guidance
 
-Use `metadata` for test criteria and run configuration, not for user-visible
-input. Good metadata examples:
+Put case criteria where the API that needs them can read them:
 
-- expected status
-- expected tool names
-- scenario labels
-- account or fixture identifiers
-- thresholds
-- flags that should not be embedded in the user prompt
+- Put scenario-owned criteria in `input` when the app should see them.
+- Put deterministic expected values in the Vitest case row for direct checks.
+- Pass per-case judge criteria through explicit matcher options.
+- Put suite-wide judge criteria on the judge instance.
 
-Harnesses and judges receive the same metadata object. Reporters keep resulting
-run data JSON-serializable.
+Use `metadata` only for normalized output/report diagnostics such as judge
+rationales, replay details, usage metadata, session metadata, or tool metadata.
 
 ## Reporter
 
@@ -692,7 +683,7 @@ tool calls, messages, usage, and partial output when execution fails.
 - Keep app output typed and narrow. Assert on `result.output` with ordinary
   Vitest matchers.
 - Keep normalized run data JSON-safe.
-- Use `metadata` for expected values and test criteria.
+- Keep expected values in case rows, explicit matcher options, or judge config.
 - Prefer deterministic judges for contracts such as tool calls and structured
   output.
 - Keep model-graded judge prompts and rubrics inside custom judges.

--- a/packages/docs/src/content/docs/api.mdx
+++ b/packages/docs/src/content/docs/api.mdx
@@ -55,7 +55,7 @@ type parameters, options, and examples.
   </a>
   <a class="api-link-card" href="/api/functions/structuredoutputjudge/">
     <strong>StructuredOutputJudge</strong>
-    <span>Score JSON-safe output fields against expected metadata or matcher input.</span>
+    <span>Score JSON-safe output fields against judge config or matcher input.</span>
   </a>
   <a class="api-link-card" href="/api/type-aliases/tosatisfyjudge/">
     <strong>toSatisfyJudge</strong>

--- a/packages/docs/src/content/docs/docs.mdx
+++ b/packages/docs/src/content/docs/docs.mdx
@@ -1,13 +1,12 @@
 ---
-title: Overview
-description: Choose a harness, configure Vitest, and follow the Paris eval story.
+title: Getting Started
+description: Get started with a harness-backed eval, direct checks, judges, and reporting.
 editUrl: false
 ---
 
 Start by choosing the harness that matches the runtime your app already uses.
-Every harness page follows the same small story: an app answers "What is the
-capital of France?", the harness normalizes that run, and a judge checks whether
-the output names Paris.
+The harness runs your app and returns normalized output, transcript, tool calls,
+traces, usage, and errors that Vitest assertions, judges, and reports can read.
 
 ## Choose a Harness
 
@@ -63,16 +62,97 @@ export default defineConfig({
 });
 ```
 
-## Follow the Story
+## Write the First Eval
 
-The harness pages intentionally use the same question, output, and judge. That
-keeps the documentation focused on the adapter boundary:
+Once the harness is configured, evals should look like ordinary Vitest tests:
+call `run(input)`, assert deterministic behavior directly, and add judges when
+you need a score or rationale in reports.
 
-| Step | What changes by runtime |
-| --- | --- |
-| App Shape | The production agent, workflow, or service function. |
-| Configure Harness | The adapter package and runtime options. |
-| Eval | The `run("What is the capital of France?")` call and `CapitalJudge`. |
+```ts title="evals/refund.eval.ts"
+import { openai } from "@ai-sdk/openai";
+import { aiSdkJudgeHarness } from "@vitest-evals/harness-ai-sdk";
+import { expect } from "vitest";
+import {
+  describeEval,
+  FactualityJudge,
+  ToolCallJudge,
+  toolCalls,
+} from "vitest-evals";
+import { refundHarness } from "./refundHarness";
+
+const judgeHarness = aiSdkJudgeHarness({
+  model: openai("gpt-4.1-mini"),
+  temperature: 0,
+});
+const factualityJudge = FactualityJudge({ judgeHarness });
+
+describeEval("refund agent", { harness: refundHarness }, (it) => {
+  it("approves a refundable invoice", async ({ run }) => {
+    const result = await run("Refund invoice inv_123");
+
+    expect(result.output).toMatchObject({ status: "approved" });
+    expect(toolCalls(result.session).map((call) => call.name)).toEqual([
+      "lookupInvoice",
+      "createRefund",
+    ]);
+    await expect(result).toSatisfyJudge(ToolCallJudge({ ordered: true }), {
+      expectedTools: ["lookupInvoice", "createRefund"],
+    });
+    await expect(result).toSatisfyJudge(factualityJudge, {
+      expected:
+        "Invoice inv_123 should be approved and refunded for the full amount.",
+      threshold: 0.6,
+    });
+  });
+});
+```
+
+Use [Harnesses](/docs/harnesses/) for adapter setup. Use
+[Session Helpers](/docs/utilities/session-helpers/) for transcript and tool
+history helpers like `toolCalls(...)`. Use [Judges](/docs/judges/) when a check
+should produce a score, threshold, or rationale.
+
+Use Vitest's case APIs when several scenarios share the same shape. Keep
+expected values in the row and pass judge criteria explicitly where they are
+used.
+
+```ts title="evals/refund.eval.ts"
+it.for([
+  {
+    name: "approves refundable invoice",
+    input: "Refund invoice inv_123",
+    expectedStatus: "approved",
+    expectedTools: ["lookupInvoice", "createRefund"],
+    expectedFacts:
+      "Invoice inv_123 should be approved and refunded for the full amount.",
+  },
+  {
+    name: "denies non-refundable invoice",
+    input: "Refund invoice inv_404",
+    expectedStatus: "denied",
+    expectedTools: ["lookupInvoice"],
+    expectedFacts:
+      "Invoice inv_404 should be denied because it is not refundable.",
+  },
+])("$name", async ({ input, expectedFacts, expectedStatus, expectedTools }, { run }) => {
+  const result = await run(input);
+
+  expect(result.output).toMatchObject({ status: expectedStatus });
+  expect(toolCalls(result.session).map((call) => call.name)).toEqual(
+    expectedTools,
+  );
+  await expect(result).toSatisfyJudge(factualityJudge, {
+    expected: expectedFacts,
+    threshold: 0.6,
+  });
+});
+```
+
+Use [StructuredOutputJudge](/docs/judges/structured-output/),
+[ToolCallJudge](/docs/judges/tool-call/), and
+[FactualityJudge](/docs/judges/factuality/) for built-in scored checks. Use
+[Trace Helpers](/docs/utilities/trace-helpers/) when the behavior you care
+about is represented by model, tool, or run spans.
 
 ## Next
 
@@ -84,6 +164,10 @@ keeps the documentation focused on the adapter boundary:
   <a class="api-link-card" href="/docs/judges/">
     <strong>Judges</strong>
     <span>Use built-in judges, write custom judges, and set thresholds.</span>
+  </a>
+  <a class="api-link-card" href="/docs/utilities/">
+    <strong>Utilities</strong>
+    <span>Find helper APIs for session, tool-call, and trace checks.</span>
   </a>
   <a class="api-link-card" href="/docs/tool-replay/">
     <strong>Tool Replay</strong>

--- a/packages/docs/src/content/docs/docs/agent-skill.mdx
+++ b/packages/docs/src/content/docs/docs/agent-skill.mdx
@@ -29,11 +29,6 @@ selection, judges, tool replay, and verification — so it writes idiomatic
   </TabItem>
 </Tabs>
 
-[dotagents](https://dotagents.sentry.dev) is the recommended installer. If your
-environment already uses
-[Vercel Skills](https://vercel.com/docs/agent-resources/skills), use the Vercel
-Skills tab instead.
-
 ## What the Skill Teaches Agents
 
 - Choose the right harness for the app runtime.

--- a/packages/docs/src/content/docs/docs/harnesses.mdx
+++ b/packages/docs/src/content/docs/docs/harnesses.mdx
@@ -6,7 +6,7 @@ editUrl: false
 
 A harness is the boundary between production behavior and eval infrastructure.
 It should be thin: call the same app entrypoint you use in production, then
-return the output, messages, tool calls, usage, and artifacts that tests and
+return the output, messages, tool calls, traces, and usage that tests and
 judges need.
 
 Use the first-party adapter that matches the runtime your app already uses. Use
@@ -46,10 +46,7 @@ same shape regardless of runtime:
 | `toolCalls` | Deterministic tool activity for tool judges and replay. |
 | `traces` | Operation spans for runs, model calls, tools, guardrails, handoffs, or custom work. |
 | `usage` | Stable usage units such as provider, model, tokens, tools, and retries. |
-| `artifacts` | Report-only details such as fixture ids or retrieved records. |
 
-Metadata is per-run test context. Put expected values, scenario labels, fixture
-ids, and judge configuration in `metadata` instead of hiding them in prompts.
 First-party harnesses attach trace spans automatically from native runtime data
 they observe, including run, model, and tool operations. `createHarness()`
 attaches fallback run and tool spans when a custom harness does not return

--- a/packages/docs/src/content/docs/docs/harnesses/_TEMPLATE.md
+++ b/packages/docs/src/content/docs/docs/harnesses/_TEMPLATE.md
@@ -50,23 +50,19 @@ export const qaHarness = runtimeHarness({
 });
 ```
 
-## Eval
+## Writing Evals
 
 Run the same simple question through the configured harness. The judge should
 score the normalized result from that run; it should not call the app again.
 
 ```ts title="evals/capital.eval.ts"
 import { expect } from "vitest";
-import {
-  createJudge,
-  describeEval,
-  type JudgeContext,
-} from "vitest-evals";
+import { createJudge, describeEval } from "vitest-evals";
 import { qaHarness } from "./qaHarness";
 
-const CapitalJudge = createJudge(
+const CapitalJudge = createJudge<string, string>(
   "CapitalJudge",
-  async ({ output }: JudgeContext<string, string>) => {
+  async ({ output }) => {
     const passed = output.toLowerCase().includes("paris");
 
     return {

--- a/packages/docs/src/content/docs/docs/harnesses/ai-sdk.mdx
+++ b/packages/docs/src/content/docs/docs/harnesses/ai-sdk.mdx
@@ -59,23 +59,19 @@ Use `output` for the value your evals care about. Messages, tool calls, usage,
 native trace spans, and errors remain available on the normalized harness run
 for judges, replay, and reports.
 
-## Eval
+## Writing Evals
 
 Call `run(input)` once, then judge that same normalized result. The judge is
 deliberately simple so the harness story stays clear.
 
 ```ts title="evals/capital.eval.ts"
 import { expect } from "vitest";
-import {
-  createJudge,
-  describeEval,
-  type JudgeContext,
-} from "vitest-evals";
+import { createJudge, describeEval } from "vitest-evals";
 import { qaHarness } from "./qaHarness";
 
-const CapitalJudge = createJudge(
+const CapitalJudge = createJudge<string, string>(
   "CapitalJudge",
-  async ({ output }: JudgeContext<string, string>) => {
+  async ({ output }) => {
     const passed = output.toLowerCase().includes("paris");
 
     return {

--- a/packages/docs/src/content/docs/docs/harnesses/custom.mdx
+++ b/packages/docs/src/content/docs/docs/harnesses/custom.mdx
@@ -60,23 +60,19 @@ export const qaHarness = createHarness<string, string>({
 Return a full `HarnessRun` only when you need complete control over messages,
 tool calls, usage, timings, artifacts, traces, and errors.
 
-## Eval
+## Writing Evals
 
 Use the custom harness like any first-party harness. The judge scores the
 normalized output from the single harness run.
 
 ```ts title="evals/capital.eval.ts"
 import { expect } from "vitest";
-import {
-  createJudge,
-  describeEval,
-  type JudgeContext,
-} from "vitest-evals";
+import { createJudge, describeEval } from "vitest-evals";
 import { qaHarness } from "./qaHarness";
 
-const CapitalJudge = createJudge(
+const CapitalJudge = createJudge<string, string>(
   "CapitalJudge",
-  async ({ output }: JudgeContext<string, string>) => {
+  async ({ output }) => {
     const passed = output.toLowerCase().includes("paris");
 
     return {

--- a/packages/docs/src/content/docs/docs/harnesses/openai-agents.mdx
+++ b/packages/docs/src/content/docs/docs/harnesses/openai-agents.mdx
@@ -59,23 +59,19 @@ Use `output` when `finalOutput` needs validation or conversion before Vitest
 assertions and judges read `result.output`. The harness also attaches native
 run, response, and tool spans to `result.traces`.
 
-## Eval
+## Writing Evals
 
 Run the same question a user would ask the agent. `CapitalJudge` scores the
 normalized output from that run; it does not run the agent a second time.
 
 ```ts title="evals/capital.eval.ts"
 import { expect } from "vitest";
-import {
-  createJudge,
-  describeEval,
-  type JudgeContext,
-} from "vitest-evals";
+import { createJudge, describeEval } from "vitest-evals";
 import { qaHarness } from "./qaHarness";
 
-const CapitalJudge = createJudge(
+const CapitalJudge = createJudge<string, string>(
   "CapitalJudge",
-  async ({ output }: JudgeContext<string, string>) => {
+  async ({ output }) => {
     const passed = output.toLowerCase().includes("paris");
 
     return {

--- a/packages/docs/src/content/docs/docs/harnesses/pi-ai.mdx
+++ b/packages/docs/src/content/docs/docs/harnesses/pi-ai.mdx
@@ -17,8 +17,8 @@ pnpm add -D vitest-evals @vitest-evals/harness-pi-ai
 
 ## App Shape
 
-The agent factory is the app boundary. It can close over prompts, metadata, and
-services, then expose the runtime-compatible `run(input, runtime)` shape the
+The agent factory is the app boundary. It can close over prompts and services,
+then expose the runtime-compatible `run(input, runtime)` shape the
 harness expects.
 
 ```ts title="src/questionAgent.ts"
@@ -30,14 +30,12 @@ type PiRuntime = {
 
 export function createQuestionAgent({
   instructions,
-  metadata,
 }: {
   instructions: string;
-  metadata: Record<string, unknown>;
 }) {
   return {
     async run(input: string, runtime: PiRuntime) {
-      const output = await answerQuestion(input, { instructions, metadata });
+      const output = await answerQuestion(input, { instructions });
 
       runtime.events?.message({
         role: "assistant",
@@ -54,18 +52,17 @@ export function createQuestionAgent({
 
 ## Configure Harness
 
-The harness creates the agent for each run and forwards per-case metadata from
-the eval into the app boundary.
+The harness creates the agent for each run and can derive app setup from the
+input or close over shared services.
 
 ```ts title="evals/qaHarness.ts"
 import { piAiHarness } from "@vitest-evals/harness-pi-ai";
 import { createQuestionAgent } from "../src/questionAgent";
 
 export const qaHarness = piAiHarness({
-  agent: ({ input, context }) =>
+  agent: ({ input }) =>
     createQuestionAgent({
       instructions: buildInstructions(input),
-      metadata: context.metadata,
     }),
 });
 ```
@@ -74,23 +71,19 @@ Return `{ output }` from the Pi entrypoint when tests and judges should assert
 on a parsed domain value. The harness attaches native run, model, and tool spans
 to `result.traces` from the Pi runtime activity it observes.
 
-## Eval
+## Writing Evals
 
 Write the eval against the harness, not the Pi runtime directly. The judge reads
 the normalized output, so the scoring code stays independent of Pi internals.
 
 ```ts title="evals/capital.eval.ts"
 import { expect } from "vitest";
-import {
-  createJudge,
-  describeEval,
-  type JudgeContext,
-} from "vitest-evals";
+import { createJudge, describeEval } from "vitest-evals";
 import { qaHarness } from "./qaHarness";
 
-const CapitalJudge = createJudge(
+const CapitalJudge = createJudge<string, string>(
   "CapitalJudge",
-  async ({ output }: JudgeContext<string, string>) => {
+  async ({ output }) => {
     const passed = output.toLowerCase().includes("paris");
 
     return {

--- a/packages/docs/src/content/docs/docs/judges.mdx
+++ b/packages/docs/src/content/docs/docs/judges.mdx
@@ -25,7 +25,7 @@ explicit judge assertions when one case needs an extra check.
   </a>
   <a class="api-link-card" href="/docs/judges/structured-output/">
     <strong>StructuredOutputJudge</strong>
-    <span>Check JSON-safe output fields against expected metadata or matcher options.</span>
+    <span>Check JSON-safe output fields against judge config or matcher options.</span>
   </a>
   <a class="api-link-card" href="/docs/judges/custom/">
     <strong>Custom Judges</strong>
@@ -52,7 +52,10 @@ const judgeHarness = aiSdkJudgeHarness({
   model: openai("gpt-4.1-mini"),
   temperature: 0,
 });
-const factualityJudge = FactualityJudge({ judgeHarness });
+const factualityJudge = FactualityJudge({
+  expected: "Paris is the capital of France.",
+  judgeHarness,
+});
 
 describeEval(
   "capital questions",
@@ -63,11 +66,7 @@ describeEval(
   },
   (it) => {
     it("knows the capital of France", async ({ run }) => {
-      const result = await run("What is the capital of France?", {
-        metadata: {
-          expected: "Paris is the capital of France.",
-        },
-      });
+      const result = await run("What is the capital of France?");
 
       expect(result.output).toContain("Paris");
     });

--- a/packages/docs/src/content/docs/docs/judges/_TEMPLATE.md
+++ b/packages/docs/src/content/docs/docs/judges/_TEMPLATE.md
@@ -19,16 +19,16 @@ describeEval("workflow", {
 });
 ```
 
-## Metadata
+## Options
 
-Show the per-run metadata the judge expects. Keep expected values near the case
+Show the matcher options or judge config the judge expects. Keep expected values near the case
 that owns them.
 
 ```ts title="evals/workflow.eval.ts"
-const result = await run("input", {
-  metadata: {
-    expected: { status: "approved" },
-  },
+const result = await run("input");
+
+await expect(result).toSatisfyJudge(RuntimeJudge(), {
+  expected: { status: "approved" },
 });
 ```
 

--- a/packages/docs/src/content/docs/docs/judges/custom.mdx
+++ b/packages/docs/src/content/docs/docs/judges/custom.mdx
@@ -6,8 +6,9 @@ editUrl: false
 
 Use `createJudge()` when a rubric should be reused across suites. A custom
 judge receives the same normalized `JudgeContext` as built-ins: input, output,
-metadata, tool calls, session, run, app harness, and a curried `runJudge`
-function when the suite has a judge harness.
+tool calls, session, run, app harness, and a curried `runJudge` function when
+the suite has a judge harness. Add explicit judge parameters to your custom
+judge options when a matcher call needs case-specific criteria.
 
 ## Usage
 
@@ -15,11 +16,11 @@ Keep deterministic checks close to the normalized output. Return stable score
 units and JSON-safe metadata that explains the result.
 
 ```ts title="evals/judges/capitalJudge.ts"
-import { createJudge, type JudgeContext } from "vitest-evals";
+import { createJudge } from "vitest-evals";
 
-export const CapitalJudge = createJudge(
+export const CapitalJudge = createJudge<string, string>(
   "CapitalJudge",
-  async ({ output }: JudgeContext<string, string>) => {
+  async ({ output }) => {
     const passed = output.toLowerCase().includes("paris");
 
     return {

--- a/packages/docs/src/content/docs/docs/judges/factuality.mdx
+++ b/packages/docs/src/content/docs/docs/judges/factuality.mdx
@@ -30,7 +30,10 @@ const judgeHarness = aiSdkJudgeHarness({
   model: openai("gpt-4.1-mini"),
   temperature: 0,
 });
-const factualityJudge = FactualityJudge({ judgeHarness });
+const factualityJudge = FactualityJudge({
+  expected: "Paris is the capital of France.",
+  judgeHarness,
+});
 
 describeEval("capital questions", {
   harness: qaHarness,
@@ -62,16 +65,19 @@ export const judgeHarness = piAiJudgeHarness({
 export const factualityJudge = FactualityJudge({ judgeHarness });
 ```
 
-## Expected Answer
+## Suite Expected Answer
 
-Put the expert answer in run metadata when every suite-level factuality judge
-should read it.
+Put a suite-wide expert answer on the judge instance.
 
 ```ts title="evals/capital.eval.ts"
-await run("What is the capital of France?", {
-  metadata: {
-    expected: "Paris is the capital of France.",
-  },
+describeEval("capital questions", {
+  harness: qaHarness,
+  judges: [
+    FactualityJudge({
+      expected: "Paris is the capital of France.",
+      judgeHarness,
+    }),
+  ],
 });
 ```
 

--- a/packages/docs/src/content/docs/docs/judges/structured-output.mdx
+++ b/packages/docs/src/content/docs/docs/judges/structured-output.mdx
@@ -5,7 +5,7 @@ editUrl: false
 ---
 
 `StructuredOutputJudge()` compares the harness output with expected values from
-metadata or matcher options. Use it for deterministic checks when the harness
+the judge config or matcher options. Use it for deterministic checks when the harness
 returns a parsed domain object instead of raw provider text.
 
 ## Usage
@@ -16,7 +16,9 @@ import { StructuredOutputJudge } from "vitest-evals";
 describeEval("capital questions", {
   harness: structuredQaHarness,
   judges: [
-    StructuredOutputJudge(),
+    StructuredOutputJudge({
+      expected: { answer: "Paris" },
+    }),
   ],
 });
 ```
@@ -28,13 +30,10 @@ record a score separately from the suite defaults.
 
 ```ts title="evals/capital.eval.ts"
 it("records a structured output score", async ({ run }) => {
-  const result = await run("What is the capital of France?", {
-    metadata: {
-      expected: { answer: "Paris", country: "France" },
-    },
-  });
+  const result = await run("What is the capital of France?");
 
-  await expect(result).toSatisfyJudge(StructuredOutputJudge, {
+  await expect(result).toSatisfyJudge(StructuredOutputJudge(), {
+    expected: { answer: "Paris", country: "France" },
     threshold: null,
   });
 });
@@ -42,18 +41,21 @@ it("records a structured output score", async ({ run }) => {
 
 `threshold: null` records the score without turning it into a failure.
 
-## Expected Output
+## Suite Expectations
 
-Put the expected value in run metadata.
+Put suite-wide expected fields on the judge instance.
 
 ```ts title="evals/capital.eval.ts"
-const result = await run("What is the capital of France?", {
-  metadata: {
-    expected: {
-      answer: "Paris",
-      country: "France",
-    },
-  },
+describeEval("capital questions", {
+  harness: structuredQaHarness,
+  judges: [
+    StructuredOutputJudge({
+      expected: {
+        answer: "Paris",
+        country: "France",
+      },
+    }),
+  ],
 });
 ```
 

--- a/packages/docs/src/content/docs/docs/judges/tool-call.mdx
+++ b/packages/docs/src/content/docs/docs/judges/tool-call.mdx
@@ -17,6 +17,7 @@ describeEval("capital questions", {
   judges: [
     ToolCallJudge({
       ordered: true,
+      expectedTools: ["lookupCapital"],
     }),
   ],
 });
@@ -24,11 +25,14 @@ describeEval("capital questions", {
 
 ## Arguments
 
-Use matcher options when a tool argument is the important assertion.
+Use matcher options when a case-specific tool argument is the important
+assertion.
 
 ```ts title="evals/capital.eval.ts"
-ToolCallJudge({
-  tools: [
+const result = await run("What is the capital of France?");
+
+await expect(result).toSatisfyJudge(ToolCallJudge({ ordered: true }), {
+  expectedTools: [
     {
       name: "lookupCapital",
       arguments: {
@@ -41,13 +45,12 @@ ToolCallJudge({
 
 ## Expected Tools
 
-Pass expected tool names through metadata on each run.
+Put suite-wide expected tool names on the judge instance.
 
 ```ts title="evals/capital.eval.ts"
-const result = await run("What is the capital of France?", {
-  metadata: {
-    expectedTools: ["lookupCapital"],
-  },
+describeEval("capital questions", {
+  harness: qaHarness,
+  judges: [ToolCallJudge({ expectedTools: ["lookupCapital"] })],
 });
 ```
 

--- a/packages/docs/src/content/docs/docs/utilities.mdx
+++ b/packages/docs/src/content/docs/docs/utilities.mdx
@@ -1,0 +1,24 @@
+---
+title: Utilities
+description: Helper APIs for deterministic checks over sessions and traces.
+editUrl: false
+---
+
+Utilities are small helper functions for reading normalized harness results.
+They are most useful in direct Vitest checks and custom judges.
+
+## Helper Categories
+
+<div class="api-link-grid">
+  <a class="api-link-card" href="/docs/utilities/session-helpers/">
+    <strong>Session Helpers</strong>
+    <span>Read messages and flattened tool calls from <code>result.session</code>.</span>
+  </a>
+  <a class="api-link-card" href="/docs/utilities/trace-helpers/">
+    <strong>Trace Helpers</strong>
+    <span>Read spans and failures from <code>result.traces</code>.</span>
+  </a>
+</div>
+
+Use [Getting Started](/docs/) for the full workflow. Use these pages when you
+already know which normalized surface you want to inspect.

--- a/packages/docs/src/content/docs/docs/utilities/session-helpers.mdx
+++ b/packages/docs/src/content/docs/docs/utilities/session-helpers.mdx
@@ -1,0 +1,76 @@
+---
+title: Session Helpers
+description: Read normalized messages and tool calls from a harness session.
+editUrl: false
+---
+
+Session helpers read `result.session`, the JSON-serializable transcript returned
+by every harness run. Use them in direct Vitest checks or inside custom judges
+through `ctx.session` and `ctx.toolCalls`.
+
+## Tool Calls
+
+Use `toolCalls(session)` for the flattened tool history.
+
+```ts title="evals/refund.eval.ts"
+import { expect } from "vitest";
+import { toolCalls } from "vitest-evals";
+
+const calls = toolCalls(result.session);
+
+expect(calls.map((call) => call.name)).toEqual([
+  "lookupInvoice",
+  "createRefund",
+]);
+expect(calls[0]).toMatchObject({
+  name: "lookupInvoice",
+  arguments: {
+    invoiceId: "inv_123",
+  },
+});
+```
+
+## Messages
+
+Use role helpers for common transcript checks.
+
+```ts title="evals/refund.eval.ts"
+import {
+  assistantMessages,
+  latestAssistantMessageContent,
+  messagesByRole,
+  toolMessages,
+  userMessages,
+} from "vitest-evals";
+
+expect(userMessages(result.session)[0]?.content).toBe("Refund invoice inv_123");
+expect(latestAssistantMessageContent(result.session)).toContain("approved");
+expect(assistantMessages(result.session).length).toBeGreaterThan(0);
+expect(toolMessages(result.session)).toHaveLength(1);
+expect(messagesByRole(result.session, "assistant")).toEqual(
+  assistantMessages(result.session),
+);
+```
+
+Read `result.session.messages` directly when order across roles matters.
+
+```ts title="evals/refund.eval.ts"
+expect(result.session.messages.map((message) => message.role)).toEqual([
+  "user",
+  "assistant",
+  "tool",
+  "assistant",
+]);
+```
+
+## API Links
+
+| Helper | Use |
+| --- | --- |
+| [`toolCalls`](/api/functions/toolcalls/) | Flatten tool calls from a session. |
+| [`assistantMessages`](/api/functions/assistantmessages/) | Read assistant transcript turns. |
+| [`userMessages`](/api/functions/usermessages/) | Read user transcript turns. |
+| [`systemMessages`](/api/functions/systemmessages/) | Read system transcript turns. |
+| [`toolMessages`](/api/functions/toolmessages/) | Read tool transcript turns. |
+| [`messagesByRole`](/api/functions/messagesbyrole/) | Read messages for any normalized role. |
+| [`latestAssistantMessageContent`](/api/functions/latestassistantmessagecontent/) | Read the latest non-empty assistant content. |

--- a/packages/docs/src/content/docs/docs/utilities/trace-helpers.mdx
+++ b/packages/docs/src/content/docs/docs/utilities/trace-helpers.mdx
@@ -1,0 +1,45 @@
+---
+title: Trace Helpers
+description: Read normalized operation spans from a harness run.
+editUrl: false
+---
+
+Trace helpers read `result.traces`, the normalized operation spans attached to a
+harness run. First-party harnesses attach native run, model, and tool spans when
+they observe them. Custom harnesses created with `createHarness()` get fallback
+run and tool spans unless they return their own traces.
+
+## Span Checks
+
+Use trace helpers for operational behavior that is not represented by output,
+messages, or tool calls.
+
+```ts title="evals/refund.eval.ts"
+import { expect } from "vitest";
+import {
+  failedSpans,
+  spansByKind,
+} from "vitest-evals";
+
+expect(spansByKind(result, "model").length).toBeGreaterThan(0);
+expect(spansByKind(result, "tool").map((span) => span.name)).toContain(
+  "lookupInvoice",
+);
+expect(failedSpans(result)).toHaveLength(0);
+```
+
+Use `spans(result)` when you need the full flattened span list.
+
+```ts title="evals/refund.eval.ts"
+import { spans } from "vitest-evals";
+
+expect(spans(result).some((span) => span.status === "error")).toBe(false);
+```
+
+## API Links
+
+| Helper | Use |
+| --- | --- |
+| [`spans`](/api/functions/spans/) | Flatten every span from a harness run. |
+| [`spansByKind`](/api/functions/spansbykind/) | Filter spans by `run`, `model`, `tool`, or another span kind. |
+| [`failedSpans`](/api/functions/failedspans/) | Read spans with error status or normalized errors. |

--- a/packages/docs/src/pages/index.astro
+++ b/packages/docs/src/pages/index.astro
@@ -6,16 +6,12 @@ import { PACKAGE_VERSION, VITEST_EVALS_ACTION } from "../utils/version";
 
 const base = import.meta.env.BASE_URL.replace(/\/$/, "");
 const evalExample = `import { expect } from "vitest";
-import {
-  createJudge,
-  describeEval,
-  type JudgeContext,
-} from "vitest-evals";
+import { createJudge, describeEval } from "vitest-evals";
 import { qaHarness } from "./qaHarness";
 
-const CapitalJudge = createJudge(
+const CapitalJudge = createJudge<string, string>(
   "CapitalJudge",
-  async ({ output }: JudgeContext<string, string>) => ({
+  async ({ output }) => ({
     score: output.toLowerCase().includes("paris") ? 1 : 0,
   }),
 );
@@ -52,8 +48,7 @@ const actionExample = `- name: Run evals
         score the normalized result with ordinary Vitest assertions and judges.
       </p>
       <div class="hero-actions">
-        <a href={`${base}/docs`} class="btn btn-primary">Documentation</a>
-        <a href={`${base}/docs/harnesses`} class="btn">Choose a Harness</a>
+        <a href={`${base}/docs`} class="btn btn-primary">Getting Started</a>
         <a href={`${base}/api`} class="btn">API Reference</a>
       </div>
     </div>
@@ -107,7 +102,7 @@ const actionExample = `- name: Run evals
         <h3>Judge the same run</h3>
         <p>
           Built-in and custom judges read output, session, tool calls, usage,
-          and metadata without re-running the app.
+          and run context without re-running the app.
         </p>
       </div>
     </div>

--- a/packages/docs/src/styles/starlight.css
+++ b/packages/docs/src/styles/starlight.css
@@ -1,0 +1,7 @@
+.sidebar-content {
+  gap: 0.45rem;
+}
+
+.sidebar .top-level > li + li {
+  margin-top: 0.35rem;
+}

--- a/packages/harness-ai-sdk/README.md
+++ b/packages/harness-ai-sdk/README.md
@@ -19,7 +19,6 @@ import {
   createJudge,
   describeEval,
   toolCalls,
-  type JudgeContext,
 } from "vitest-evals";
 
 const tools = {
@@ -73,17 +72,15 @@ const harness = aiSdkHarness({
 ```
 
 If your app exposes an agent object instead, `agent` can be either that object
-or a per-run factory. Factories receive the eval input and harness context so
-input-dependent instructions, metadata, or seeded state do not require
-side-channel setup:
+or a per-run factory. Factories receive the eval input so input-dependent
+instructions or seeded state do not require side-channel setup:
 
 ```ts
 const harness = aiSdkHarness({
   tools,
-  agent: ({ input, context }) =>
+  agent: ({ input }) =>
     createRefundAgent({
       instructions: buildInstructions(input),
-      metadata: context.metadata,
     }),
 });
 ```

--- a/packages/harness-ai-sdk/src/index.test.ts
+++ b/packages/harness-ai-sdk/src/index.test.ts
@@ -12,9 +12,6 @@ import type { Harness, HarnessContext, JsonValue } from "vitest-evals/harness";
 import { z } from "zod";
 import { aiSdkHarness, type AiSdkToolset } from "./index";
 
-type DemoMetadata = {
-  scenario?: string;
-};
 type RefundDecision = {
   status: "approved" | "denied";
 };
@@ -24,7 +21,7 @@ type Equal<TActual, TExpected> = (<T>() => T extends TActual ? 1 : 2) extends <
   ? true
   : false;
 type Expect<T extends true> = T;
-type HarnessOutput<THarness> = THarness extends Harness<any, infer TOutput, any>
+type HarnessOutput<THarness> = THarness extends Harness<any, infer TOutput>
   ? TOutput
   : never;
 
@@ -123,11 +120,8 @@ afterEach(() => {
   }
 });
 
-function createHarnessContext<TMetadata extends Record<string, unknown>>(
-  metadata: TMetadata,
-) {
+function createHarnessContext(_metadata?: unknown) {
   return {
-    metadata,
     artifacts: {},
     setArtifact: vi.fn(),
   };
@@ -474,7 +468,7 @@ test("default agent run receives wrapped runtime tools", async () => {
         tools: {
           lookupInvoice: {
             execute: NonNullable<
-              AiSdkToolset<string, DemoMetadata>["lookupInvoice"]["execute"]
+              AiSdkToolset<string>["lookupInvoice"]["execute"]
             >;
           };
         };
@@ -562,7 +556,7 @@ test("default agent run receives wrapped runtime tools", async () => {
         }),
         execute,
       },
-    } satisfies AiSdkToolset<string, DemoMetadata>,
+    } satisfies AiSdkToolset<string>,
   });
 
   const result = await harness.run(
@@ -725,7 +719,7 @@ test("attaches partial runtime tool calls when custom run errors", async () => {
         }),
         execute,
       },
-    } satisfies AiSdkToolset<string, DemoMetadata>,
+    } satisfies AiSdkToolset<string>,
     run: async ({ runtime }) => {
       await runtime.tools.lookupInvoice.execute?.(
         {
@@ -817,7 +811,6 @@ test("attaches a failed run when agent setup fails", async () => {
     },
   });
   const context = {
-    metadata: {},
     artifacts: {} as Record<string, JsonValue>,
     setArtifact: vi.fn((name: string, value: JsonValue) => {
       context.artifacts[name] = value;
@@ -868,7 +861,7 @@ test("omits empty runtime tool error content when custom run errors", async () =
           throw new Error("");
         },
       },
-    } satisfies AiSdkToolset<string, DemoMetadata>,
+    } satisfies AiSdkToolset<string>,
     run: async ({ runtime }) => {
       await runtime.tools.lookupInvoice.execute?.(
         {
@@ -933,7 +926,7 @@ test("preserves explicit null runtime tool results", async () => {
         }),
         execute: async () => null,
       },
-    } satisfies AiSdkToolset<string, DemoMetadata>,
+    } satisfies AiSdkToolset<string>,
     run: async ({ runtime }) => {
       await runtime.tools.lookupInvoice.execute?.(
         {
@@ -1118,7 +1111,7 @@ test("keeps runtime-only tool calls when SDK steps are also present", async () =
         }),
         execute,
       },
-    } satisfies AiSdkToolset<string, DemoMetadata>,
+    } satisfies AiSdkToolset<string>,
     run: async ({ runtime }) => {
       await runtime.tools.lookupInvoice.execute?.(
         {
@@ -1246,10 +1239,9 @@ test("passes run input and context to agent factories", async () => {
       context,
     }: {
       input: string;
-      context: HarnessContext<DemoMetadata>;
+      context: HarnessContext;
     }) => {
       context.setArtifact("preparedInput", input);
-      const scenario = context.metadata.scenario ?? "unknown";
 
       return {
         run: async (runInput: string) => ({
@@ -1257,7 +1249,6 @@ test("passes run input and context to agent factories", async () => {
             status: "approved",
             input: runInput,
             preparedInput: input,
-            scenario,
           },
         }),
       };
@@ -1266,9 +1257,7 @@ test("passes run input and context to agent factories", async () => {
   const harness = aiSdkHarness({
     agent: agentFactory,
   });
-  const context = createHarnessContext({
-    scenario: "refund",
-  });
+  const context = createHarnessContext();
 
   const result = await harness.run("Refund invoice inv_123", context);
 
@@ -1276,9 +1265,7 @@ test("passes run input and context to agent factories", async () => {
     expect.objectContaining({
       input: "Refund invoice inv_123",
       context: expect.objectContaining({
-        metadata: {
-          scenario: "refund",
-        },
+        artifacts: expect.any(Object),
       }),
     }),
   );
@@ -1290,7 +1277,6 @@ test("passes run input and context to agent factories", async () => {
     status: "approved",
     input: "Refund invoice inv_123",
     preparedInput: "Refund invoice inv_123",
-    scenario: "refund",
   });
 });
 
@@ -1300,10 +1286,10 @@ test("normalizes domain results that resemble harness runs", async () => {
       context,
       result,
     }: {
-      context: { metadata: DemoMetadata };
+      context: HarnessContext;
       result: { object: { status: string } };
     }) => {
-      expect(context.metadata.scenario).toBe("refund");
+      expect(context.artifacts).toEqual({});
       return result.object;
     },
   );
@@ -1322,7 +1308,7 @@ test("normalizes domain results that resemble harness runs", async () => {
 
   const run = await harness.run(
     "Refund invoice inv_123",
-    createHarnessContext({ scenario: "refund" }),
+    createHarnessContext(),
   );
 
   expect(run.output).toEqual({
@@ -1751,7 +1737,7 @@ test("records and replays opt-in tools in auto mode", async () => {
         }),
         execute,
       },
-    } satisfies AiSdkToolset<string, DemoMetadata>,
+    } satisfies AiSdkToolset<string>,
     run: async ({ runtime }) => {
       const lookupInvoice = runtime.tools.lookupInvoice;
       const toolInput = {
@@ -1896,7 +1882,7 @@ test("does not opt into replay from tool definitions", async () => {
         }),
         execute,
       },
-    } as unknown as AiSdkToolset<string, DemoMetadata>,
+    } as unknown as AiSdkToolset<string>,
     run: async ({ runtime }) => {
       await runtime.tools.lookupInvoice.execute?.(
         {
@@ -1943,7 +1929,7 @@ test("rejects async iterable replay outputs after awaiting execute", async () =>
         }),
         execute: vi.fn(async () => streamOutput()),
       },
-    } as unknown as AiSdkToolset<string, DemoMetadata>,
+    } as unknown as AiSdkToolset<string>,
     run: async ({ runtime }) => {
       await runtime.tools.streamRefund.execute?.(
         {
@@ -1990,7 +1976,7 @@ test("errors when strict mode is missing a recording", async () => {
         }),
         execute,
       },
-    } satisfies AiSdkToolset<string, DemoMetadata>,
+    } satisfies AiSdkToolset<string>,
     run: async ({ runtime }) => {
       await runtime.tools.lookupInvoice.execute?.(
         {

--- a/packages/harness-ai-sdk/src/index.ts
+++ b/packages/harness-ai-sdk/src/index.ts
@@ -21,7 +21,6 @@ import {
 import type {
   Harness,
   HarnessContext,
-  HarnessMetadata,
   HarnessRun,
   JsonValue,
   NormalizedMessage,
@@ -75,17 +74,13 @@ type ResultFieldOutput<
     ? JsonOutput<TResult[TKey]> | undefined
     : JsonOutput<TResult[TKey]>
   : undefined;
-type AgentSource<
-  TAgent,
-  TInput = string,
-  TMetadata extends HarnessMetadata = HarnessMetadata,
-> =
+type AgentSource<TAgent, TInput = string> =
   | TAgent
-  | ((args: AiSdkCreateAgentArgs<TInput, TMetadata>) => MaybePromise<TAgent>);
-type AnyAiSdkToolset<
-  TInput = string,
-  TMetadata extends HarnessMetadata = HarnessMetadata,
-> = Record<string, AiSdkToolDefinition<any, any, TInput, TMetadata>>;
+  | ((args: AiSdkCreateAgentArgs<TInput>) => MaybePromise<TAgent>);
+type AnyAiSdkToolset<TInput = string> = Record<
+  string,
+  AiSdkToolDefinition<any, any, TInput>
+>;
 
 let nextTraceId = 0;
 
@@ -240,33 +235,28 @@ type AiSdkResultOutput<TResult> = TResult extends HarnessRun<infer TOutput>
 type AiSdkAgentResult<
   TAgent,
   TInput,
-  TMetadata extends HarnessMetadata,
-  TTools extends AiSdkToolset<TInput, TMetadata>,
+  TTools extends AiSdkToolset<TInput>,
 > = TAgent extends {
   run: (
     input: TInput,
-    runtime: AiSdkRuntime<TTools, TInput, TMetadata>,
+    runtime: AiSdkRuntime<TTools, TInput>,
   ) => MaybePromise<infer TResult>;
 }
   ? Awaited<TResult>
   : TAgent extends {
         generate: (
           input: TInput,
-          runtime: AiSdkRuntime<TTools, TInput, TMetadata>,
+          runtime: AiSdkRuntime<TTools, TInput>,
         ) => MaybePromise<infer TResult>;
       }
     ? Awaited<TResult>
     : unknown;
 
 /** Context passed to instrumented AI SDK tool executions. */
-export interface AiSdkToolContext<
-  TInput = string,
-  TMetadata extends HarnessMetadata = HarnessMetadata,
-> {
+export interface AiSdkToolContext<TInput = string> {
   input: TInput;
-  metadata: HarnessContext<TMetadata>["metadata"];
   signal?: AbortSignal;
-  setArtifact: HarnessContext<TMetadata>["setArtifact"];
+  setArtifact: HarnessContext["setArtifact"];
   execution: ToolExecutionOptions;
 }
 
@@ -284,42 +274,35 @@ export type AiSdkToolReplayConfig<
   TArgs extends JsonValue = JsonValue,
   TResult extends JsonValue = JsonValue,
   TInput = string,
-  TMetadata extends HarnessMetadata = HarnessMetadata,
-> = ToolReplayConfig<TArgs, TResult, AiSdkToolContext<TInput, TMetadata>>;
+> = ToolReplayConfig<TArgs, TResult, AiSdkToolContext<TInput>>;
 
 /** AI SDK tool definition accepted by the harness. */
 export type AiSdkToolDefinition<
   TArgs extends JsonValue = JsonValue,
   TResult extends JsonValue = JsonValue,
   _TInput = string,
-  _TMetadata extends HarnessMetadata = HarnessMetadata,
 > = Tool<TArgs, TResult>;
 
 /** Replay policy for one AI SDK tool. */
-export type AiSdkToolReplayPolicy<
-  TInput = string,
-  TMetadata extends HarnessMetadata = HarnessMetadata,
-> = boolean | AiSdkToolReplayConfig<JsonValue, JsonValue, TInput, TMetadata>;
+export type AiSdkToolReplayPolicy<TInput = string> =
+  | boolean
+  | AiSdkToolReplayConfig<JsonValue, JsonValue, TInput>;
 
 /** Replay policy map keyed by AI SDK tool name. */
-export type AiSdkToolReplayPolicies<
-  TInput = string,
-  TMetadata extends HarnessMetadata = HarnessMetadata,
-> = Record<string, AiSdkToolReplayPolicy<TInput, TMetadata>>;
+export type AiSdkToolReplayPolicies<TInput = string> = Record<
+  string,
+  AiSdkToolReplayPolicy<TInput>
+>;
 
 /** Toolset shape accepted by the AI SDK harness. */
-export type AiSdkToolset<
-  TInput = string,
-  TMetadata extends HarnessMetadata = HarnessMetadata,
-> = AnyAiSdkToolset<TInput, TMetadata>;
+export type AiSdkToolset<TInput = string> = AnyAiSdkToolset<TInput>;
 
 /** Runtime toolset exposed to the system under test. */
-export type AiSdkRuntimeToolset<TTools extends AnyAiSdkToolset<any, any>> = {
+export type AiSdkRuntimeToolset<TTools extends AnyAiSdkToolset<any>> = {
   [K in keyof TTools]: TTools[K] extends AiSdkToolDefinition<
     infer TArgs extends JsonValue,
     infer TResult extends JsonValue,
-    infer _TInput,
-    infer _TMetadata
+    infer _TInput
   >
     ? Omit<TTools[K], "execute"> & {
         execute?: ToolExecuteFunction<TArgs, TResult>;
@@ -329,34 +312,29 @@ export type AiSdkRuntimeToolset<TTools extends AnyAiSdkToolset<any, any>> = {
 
 /** Runtime object passed into AI SDK-style agent entrypoints. */
 export interface AiSdkRuntime<
-  TTools extends AiSdkToolset<TInput, TMetadata>,
+  TTools extends AiSdkToolset<TInput>,
   TInput = string,
-  TMetadata extends HarnessMetadata = HarnessMetadata,
 > {
   tools: AiSdkRuntimeToolset<TTools>;
   signal?: AbortSignal;
 }
 
 /** Arguments passed to per-run AI SDK agent factories. */
-export interface AiSdkCreateAgentArgs<
-  TInput = string,
-  TMetadata extends HarnessMetadata = HarnessMetadata,
-> {
+export interface AiSdkCreateAgentArgs<TInput = string> {
   input: TInput;
-  context: HarnessContext<TMetadata>;
+  context: HarnessContext;
 }
 
 /** Arguments passed to custom AI SDK harness run callbacks. */
 export interface AiSdkHarnessRunArgs<
   TAgent,
   TInput,
-  TMetadata extends HarnessMetadata,
-  TTools extends AiSdkToolset<TInput, TMetadata>,
+  TTools extends AiSdkToolset<TInput>,
 > {
   agent: TAgent | undefined;
   input: TInput;
-  context: HarnessContext<TMetadata>;
-  runtime: AiSdkRuntime<TTools, TInput, TMetadata>;
+  context: HarnessContext;
+  runtime: AiSdkRuntime<TTools, TInput>;
   tools: AiSdkRuntimeToolset<TTools>;
 }
 
@@ -364,50 +342,37 @@ export interface AiSdkHarnessRunArgs<
 export interface AiSdkHarnessResultArgs<
   TAgent,
   TInput,
-  TMetadata extends HarnessMetadata,
   TResult,
-  TTools extends AiSdkToolset<TInput, TMetadata>,
-> extends AiSdkHarnessRunArgs<TAgent, TInput, TMetadata, TTools> {
+  TTools extends AiSdkToolset<TInput>,
+> extends AiSdkHarnessRunArgs<TAgent, TInput, TTools> {
   result: TResult;
 }
 
 type AiSdkHarnessOutputSelector<
   TAgent,
   TInput,
-  TMetadata extends HarnessMetadata,
   TResult,
-  TTools extends AiSdkToolset<TInput, TMetadata>,
+  TTools extends AiSdkToolset<TInput>,
   TOutput extends JsonValue | undefined,
 > = (
-  args: AiSdkHarnessResultArgs<TAgent, TInput, TMetadata, TResult, TTools>,
+  args: AiSdkHarnessResultArgs<TAgent, TInput, TResult, TTools>,
 ) => MaybePromise<TOutput>;
 
 type AiSdkHarnessOptions<
   TAgent = unknown,
   TInput = string,
-  TMetadata extends HarnessMetadata = HarnessMetadata,
   TResult = unknown,
-  TTools extends AiSdkToolset<TInput, TMetadata> = AiSdkToolset<
-    TInput,
-    TMetadata
-  >,
+  TTools extends AiSdkToolset<TInput> = AiSdkToolset<TInput>,
   TOutput extends JsonValue | undefined = JsonValue | undefined,
-> = AiSdkHarnessBaseOptions<
-  TAgent,
-  TInput,
-  TMetadata,
-  TResult,
-  TTools,
-  TOutput
-> &
+> = AiSdkHarnessBaseOptions<TAgent, TInput, TResult, TTools, TOutput> &
   (
     | {
-        agent: AgentSource<TAgent, TInput, TMetadata>;
+        agent: AgentSource<TAgent, TInput>;
         run?: never;
       }
     | {
         run: (
-          args: AiSdkHarnessRunArgs<TAgent, TInput, TMetadata, TTools>,
+          args: AiSdkHarnessRunArgs<TAgent, TInput, TTools>,
         ) => MaybePromise<TResult | HarnessRun<TOutput>>;
         agent?: never;
       }
@@ -416,43 +381,27 @@ type AiSdkHarnessOptions<
 type AiSdkHarnessOptionsWithOutput<
   TAgent = unknown,
   TInput = string,
-  TMetadata extends HarnessMetadata = HarnessMetadata,
   TResult = unknown,
-  TTools extends AiSdkToolset<TInput, TMetadata> = AiSdkToolset<
-    TInput,
-    TMetadata
-  >,
+  TTools extends AiSdkToolset<TInput> = AiSdkToolset<TInput>,
   TOutput extends JsonValue | undefined = JsonValue | undefined,
-> = AiSdkHarnessOptions<TAgent, TInput, TMetadata, TResult, TTools, TOutput> & {
-  output: AiSdkHarnessOutputSelector<
-    TAgent,
-    TInput,
-    TMetadata,
-    TResult,
-    TTools,
-    TOutput
-  >;
+> = AiSdkHarnessOptions<TAgent, TInput, TResult, TTools, TOutput> & {
+  output: AiSdkHarnessOutputSelector<TAgent, TInput, TResult, TTools, TOutput>;
 };
 
 type AiSdkHarnessRunOptionsWithoutOutput<
   TAgent = unknown,
   TInput = string,
-  TMetadata extends HarnessMetadata = HarnessMetadata,
   TResult = unknown,
-  TTools extends AiSdkToolset<TInput, TMetadata> = AiSdkToolset<
-    TInput,
-    TMetadata
-  >,
+  TTools extends AiSdkToolset<TInput> = AiSdkToolset<TInput>,
 > = AiSdkHarnessBaseOptions<
   TAgent,
   TInput,
-  TMetadata,
   TResult,
   TTools,
   JsonValue | undefined
 > & {
   run: (
-    args: AiSdkHarnessRunArgs<TAgent, TInput, TMetadata, TTools>,
+    args: AiSdkHarnessRunArgs<TAgent, TInput, TTools>,
   ) => MaybePromise<TResult>;
   agent?: never;
   output?: never;
@@ -461,20 +410,15 @@ type AiSdkHarnessRunOptionsWithoutOutput<
 type AiSdkHarnessAgentOptionsWithoutOutput<
   TAgent = unknown,
   TInput = string,
-  TMetadata extends HarnessMetadata = HarnessMetadata,
-  TTools extends AiSdkToolset<TInput, TMetadata> = AiSdkToolset<
-    TInput,
-    TMetadata
-  >,
+  TTools extends AiSdkToolset<TInput> = AiSdkToolset<TInput>,
 > = AiSdkHarnessBaseOptions<
   TAgent,
   TInput,
-  TMetadata,
   unknown,
   TTools,
   JsonValue | undefined
 > & {
-  agent: AgentSource<TAgent, TInput, TMetadata>;
+  agent: AgentSource<TAgent, TInput>;
   run?: never;
   output?: never;
 };
@@ -482,50 +426,37 @@ type AiSdkHarnessAgentOptionsWithoutOutput<
 interface AiSdkHarnessBaseOptions<
   TAgent = unknown,
   TInput = string,
-  TMetadata extends HarnessMetadata = HarnessMetadata,
   TResult = unknown,
-  TTools extends AiSdkToolset<TInput, TMetadata> = AiSdkToolset<
-    TInput,
-    TMetadata
-  >,
+  TTools extends AiSdkToolset<TInput> = AiSdkToolset<TInput>,
   TOutput extends JsonValue | undefined = JsonValue | undefined,
 > {
   tools?: TTools;
-  toolReplay?: AiSdkToolReplayPolicies<TInput, TMetadata>;
-  output?: AiSdkHarnessOutputSelector<
-    TAgent,
-    TInput,
-    TMetadata,
-    TResult,
-    TTools,
-    TOutput
-  >;
+  toolReplay?: AiSdkToolReplayPolicies<TInput>;
+  output?: AiSdkHarnessOutputSelector<TAgent, TInput, TResult, TTools, TOutput>;
   name?: string;
 }
 
 type AiSdkRunnableAgent<
   TInput,
-  TMetadata extends HarnessMetadata,
   TResult,
   TOutput extends JsonValue | undefined,
-  TTools extends AiSdkToolset<TInput, TMetadata>,
+  TTools extends AiSdkToolset<TInput>,
 > = {
   run: (
     input: TInput,
-    runtime: AiSdkRuntime<TTools, TInput, TMetadata>,
+    runtime: AiSdkRuntime<TTools, TInput>,
   ) => MaybePromise<TResult | HarnessRun<TOutput>>;
 };
 
 type AiSdkGeneratableAgent<
   TInput,
-  TMetadata extends HarnessMetadata,
   TResult,
   TOutput extends JsonValue | undefined,
-  TTools extends AiSdkToolset<TInput, TMetadata>,
+  TTools extends AiSdkToolset<TInput>,
 > = {
   generate: (
     input: TInput,
-    runtime: AiSdkRuntime<TTools, TInput, TMetadata>,
+    runtime: AiSdkRuntime<TTools, TInput>,
   ) => MaybePromise<TResult | HarnessRun<TOutput>>;
 };
 
@@ -533,85 +464,46 @@ type AiSdkGeneratableAgent<
 export function aiSdkHarness<
   TAgent = unknown,
   TInput = string,
-  TMetadata extends HarnessMetadata = HarnessMetadata,
   TResult = unknown,
-  TTools extends AiSdkToolset<TInput, TMetadata> = AiSdkToolset<
-    TInput,
-    TMetadata
-  >,
+  TTools extends AiSdkToolset<TInput> = AiSdkToolset<TInput>,
   TOutput extends JsonValue | undefined = JsonValue | undefined,
 >(
   options: AiSdkHarnessOptionsWithOutput<
     TAgent,
     TInput,
-    TMetadata,
     TResult,
     TTools,
     TOutput
   >,
-): Harness<TInput, TOutput, TMetadata>;
+): Harness<TInput, TOutput>;
 export function aiSdkHarness<
   TAgent = unknown,
   TInput = string,
-  TMetadata extends HarnessMetadata = HarnessMetadata,
   TResult = unknown,
-  TTools extends AiSdkToolset<TInput, TMetadata> = AiSdkToolset<
-    TInput,
-    TMetadata
-  >,
+  TTools extends AiSdkToolset<TInput> = AiSdkToolset<TInput>,
 >(
-  options: AiSdkHarnessRunOptionsWithoutOutput<
-    TAgent,
-    TInput,
-    TMetadata,
-    TResult,
-    TTools
-  >,
-): Harness<TInput, AiSdkResultOutput<Awaited<TResult>>, TMetadata>;
+  options: AiSdkHarnessRunOptionsWithoutOutput<TAgent, TInput, TResult, TTools>,
+): Harness<TInput, AiSdkResultOutput<Awaited<TResult>>>;
 export function aiSdkHarness<
   TAgent = unknown,
   TInput = string,
-  TMetadata extends HarnessMetadata = HarnessMetadata,
-  TTools extends AiSdkToolset<TInput, TMetadata> = AiSdkToolset<
-    TInput,
-    TMetadata
-  >,
+  TTools extends AiSdkToolset<TInput> = AiSdkToolset<TInput>,
 >(
-  options: AiSdkHarnessAgentOptionsWithoutOutput<
-    TAgent,
-    TInput,
-    TMetadata,
-    TTools
-  >,
-): Harness<
-  TInput,
-  AiSdkResultOutput<AiSdkAgentResult<TAgent, TInput, TMetadata, TTools>>,
-  TMetadata
->;
+  options: AiSdkHarnessAgentOptionsWithoutOutput<TAgent, TInput, TTools>,
+): Harness<TInput, AiSdkResultOutput<AiSdkAgentResult<TAgent, TInput, TTools>>>;
 export function aiSdkHarness<
   TAgent = unknown,
   TInput = string,
-  TMetadata extends HarnessMetadata = HarnessMetadata,
   TResult = unknown,
-  TTools extends AiSdkToolset<TInput, TMetadata> = AiSdkToolset<
-    TInput,
-    TMetadata
-  >,
+  TTools extends AiSdkToolset<TInput> = AiSdkToolset<TInput>,
   TOutput extends JsonValue | undefined = JsonValue | undefined,
 >(
-  options: AiSdkHarnessOptions<
-    TAgent,
-    TInput,
-    TMetadata,
-    TResult,
-    TTools,
-    TOutput
-  >,
-): Harness<TInput, TOutput, TMetadata> {
+  options: AiSdkHarnessOptions<TAgent, TInput, TResult, TTools, TOutput>,
+): Harness<TInput, TOutput> {
   validateOptions(options);
 
   const harnessName = options.name ?? "ai-sdk";
-  const harness: Harness<TInput, TOutput, TMetadata> = {
+  const harness: Harness<TInput, TOutput> = {
     name: harnessName,
     run: async (input, context) => {
       const startedAt = new Date();
@@ -638,9 +530,9 @@ export function aiSdkHarness<
   return harness;
 }
 
-function createFailedAiSdkRun<TInput, TMetadata extends HarnessMetadata>(
+function createFailedAiSdkRun<TInput>(
   input: TInput,
-  context: HarnessContext<TMetadata>,
+  context: HarnessContext,
   error: unknown,
   harnessName: string,
   startedAt: Date,
@@ -662,22 +554,14 @@ function createFailedAiSdkRun<TInput, TMetadata extends HarnessMetadata>(
 async function runAiSdkHarness<
   TAgent,
   TInput,
-  TMetadata extends HarnessMetadata,
   TResult,
   TOutput extends JsonValue | undefined,
-  TTools extends AiSdkToolset<TInput, TMetadata>,
+  TTools extends AiSdkToolset<TInput>,
 >(
-  options: AiSdkHarnessOptions<
-    TAgent,
-    TInput,
-    TMetadata,
-    TResult,
-    TTools,
-    TOutput
-  >,
+  options: AiSdkHarnessOptions<TAgent, TInput, TResult, TTools, TOutput>,
   agent: TAgent | undefined,
   input: TInput,
-  context: HarnessContext<TMetadata>,
+  context: HarnessContext,
 ): Promise<HarnessRun<TOutput>> {
   const trace = createTraceRecorder(options.name ?? "ai-sdk");
   const replayMetadataByToolCallId = new Map<string, ReplayMetadata>();
@@ -693,7 +577,7 @@ async function runAiSdkHarness<
   const runtime = {
     tools,
     signal: context.signal,
-  } satisfies AiSdkRuntime<TTools, TInput, TMetadata>;
+  } satisfies AiSdkRuntime<TTools, TInput>;
 
   try {
     const result = await runAgent(options, {
@@ -719,13 +603,7 @@ async function runAiSdkHarness<
       runtime,
       tools,
       result: result as TResult,
-    } satisfies AiSdkHarnessResultArgs<
-      TAgent,
-      TInput,
-      TMetadata,
-      TResult,
-      TTools
-    >;
+    } satisfies AiSdkHarnessResultArgs<TAgent, TInput, TResult, TTools>;
 
     const output = options.output
       ? await options.output(resultArgs)
@@ -798,40 +676,22 @@ async function runAiSdkHarness<
 function hasOutputSelector<
   TAgent,
   TInput,
-  TMetadata extends HarnessMetadata,
   TResult,
   TOutput extends JsonValue | undefined,
-  TTools extends AiSdkToolset<TInput, TMetadata>,
->(
-  options: AiSdkHarnessBaseOptions<
-    TAgent,
-    TInput,
-    TMetadata,
-    TResult,
-    TTools,
-    TOutput
-  >,
-) {
+  TTools extends AiSdkToolset<TInput>,
+>(options: AiSdkHarnessBaseOptions<TAgent, TInput, TResult, TTools, TOutput>) {
   return Boolean(options.output);
 }
 
 async function resolveAgent<
   TAgent,
   TInput,
-  TMetadata extends HarnessMetadata,
   TResult,
   TOutput extends JsonValue | undefined,
-  TTools extends AiSdkToolset<TInput, TMetadata>,
+  TTools extends AiSdkToolset<TInput>,
 >(
-  options: AiSdkHarnessOptions<
-    TAgent,
-    TInput,
-    TMetadata,
-    TResult,
-    TTools,
-    TOutput
-  >,
-  args: AiSdkCreateAgentArgs<TInput, TMetadata>,
+  options: AiSdkHarnessOptions<TAgent, TInput, TResult, TTools, TOutput>,
+  args: AiSdkCreateAgentArgs<TInput>,
 ) {
   return hasAgentSource(options)
     ? await resolveAgentSource(options.agent, args)
@@ -841,36 +701,22 @@ async function resolveAgent<
 async function runAgent<
   TAgent,
   TInput,
-  TMetadata extends HarnessMetadata,
   TResult,
   TOutput extends JsonValue | undefined,
-  TTools extends AiSdkToolset<TInput, TMetadata>,
+  TTools extends AiSdkToolset<TInput>,
 >(
-  options: AiSdkHarnessOptions<
-    TAgent,
-    TInput,
-    TMetadata,
-    TResult,
-    TTools,
-    TOutput
-  >,
-  args: AiSdkHarnessRunArgs<TAgent, TInput, TMetadata, TTools>,
+  options: AiSdkHarnessOptions<TAgent, TInput, TResult, TTools, TOutput>,
+  args: AiSdkHarnessRunArgs<TAgent, TInput, TTools>,
 ): Promise<TResult | HarnessRun<TOutput>> {
   if (options.run) {
     return options.run(args);
   }
 
-  if (
-    hasAiSdkRunMethod<TInput, TMetadata, TResult, TOutput, TTools>(args.agent)
-  ) {
+  if (hasAiSdkRunMethod<TInput, TResult, TOutput, TTools>(args.agent)) {
     return args.agent.run(args.input, args.runtime);
   }
 
-  if (
-    hasAiSdkGenerateMethod<TInput, TMetadata, TResult, TOutput, TTools>(
-      args.agent,
-    )
-  ) {
+  if (hasAiSdkGenerateMethod<TInput, TResult, TOutput, TTools>(args.agent)) {
     return args.agent.generate(args.input, args.runtime);
   }
 
@@ -882,20 +728,10 @@ async function runAgent<
 function validateOptions<
   TAgent,
   TInput,
-  TMetadata extends HarnessMetadata,
   TResult,
   TOutput extends JsonValue | undefined,
-  TTools extends AiSdkToolset<TInput, TMetadata>,
->(
-  options: AiSdkHarnessOptions<
-    TAgent,
-    TInput,
-    TMetadata,
-    TResult,
-    TTools,
-    TOutput
-  >,
-) {
+  TTools extends AiSdkToolset<TInput>,
+>(options: AiSdkHarnessOptions<TAgent, TInput, TResult, TTools, TOutput>) {
   const hasAgent = hasAgentSource(options);
   const hasRun = typeof (options as { run?: unknown }).run === "function";
   const entrypoints = [hasAgent, hasRun].filter(Boolean).length;
@@ -916,37 +752,24 @@ function validateOptions<
 function hasAgentSource<
   TAgent,
   TInput,
-  TMetadata extends HarnessMetadata,
   TResult,
   TOutput extends JsonValue | undefined,
-  TTools extends AiSdkToolset<TInput, TMetadata>,
+  TTools extends AiSdkToolset<TInput>,
 >(
-  options: AiSdkHarnessOptions<
-    TAgent,
-    TInput,
-    TMetadata,
-    TResult,
-    TTools,
-    TOutput
-  >,
+  options: AiSdkHarnessOptions<TAgent, TInput, TResult, TTools, TOutput>,
 ): options is AiSdkHarnessBaseOptions<
   TAgent,
   TInput,
-  TMetadata,
   TResult,
   TTools,
   TOutput
-> & { agent: AgentSource<TAgent, TInput, TMetadata> } {
+> & { agent: AgentSource<TAgent, TInput> } {
   return "agent" in options && options.agent !== undefined;
 }
 
-async function resolveAgentSource<
-  TAgent,
-  TInput,
-  TMetadata extends HarnessMetadata,
->(
-  agent: AgentSource<TAgent, TInput, TMetadata>,
-  args: AiSdkCreateAgentArgs<TInput, TMetadata>,
+async function resolveAgentSource<TAgent, TInput>(
+  agent: AgentSource<TAgent, TInput>,
+  args: AiSdkCreateAgentArgs<TInput>,
 ): Promise<TAgent> {
   if (isAgentFactory(agent)) {
     return agent(args);
@@ -957,33 +780,29 @@ async function resolveAgentSource<
 
 function hasAiSdkRunMethod<
   TInput,
-  TMetadata extends HarnessMetadata,
   TResult,
   TOutput extends JsonValue | undefined,
-  TTools extends AiSdkToolset<TInput, TMetadata>,
+  TTools extends AiSdkToolset<TInput>,
 >(
   agent: unknown,
-): agent is AiSdkRunnableAgent<TInput, TMetadata, TResult, TOutput, TTools> {
+): agent is AiSdkRunnableAgent<TInput, TResult, TOutput, TTools> {
   return hasCallableMethod(agent, "run");
 }
 
 function hasAiSdkGenerateMethod<
   TInput,
-  TMetadata extends HarnessMetadata,
   TResult,
   TOutput extends JsonValue | undefined,
-  TTools extends AiSdkToolset<TInput, TMetadata>,
+  TTools extends AiSdkToolset<TInput>,
 >(
   agent: unknown,
-): agent is AiSdkGeneratableAgent<TInput, TMetadata, TResult, TOutput, TTools> {
+): agent is AiSdkGeneratableAgent<TInput, TResult, TOutput, TTools> {
   return hasCallableMethod(agent, "generate");
 }
 
-function isAgentFactory<TAgent, TInput, TMetadata extends HarnessMetadata>(
-  agent: AgentSource<TAgent, TInput, TMetadata>,
-): agent is (
-  args: AiSdkCreateAgentArgs<TInput, TMetadata>,
-) => MaybePromise<TAgent> {
+function isAgentFactory<TAgent, TInput>(
+  agent: AgentSource<TAgent, TInput>,
+): agent is (args: AiSdkCreateAgentArgs<TInput>) => MaybePromise<TAgent> {
   return (
     typeof agent === "function" &&
     !hasCallableMethod(agent, "run") &&
@@ -1152,11 +971,7 @@ function createUsageModelSpan(
   };
 }
 
-function createToolset<
-  TInput,
-  TMetadata extends HarnessMetadata,
-  TTools extends AiSdkToolset<TInput, TMetadata>,
->({
+function createToolset<TInput, TTools extends AiSdkToolset<TInput>>({
   input,
   context,
   tools,
@@ -1165,9 +980,9 @@ function createToolset<
   runtimeToolCalls,
 }: {
   input: TInput;
-  context: HarnessContext<TMetadata>;
+  context: HarnessContext;
   tools: TTools | undefined;
-  toolReplay: AiSdkToolReplayPolicies<TInput, TMetadata> | undefined;
+  toolReplay: AiSdkToolReplayPolicies<TInput> | undefined;
   replayMetadataByToolCallId: Map<string, ReplayMetadata>;
   runtimeToolCalls: ToolCallRecord[];
 }) {
@@ -1196,11 +1011,10 @@ function createToolset<
           const normalizedArgs = normalizeArguments(toolInput);
           const replayContext = {
             input,
-            metadata: context.metadata,
             signal: context.signal,
             setArtifact: context.setArtifact,
             execution,
-          } satisfies AiSdkToolContext<TInput, TMetadata>;
+          } satisfies AiSdkToolContext<TInput>;
 
           try {
             const executionResult = replay
@@ -1274,8 +1088,7 @@ function createToolset<
 
 async function executeToolWithReplay<
   TInput,
-  TMetadata extends HarnessMetadata,
-  TTool extends AiSdkToolDefinition<any, any, TInput, TMetadata>,
+  TTool extends AiSdkToolDefinition<any, any, TInput>,
 >({
   toolName,
   toolInput,
@@ -1288,16 +1101,12 @@ async function executeToolWithReplay<
   toolInput: InferToolInput<TTool>;
   execute: NonNullable<TTool["execute"]>;
   execution: ToolExecutionOptions;
-  context: AiSdkToolContext<TInput, TMetadata>;
-  replay: AiSdkToolReplayPolicy<TInput, TMetadata>;
+  context: AiSdkToolContext<TInput>;
+  replay: AiSdkToolReplayPolicy<TInput>;
 }) {
   const replayInput = toReplayJsonValue(toolInput, `${toolName} tool input`);
 
-  return executeWithReplay<
-    JsonValue,
-    JsonValue,
-    AiSdkToolContext<TInput, TMetadata>
-  >({
+  return executeWithReplay<JsonValue, JsonValue, AiSdkToolContext<TInput>>({
     toolName,
     args: replayInput,
     context,

--- a/packages/harness-ai-sdk/src/judgeHarness.test.ts
+++ b/packages/harness-ai-sdk/src/judgeHarness.test.ts
@@ -51,7 +51,6 @@ test("aiSdkJudgeHarness uses generateObject for JSON response formats", async ()
       },
     },
     {
-      metadata: {},
       signal,
       artifacts: {},
       setArtifact: () => {},
@@ -93,7 +92,6 @@ test("aiSdkJudgeHarness uses generateText without a JSON schema", async () => {
       },
     },
     {
-      metadata: {},
       artifacts: {},
       setArtifact: () => {},
     },

--- a/packages/harness-openai-agents/README.md
+++ b/packages/harness-openai-agents/README.md
@@ -18,7 +18,6 @@ import {
   createJudge,
   describeEval,
   toolCalls,
-  type JudgeContext,
 } from "vitest-evals";
 
 const harness = openaiAgentsHarness({
@@ -45,8 +44,8 @@ describeEval("classifier agent", { harness }, (it) => {
 ```
 
 The adapter calls `runner.run(agent, input, options)` by default. It forwards
-the eval metadata, artifact helpers, and abort signal through the run options,
-then normalizes the `RunResult` into the standard `HarnessRun` shape.
+artifact helpers and the abort signal through the run options, then normalizes
+the `RunResult` into the standard `HarnessRun` shape.
 
 If your application has a custom entrypoint, wire it directly:
 
@@ -70,16 +69,15 @@ const harness = openaiAgentsHarness({
 ```
 
 `agent` and `runner` can be objects or per-run factories. An `agent` factory
-receives the per-run input and harness context before the adapter instruments
-local function tools. Use that when an agent needs scenario-specific tool
-closures, instructions, or metadata while staying on the native replay path:
+receives the per-run input before the adapter instruments local function tools.
+Use that when an agent needs scenario-specific tool closures or instructions
+while staying on the native replay path:
 
 ```ts
 const harness = openaiAgentsHarness({
-  agent: ({ input, context }) =>
+  agent: ({ input }) =>
     createClassifierAgent({
       bottleId: parseBottleId(input),
-      metadata: context.metadata,
     }),
   runner: () => new Runner({ modelProvider, tracingDisabled: true }),
   toolReplay: {

--- a/packages/harness-openai-agents/src/index.test.ts
+++ b/packages/harness-openai-agents/src/index.test.ts
@@ -11,9 +11,6 @@ import {
 import type { Harness, HarnessContext, JsonValue } from "vitest-evals/harness";
 import { openaiAgentsHarness, type OpenAiAgentsTool } from "./index";
 
-type DemoMetadata = {
-  scenario?: string;
-};
 type Classification = {
   label: "bourbon" | "scotch";
 };
@@ -23,7 +20,7 @@ type Equal<TActual, TExpected> = (<T>() => T extends TActual ? 1 : 2) extends <
   ? true
   : false;
 type Expect<T extends true> = T;
-type HarnessOutput<THarness> = THarness extends Harness<any, infer TOutput, any>
+type HarnessOutput<THarness> = THarness extends Harness<any, infer TOutput>
   ? TOutput
   : never;
 
@@ -155,7 +152,7 @@ type _OpenAiDecisionFieldOutput = Expect<
 type DemoAgent = {
   name: string;
   model: string;
-  tools?: OpenAiAgentsTool<string, DemoMetadata>[];
+  tools?: OpenAiAgentsTool<string>[];
 };
 
 let replayDir: string | undefined;
@@ -168,11 +165,8 @@ afterEach(() => {
   }
 });
 
-function createHarnessContext<TMetadata extends Record<string, unknown>>(
-  metadata: TMetadata,
-) {
+function createHarnessContext(_metadata?: unknown) {
   const context = {
-    metadata,
     artifacts: {} as Record<string, JsonValue>,
     setArtifact: vi.fn((name: string, value: JsonValue) => {
       context.artifacts[name] = value;
@@ -265,9 +259,7 @@ describeEval(
       runner: {
         run: vi.fn(async (_agent: DemoAgent, _input: string, options) => {
           expect(options?.context).toMatchObject({
-            metadata: {
-              scenario: "peated",
-            },
+            artifacts: {},
           });
           expect(options?.stream).toBe(false);
           return {
@@ -280,11 +272,7 @@ describeEval(
   },
   (it) => {
     it("normalizes native run results", async ({ run }) => {
-      const result = await run("Classify bottle bt_123", {
-        metadata: {
-          scenario: "peated",
-        },
-      });
+      const result = await run("Classify bottle bt_123");
 
       expect(result.output).toEqual({
         status: "classified",
@@ -524,8 +512,8 @@ test("supports custom app output mapping", async () => {
     run: async ({ context, runOptions }) => {
       context.setArtifact("entrypoint", "custom");
       expect(runOptions.context).toMatchObject({
-        metadata: {
-          scenario: "domain",
+        artifacts: {
+          entrypoint: "custom",
         },
       });
 
@@ -573,17 +561,17 @@ test("passes run input and context to agent factory before tool instrumentation"
   vi.stubEnv("VITEST_EVALS_REPLAY_MODE", "auto");
   vi.stubEnv("VITEST_EVALS_REPLAY_DIR", replayDir);
 
-  let createdTool: OpenAiAgentsTool<string, DemoMetadata> | undefined;
+  let createdTool: OpenAiAgentsTool<string> | undefined;
   const agentFactory = vi.fn(
     ({
       input,
       context,
     }: {
       input: string;
-      context: HarnessContext<DemoMetadata>;
+      context: HarnessContext;
     }) => {
       context.setArtifact("preparedInput", input);
-      const scenario = context.metadata.scenario ?? "unknown";
+      const scenario = "refund";
       const lookupBottle = {
         type: "function",
         name: "lookupBottle",
@@ -599,7 +587,7 @@ test("passes run input and context to agent factory before tool instrumentation"
             scenario,
           };
         }),
-      } satisfies OpenAiAgentsTool<string, DemoMetadata>;
+      } satisfies OpenAiAgentsTool<string>;
 
       createdTool = lookupBottle;
       return {
@@ -647,8 +635,8 @@ test("passes run input and context to agent factory before tool instrumentation"
     expect.objectContaining({
       input: "Classify bottle bt_123",
       context: expect.objectContaining({
-        metadata: {
-          scenario: "peated",
+        artifacts: {
+          preparedInput: "Classify bottle bt_123",
         },
       }),
     }),
@@ -659,7 +647,7 @@ test("passes run input and context to agent factory before tool instrumentation"
   expect(result.output).toEqual({
     bottleId: "bt_123",
     preparedInput: "Classify bottle bt_123",
-    scenario: "peated",
+    scenario: "refund",
   });
   expect(toolCalls(result.session)).toMatchObject([
     {
@@ -668,7 +656,7 @@ test("passes run input and context to agent factory before tool instrumentation"
       result: {
         bottleId: "bt_123",
         preparedInput: "Classify bottle bt_123",
-        scenario: "peated",
+        scenario: "refund",
       },
       metadata: {
         replay: {
@@ -755,7 +743,7 @@ test("wraps OpenAI Agents function tools with replay metadata", async () => {
     type: "function",
     name: "lookupBottle",
     invoke,
-  } satisfies OpenAiAgentsTool<string, DemoMetadata>;
+  } satisfies OpenAiAgentsTool<string>;
   const originalInvoke = lookupBottle.invoke;
   const agent = {
     name: "classifier",
@@ -874,7 +862,7 @@ test("prefers captured local tool results over model-visible output wrappers", a
       bottleId: "bt_123",
       family: "bourbon",
     })),
-  } satisfies OpenAiAgentsTool<string, DemoMetadata>;
+  } satisfies OpenAiAgentsTool<string>;
   const harness = openaiAgentsHarness({
     agent: {
       name: "classifier",
@@ -958,7 +946,7 @@ test("preserves explicit null captured local tool results", async () => {
     type: "function",
     name: "lookupBottle",
     invoke: vi.fn(async () => null),
-  } satisfies OpenAiAgentsTool<string, DemoMetadata>;
+  } satisfies OpenAiAgentsTool<string>;
   const harness = openaiAgentsHarness({
     agent: {
       name: "classifier",
@@ -1026,7 +1014,7 @@ test("errors when replay is configured for unknown OpenAI Agents tools", async (
     type: "function",
     name: "lookupBottle",
     invoke: vi.fn(),
-  } satisfies OpenAiAgentsTool<string, DemoMetadata>;
+  } satisfies OpenAiAgentsTool<string>;
   const runner = {
     run: vi.fn(),
   };
@@ -1055,7 +1043,7 @@ test("errors when replay is configured for OpenAI Agents tools without invoke", 
   const hostedTool = {
     type: "web_search_preview",
     name: "web_search_preview",
-  } satisfies OpenAiAgentsTool<string, DemoMetadata>;
+  } satisfies OpenAiAgentsTool<string>;
   const runner = {
     run: vi.fn(),
   };
@@ -1115,10 +1103,7 @@ test("instruments real OpenAI Agent tools without mutating the caller's agent", 
         expect(runAgent).not.toBe(agent);
         expect(runAgent.tools[0]).not.toBe(originalTool);
 
-        const runtimeTool = runAgent.tools[0] as OpenAiAgentsTool<
-          string,
-          DemoMetadata
-        >;
+        const runtimeTool = runAgent.tools[0] as OpenAiAgentsTool<string>;
         const evidence = await runtimeTool.invoke?.(
           runOptions?.context,
           JSON.stringify({
@@ -1164,7 +1149,7 @@ test("accepts agent and runner as factories", async () => {
       context,
     }: {
       input: string;
-      context: HarnessContext<DemoMetadata>;
+      context: HarnessContext;
     }) => {
       context.setArtifact("preparedInput", input);
       return {
@@ -1176,8 +1161,8 @@ test("accepts agent and runner as factories", async () => {
   const runnerRun = vi.fn(
     async (_agent: DemoAgent, _input: string, runOptions) => {
       expect(runOptions?.context).toMatchObject({
-        metadata: {
-          scenario: "peated",
+        artifacts: {
+          preparedInput: "Classify bottle bt_123",
         },
       });
       return runResult;
@@ -1236,7 +1221,7 @@ test("keeps tool capture isolated across overlapping runs", async () => {
     type: "function",
     name: "lookupBottle",
     invoke,
-  } satisfies OpenAiAgentsTool<string, DemoMetadata>;
+  } satisfies OpenAiAgentsTool<string>;
   const originalInvoke = lookupBottle.invoke;
   const agent = {
     name: "classifier",
@@ -1246,11 +1231,8 @@ test("keeps tool capture isolated across overlapping runs", async () => {
   const harness = openaiAgentsHarness({
     agent,
     runner: {
-      run: async (runAgent: DemoAgent, _input: string, runOptions) => {
-        const runtimeContext = runOptions?.context as
-          | { metadata: DemoMetadata }
-          | undefined;
-        const scenario = runtimeContext?.metadata.scenario ?? "unknown";
+      run: async (runAgent: DemoAgent, input: string, runOptions) => {
+        const scenario = input.includes("first") ? "first" : "second";
         await new Promise((resolve) => setTimeout(resolve, 1));
         const evidence = await runAgent.tools?.[0].invoke?.(
           runOptions?.context,
@@ -1368,7 +1350,7 @@ test("attaches partial tool calls when Runner.run errors", async () => {
       bottleId: "bt_missing",
       family: "unknown",
     }),
-  } satisfies OpenAiAgentsTool<string, DemoMetadata>;
+  } satisfies OpenAiAgentsTool<string>;
   const harness = openaiAgentsHarness({
     agent: {
       name: "classifier",

--- a/packages/harness-openai-agents/src/index.ts
+++ b/packages/harness-openai-agents/src/index.ts
@@ -1,7 +1,6 @@
 import type {
   Harness,
   HarnessContext,
-  HarnessMetadata,
   HarnessRun,
   JsonValue,
   NormalizedMessage,
@@ -95,12 +94,9 @@ type OpenAiAgentsRunnerResultOutput<TResult> = TResult extends HarnessRun<
 export type OpenAiAgentsReplayMode = ReplayMode;
 
 /** Runtime context object passed through OpenAI Agents run options. */
-export interface OpenAiAgentsRuntimeContext<
-  TMetadata extends HarnessMetadata = HarnessMetadata,
-> {
-  metadata: Readonly<TMetadata>;
-  artifacts: HarnessContext<TMetadata>["artifacts"];
-  setArtifact: HarnessContext<TMetadata>["setArtifact"];
+export interface OpenAiAgentsRuntimeContext {
+  artifacts: HarnessContext["artifacts"];
+  setArtifact: HarnessContext["setArtifact"];
 }
 
 /** Run options forwarded to OpenAI Agents runners. */
@@ -131,70 +127,45 @@ export interface OpenAiAgentsRunner<
 /** Runtime object prepared for OpenAI Agents harness executions. */
 export interface OpenAiAgentsRuntime<
   TInput = string,
-  TMetadata extends HarnessMetadata = HarnessMetadata,
-  TContext = OpenAiAgentsRuntimeContext<TMetadata>,
+  TContext = OpenAiAgentsRuntimeContext,
 > {
   context: TContext;
   runOptions: OpenAiAgentsRunOptions<TContext>;
   signal?: AbortSignal;
-  tools: OpenAiAgentsTool<TInput, TMetadata>[];
+  tools: OpenAiAgentsTool<TInput>[];
 }
 
 /** Arguments passed to per-run OpenAI agent factories. */
-export interface OpenAiAgentsCreateAgentArgs<
-  TInput = string,
-  TMetadata extends HarnessMetadata = HarnessMetadata,
-> {
+export interface OpenAiAgentsCreateAgentArgs<TInput = string> {
   input: TInput;
-  context: HarnessContext<TMetadata>;
+  context: HarnessContext;
 }
 
 /** Arguments passed to custom OpenAI Agents harness run callbacks. */
 export interface OpenAiAgentsHarnessRunArgs<
   TAgent,
   TInput,
-  TMetadata extends HarnessMetadata,
   TRunner,
   TResult,
   TContext,
 > {
   agent: TAgent;
   input: TInput;
-  context: HarnessContext<TMetadata>;
-  runtime: OpenAiAgentsRuntime<TInput, TMetadata, TContext>;
+  context: HarnessContext;
+  runtime: OpenAiAgentsRuntime<TInput, TContext>;
   runner: TRunner | undefined;
   runOptions: OpenAiAgentsRunOptions<TContext>;
 }
 
-type AgentSource<
-  TAgent,
-  TInput = string,
-  TMetadata extends HarnessMetadata = HarnessMetadata,
-> =
+type AgentSource<TAgent, TInput = string> =
   | TAgent
-  | ((
-      args: OpenAiAgentsCreateAgentArgs<TInput, TMetadata>,
-    ) => MaybePromise<TAgent>);
+  | ((args: OpenAiAgentsCreateAgentArgs<TInput>) => MaybePromise<TAgent>);
 
-type RunnerSource<
-  TAgent,
-  TInput,
-  TMetadata extends HarnessMetadata,
-  TRunner,
-  TResult,
-  TContext,
-> =
+type RunnerSource<TAgent, TInput, TRunner, TResult, TContext> =
   | TRunner
   | ((
       args: Omit<
-        OpenAiAgentsHarnessRunArgs<
-          TAgent,
-          TInput,
-          TMetadata,
-          TRunner,
-          TResult,
-          TContext
-        >,
+        OpenAiAgentsHarnessRunArgs<TAgent, TInput, TRunner, TResult, TContext>,
         "runner"
       >,
     ) => MaybePromise<TRunner>);
@@ -214,14 +185,12 @@ type OpenAiAgentsRunnerResult<TAgent, TInput, TContext, TRunner> =
 export interface OpenAiAgentsHarnessResultArgs<
   TAgent,
   TInput,
-  TMetadata extends HarnessMetadata,
   TRunner,
   TResult,
   TContext,
 > extends OpenAiAgentsHarnessRunArgs<
     TAgent,
     TInput,
-    TMetadata,
     TRunner,
     TResult,
     TContext
@@ -230,17 +199,13 @@ export interface OpenAiAgentsHarnessResultArgs<
 }
 
 /** Context passed to instrumented OpenAI Agents tools. */
-export interface OpenAiAgentsToolContext<
-  TInput = string,
-  TMetadata extends HarnessMetadata = HarnessMetadata,
-> {
+export interface OpenAiAgentsToolContext<TInput = string> {
   input: TInput;
-  metadata: HarnessContext<TMetadata>["metadata"];
   signal?: AbortSignal;
-  setArtifact: HarnessContext<TMetadata>["setArtifact"];
+  setArtifact: HarnessContext["setArtifact"];
   runContext: unknown;
   details: unknown;
-  tool: OpenAiAgentsTool<TInput, TMetadata>;
+  tool: OpenAiAgentsTool<TInput>;
 }
 
 /** Tool replay recording shape for OpenAI Agents tools. */
@@ -254,26 +219,18 @@ export type OpenAiAgentsToolReplayConfig<
   TArgs extends JsonValue = JsonValue,
   TResult extends JsonValue = JsonValue,
   TInput = string,
-  TMetadata extends HarnessMetadata = HarnessMetadata,
-> = ToolReplayConfig<
-  TArgs,
-  TResult,
-  OpenAiAgentsToolContext<TInput, TMetadata>
->;
+> = ToolReplayConfig<TArgs, TResult, OpenAiAgentsToolContext<TInput>>;
 
 /** Replay policy for one OpenAI Agents tool. */
-export type OpenAiAgentsToolReplayPolicy<
-  TInput = string,
-  TMetadata extends HarnessMetadata = HarnessMetadata,
-> =
+export type OpenAiAgentsToolReplayPolicy<TInput = string> =
   | boolean
-  | OpenAiAgentsToolReplayConfig<JsonValue, JsonValue, TInput, TMetadata>;
+  | OpenAiAgentsToolReplayConfig<JsonValue, JsonValue, TInput>;
 
 /** Replay policy map keyed by OpenAI Agents tool name. */
-export type OpenAiAgentsToolReplayPolicies<
-  TInput = string,
-  TMetadata extends HarnessMetadata = HarnessMetadata,
-> = Record<string, OpenAiAgentsToolReplayPolicy<TInput, TMetadata>>;
+export type OpenAiAgentsToolReplayPolicies<TInput = string> = Record<
+  string,
+  OpenAiAgentsToolReplayPolicy<TInput>
+>;
 
 type OpenAiAgentsInvoke = (...args: unknown[]) => unknown;
 
@@ -427,10 +384,7 @@ function resolveOpenAiAgentsJudgeOutput(result: unknown) {
 }
 
 /** Minimal OpenAI Agents tool shape instrumented by the harness. */
-export type OpenAiAgentsTool<
-  TInput = string,
-  TMetadata extends HarnessMetadata = HarnessMetadata,
-> = Record<string, unknown> & {
+export type OpenAiAgentsTool<TInput = string> = Record<string, unknown> & {
   name?: string;
   toolName?: string;
   type?: string;
@@ -440,16 +394,14 @@ export type OpenAiAgentsTool<
 type OpenAiAgentsHarnessOutputSelector<
   TAgent,
   TInput = string,
-  TMetadata extends HarnessMetadata = HarnessMetadata,
   TRunner = unknown,
   TResult = unknown,
-  TContext = OpenAiAgentsRuntimeContext<TMetadata>,
+  TContext = OpenAiAgentsRuntimeContext,
   TOutput extends JsonValue | undefined = JsonValue | undefined,
 > = (
   args: OpenAiAgentsHarnessResultArgs<
     TAgent,
     TInput,
-    TMetadata,
     TRunner,
     TResult,
     TContext
@@ -459,19 +411,18 @@ type OpenAiAgentsHarnessOutputSelector<
 type OpenAiAgentsHarnessBaseOptions<
   TAgent,
   TInput = string,
-  TMetadata extends HarnessMetadata = HarnessMetadata,
   TRunner = OpenAiAgentsRunner<
     TAgent,
     TInput,
-    OpenAiAgentsRuntimeContext<TMetadata>,
+    OpenAiAgentsRuntimeContext,
     unknown,
     JsonValue | undefined
   >,
   TResult = unknown,
-  TContext = OpenAiAgentsRuntimeContext<TMetadata>,
+  TContext = OpenAiAgentsRuntimeContext,
   TOutput extends JsonValue | undefined = JsonValue | undefined,
 > = {
-  agent: AgentSource<TAgent, TInput, TMetadata>;
+  agent: AgentSource<TAgent, TInput>;
   runOptions?:
     | OpenAiAgentsRunOptions<TContext>
     | ((
@@ -479,7 +430,6 @@ type OpenAiAgentsHarnessBaseOptions<
           OpenAiAgentsHarnessRunArgs<
             TAgent,
             TInput,
-            TMetadata,
             TRunner,
             TResult,
             TContext
@@ -487,11 +437,10 @@ type OpenAiAgentsHarnessBaseOptions<
           "runner" | "runtime" | "runOptions"
         >,
       ) => MaybePromise<OpenAiAgentsRunOptions<TContext> | undefined>);
-  toolReplay?: OpenAiAgentsToolReplayPolicies<TInput, TMetadata>;
+  toolReplay?: OpenAiAgentsToolReplayPolicies<TInput>;
   output?: OpenAiAgentsHarnessOutputSelector<
     TAgent,
     TInput,
-    TMetadata,
     TRunner,
     TResult,
     TContext,
@@ -503,40 +452,30 @@ type OpenAiAgentsHarnessBaseOptions<
 type OpenAiAgentsRunFn<
   TAgent,
   TInput,
-  TMetadata extends HarnessMetadata,
   TRunner,
   TResult,
   TContext,
   TOutput extends JsonValue | undefined,
 > = (
-  args: OpenAiAgentsHarnessRunArgs<
-    TAgent,
-    TInput,
-    TMetadata,
-    TRunner,
-    TResult,
-    TContext
-  >,
+  args: OpenAiAgentsHarnessRunArgs<TAgent, TInput, TRunner, TResult, TContext>,
 ) => MaybePromise<TResult | HarnessRun<TOutput>>;
 
 type OpenAiAgentsHarnessOptions<
   TAgent,
   TInput = string,
-  TMetadata extends HarnessMetadata = HarnessMetadata,
   TRunner = OpenAiAgentsRunner<
     TAgent,
     TInput,
-    OpenAiAgentsRuntimeContext<TMetadata>,
+    OpenAiAgentsRuntimeContext,
     unknown,
     JsonValue | undefined
   >,
   TResult = unknown,
-  TContext = OpenAiAgentsRuntimeContext<TMetadata>,
+  TContext = OpenAiAgentsRuntimeContext,
   TOutput extends JsonValue | undefined = JsonValue | undefined,
 > = OpenAiAgentsHarnessBaseOptions<
   TAgent,
   TInput,
-  TMetadata,
   TRunner,
   TResult,
   TContext,
@@ -544,18 +483,10 @@ type OpenAiAgentsHarnessOptions<
 > &
   (
     | {
-        runner: RunnerSource<
-          TAgent,
-          TInput,
-          TMetadata,
-          TRunner,
-          TResult,
-          TContext
-        >;
+        runner: RunnerSource<TAgent, TInput, TRunner, TResult, TContext>;
         run?: OpenAiAgentsRunFn<
           TAgent,
           TInput,
-          TMetadata,
           TRunner,
           TResult,
           TContext,
@@ -566,41 +497,31 @@ type OpenAiAgentsHarnessOptions<
         run: OpenAiAgentsRunFn<
           TAgent,
           TInput,
-          TMetadata,
           TRunner,
           TResult,
           TContext,
           TOutput
         >;
-        runner?: RunnerSource<
-          TAgent,
-          TInput,
-          TMetadata,
-          TRunner,
-          TResult,
-          TContext
-        >;
+        runner?: RunnerSource<TAgent, TInput, TRunner, TResult, TContext>;
       }
   );
 
 type OpenAiAgentsHarnessOptionsWithOutput<
   TAgent,
   TInput = string,
-  TMetadata extends HarnessMetadata = HarnessMetadata,
   TRunner = OpenAiAgentsRunner<
     TAgent,
     TInput,
-    OpenAiAgentsRuntimeContext<TMetadata>,
+    OpenAiAgentsRuntimeContext,
     unknown,
     JsonValue | undefined
   >,
   TResult = unknown,
-  TContext = OpenAiAgentsRuntimeContext<TMetadata>,
+  TContext = OpenAiAgentsRuntimeContext,
   TOutput extends JsonValue | undefined = JsonValue | undefined,
 > = OpenAiAgentsHarnessOptions<
   TAgent,
   TInput,
-  TMetadata,
   TRunner,
   TResult,
   TContext,
@@ -609,7 +530,6 @@ type OpenAiAgentsHarnessOptionsWithOutput<
   output: OpenAiAgentsHarnessOutputSelector<
     TAgent,
     TInput,
-    TMetadata,
     TRunner,
     TResult,
     TContext,
@@ -620,20 +540,18 @@ type OpenAiAgentsHarnessOptionsWithOutput<
 type OpenAiAgentsHarnessRunOptionsWithoutOutput<
   TAgent,
   TInput = string,
-  TMetadata extends HarnessMetadata = HarnessMetadata,
   TRunner = OpenAiAgentsRunner<
     TAgent,
     TInput,
-    OpenAiAgentsRuntimeContext<TMetadata>,
+    OpenAiAgentsRuntimeContext,
     unknown,
     JsonValue | undefined
   >,
   TResult = unknown,
-  TContext = OpenAiAgentsRuntimeContext<TMetadata>,
+  TContext = OpenAiAgentsRuntimeContext,
 > = OpenAiAgentsHarnessBaseOptions<
   TAgent,
   TInput,
-  TMetadata,
   TRunner,
   TResult,
   TContext,
@@ -642,32 +560,29 @@ type OpenAiAgentsHarnessRunOptionsWithoutOutput<
   run: OpenAiAgentsRunFn<
     TAgent,
     TInput,
-    TMetadata,
     TRunner,
     TResult,
     TContext,
     JsonValue | undefined
   >;
-  runner?: RunnerSource<TAgent, TInput, TMetadata, TRunner, TResult, TContext>;
+  runner?: RunnerSource<TAgent, TInput, TRunner, TResult, TContext>;
   output?: never;
 };
 
 type OpenAiAgentsHarnessRunnerOptionsWithoutOutput<
   TAgent,
   TInput = string,
-  TMetadata extends HarnessMetadata = HarnessMetadata,
   TRunner = OpenAiAgentsRunner<
     TAgent,
     TInput,
-    OpenAiAgentsRuntimeContext<TMetadata>,
+    OpenAiAgentsRuntimeContext,
     unknown,
     JsonValue | undefined
   >,
-  TContext = OpenAiAgentsRuntimeContext<TMetadata>,
+  TContext = OpenAiAgentsRuntimeContext,
 > = OpenAiAgentsHarnessBaseOptions<
   TAgent,
   TInput,
-  TMetadata,
   TRunner,
   OpenAiAgentsRunnerResult<TAgent, TInput, TContext, TRunner>,
   TContext,
@@ -676,7 +591,6 @@ type OpenAiAgentsHarnessRunnerOptionsWithoutOutput<
   runner: RunnerSource<
     TAgent,
     TInput,
-    TMetadata,
     TRunner,
     OpenAiAgentsRunnerResult<TAgent, TInput, TContext, TRunner>,
     TContext
@@ -693,68 +607,62 @@ type RuntimeToolCapture = {
 export function openaiAgentsHarness<
   TAgent,
   TInput = string,
-  TMetadata extends HarnessMetadata = HarnessMetadata,
   TRunner = OpenAiAgentsRunner<
     TAgent,
     TInput,
-    OpenAiAgentsRuntimeContext<TMetadata>,
+    OpenAiAgentsRuntimeContext,
     unknown,
     JsonValue | undefined
   >,
   TResult = unknown,
-  TContext = OpenAiAgentsRuntimeContext<TMetadata>,
+  TContext = OpenAiAgentsRuntimeContext,
   TOutput extends JsonValue | undefined = JsonValue | undefined,
 >(
   options: OpenAiAgentsHarnessOptionsWithOutput<
     TAgent,
     TInput,
-    TMetadata,
     TRunner,
     TResult,
     TContext,
     TOutput
   >,
-): Harness<TInput, TOutput, TMetadata>;
+): Harness<TInput, TOutput>;
 export function openaiAgentsHarness<
   TAgent,
   TInput = string,
-  TMetadata extends HarnessMetadata = HarnessMetadata,
   TRunner = OpenAiAgentsRunner<
     TAgent,
     TInput,
-    OpenAiAgentsRuntimeContext<TMetadata>,
+    OpenAiAgentsRuntimeContext,
     unknown,
     JsonValue | undefined
   >,
   TResult = unknown,
-  TContext = OpenAiAgentsRuntimeContext<TMetadata>,
+  TContext = OpenAiAgentsRuntimeContext,
 >(
   options: OpenAiAgentsHarnessRunOptionsWithoutOutput<
     TAgent,
     TInput,
-    TMetadata,
     TRunner,
     TResult,
     TContext
   >,
-): Harness<TInput, OpenAiAgentsRunResultOutput<Awaited<TResult>>, TMetadata>;
+): Harness<TInput, OpenAiAgentsRunResultOutput<Awaited<TResult>>>;
 export function openaiAgentsHarness<
   TAgent,
   TInput = string,
-  TMetadata extends HarnessMetadata = HarnessMetadata,
   TRunner = OpenAiAgentsRunner<
     TAgent,
     TInput,
-    OpenAiAgentsRuntimeContext<TMetadata>,
+    OpenAiAgentsRuntimeContext,
     unknown,
     JsonValue | undefined
   >,
-  TContext = OpenAiAgentsRuntimeContext<TMetadata>,
+  TContext = OpenAiAgentsRuntimeContext,
 >(
   options: OpenAiAgentsHarnessRunnerOptionsWithoutOutput<
     TAgent,
     TInput,
-    TMetadata,
     TRunner,
     TContext
   >,
@@ -762,38 +670,35 @@ export function openaiAgentsHarness<
   TInput,
   OpenAiAgentsRunnerResultOutput<
     OpenAiAgentsRunnerResult<TAgent, TInput, TContext, TRunner>
-  >,
-  TMetadata
+  >
 >;
 export function openaiAgentsHarness<
   TAgent,
   TInput = string,
-  TMetadata extends HarnessMetadata = HarnessMetadata,
   TRunner = OpenAiAgentsRunner<
     TAgent,
     TInput,
-    OpenAiAgentsRuntimeContext<TMetadata>,
+    OpenAiAgentsRuntimeContext,
     unknown,
     JsonValue | undefined
   >,
   TResult = unknown,
-  TContext = OpenAiAgentsRuntimeContext<TMetadata>,
+  TContext = OpenAiAgentsRuntimeContext,
   TOutput extends JsonValue | undefined = JsonValue | undefined,
 >(
   options: OpenAiAgentsHarnessOptions<
     TAgent,
     TInput,
-    TMetadata,
     TRunner,
     TResult,
     TContext,
     TOutput
   >,
-): Harness<TInput, TOutput, TMetadata> {
+): Harness<TInput, TOutput> {
   validateOptions(options);
 
   const harnessName = options.name ?? "openai-agents";
-  const harness: Harness<TInput, TOutput, TMetadata> = {
+  const harness: Harness<TInput, TOutput> = {
     name: harnessName,
     run: async (input, context) => {
       const startedAt = new Date();
@@ -826,9 +731,9 @@ export function openaiAgentsHarness<
   return harness;
 }
 
-function createFailedOpenAiAgentsRun<TInput, TMetadata extends HarnessMetadata>(
+function createFailedOpenAiAgentsRun<TInput>(
   input: TInput,
-  context: HarnessContext<TMetadata>,
+  context: HarnessContext,
   error: unknown,
   harnessName: string,
   startedAt: Date,
@@ -850,7 +755,6 @@ function createFailedOpenAiAgentsRun<TInput, TMetadata extends HarnessMetadata>(
 async function executeOpenAiAgentsHarness<
   TAgent,
   TInput,
-  TMetadata extends HarnessMetadata,
   TRunner,
   TResult,
   TContext,
@@ -859,7 +763,6 @@ async function executeOpenAiAgentsHarness<
   options: OpenAiAgentsHarnessOptions<
     TAgent,
     TInput,
-    TMetadata,
     TRunner,
     TResult,
     TContext,
@@ -867,7 +770,7 @@ async function executeOpenAiAgentsHarness<
   >,
   agent: TAgent,
   input: TInput,
-  context: HarnessContext<TMetadata>,
+  context: HarnessContext,
 ): Promise<HarnessRun<TOutput>> {
   const startedAt = Date.now();
   const trace = createTraceRecorder(options.name ?? "openai-agents");
@@ -885,14 +788,12 @@ async function executeOpenAiAgentsHarness<
     },
     async (instrumentedAgent, runtimeTools) => {
       const defaultRuntimeContext = {
-        metadata: context.metadata,
         artifacts: context.artifacts,
         setArtifact: context.setArtifact,
-      } satisfies OpenAiAgentsRuntimeContext<TMetadata>;
+      } satisfies OpenAiAgentsRuntimeContext;
       const runOptions = await resolveRunOptions<
         TAgent,
         TInput,
-        TMetadata,
         TRunner,
         TResult,
         TContext,
@@ -909,7 +810,7 @@ async function executeOpenAiAgentsHarness<
         runOptions,
         signal: runOptions.signal,
         tools: runtimeTools,
-      } satisfies OpenAiAgentsRuntime<TInput, TMetadata, TContext>;
+      } satisfies OpenAiAgentsRuntime<TInput, TContext>;
       const runner = await resolveRunner(options, {
         agent: instrumentedAgent,
         input,
@@ -958,7 +859,6 @@ async function executeOpenAiAgentsHarness<
         const resultArgs: OpenAiAgentsHarnessResultArgs<
           TAgent,
           TInput,
-          TMetadata,
           TRunner,
           TResult,
           TContext
@@ -1032,7 +932,6 @@ async function executeOpenAiAgentsHarness<
 function validateOptions<
   TAgent,
   TInput,
-  TMetadata extends HarnessMetadata,
   TRunner,
   TResult,
   TContext,
@@ -1041,7 +940,6 @@ function validateOptions<
   options: OpenAiAgentsHarnessOptions<
     TAgent,
     TInput,
-    TMetadata,
     TRunner,
     TResult,
     TContext,
@@ -1064,7 +962,6 @@ function validateOptions<
 async function resolveAgent<
   TAgent,
   TInput,
-  TMetadata extends HarnessMetadata,
   TRunner,
   TResult,
   TContext,
@@ -1073,24 +970,19 @@ async function resolveAgent<
   options: OpenAiAgentsHarnessOptions<
     TAgent,
     TInput,
-    TMetadata,
     TRunner,
     TResult,
     TContext,
     TOutput
   >,
-  args: OpenAiAgentsCreateAgentArgs<TInput, TMetadata>,
+  args: OpenAiAgentsCreateAgentArgs<TInput>,
 ) {
   return resolveAgentSource(options.agent, args);
 }
 
-async function resolveAgentSource<
-  TAgent,
-  TInput,
-  TMetadata extends HarnessMetadata,
->(
-  agent: AgentSource<TAgent, TInput, TMetadata>,
-  args: OpenAiAgentsCreateAgentArgs<TInput, TMetadata>,
+async function resolveAgentSource<TAgent, TInput>(
+  agent: AgentSource<TAgent, TInput>,
+  args: OpenAiAgentsCreateAgentArgs<TInput>,
 ): Promise<TAgent> {
   if (isAgentFactory(agent)) {
     return agent(args);
@@ -1099,10 +991,10 @@ async function resolveAgentSource<
   return agent;
 }
 
-function isAgentFactory<TAgent, TInput, TMetadata extends HarnessMetadata>(
-  agent: AgentSource<TAgent, TInput, TMetadata>,
+function isAgentFactory<TAgent, TInput>(
+  agent: AgentSource<TAgent, TInput>,
 ): agent is (
-  args: OpenAiAgentsCreateAgentArgs<TInput, TMetadata>,
+  args: OpenAiAgentsCreateAgentArgs<TInput>,
 ) => MaybePromise<TAgent> {
   return typeof agent === "function" && !hasCallableMethod(agent, "run");
 }
@@ -1110,7 +1002,6 @@ function isAgentFactory<TAgent, TInput, TMetadata extends HarnessMetadata>(
 async function resolveRunner<
   TAgent,
   TInput,
-  TMetadata extends HarnessMetadata,
   TRunner,
   TResult,
   TContext,
@@ -1119,21 +1010,13 @@ async function resolveRunner<
   options: OpenAiAgentsHarnessOptions<
     TAgent,
     TInput,
-    TMetadata,
     TRunner,
     TResult,
     TContext,
     TOutput
   >,
   args: Omit<
-    OpenAiAgentsHarnessRunArgs<
-      TAgent,
-      TInput,
-      TMetadata,
-      TRunner,
-      TResult,
-      TContext
-    >,
+    OpenAiAgentsHarnessRunArgs<TAgent, TInput, TRunner, TResult, TContext>,
     "runner"
   >,
 ) {
@@ -1144,24 +1027,10 @@ async function resolveRunner<
   return undefined;
 }
 
-async function resolveRunnerSource<
-  TAgent,
-  TInput,
-  TMetadata extends HarnessMetadata,
-  TRunner,
-  TResult,
-  TContext,
->(
-  runner: RunnerSource<TAgent, TInput, TMetadata, TRunner, TResult, TContext>,
+async function resolveRunnerSource<TAgent, TInput, TRunner, TResult, TContext>(
+  runner: RunnerSource<TAgent, TInput, TRunner, TResult, TContext>,
   args: Omit<
-    OpenAiAgentsHarnessRunArgs<
-      TAgent,
-      TInput,
-      TMetadata,
-      TRunner,
-      TResult,
-      TContext
-    >,
+    OpenAiAgentsHarnessRunArgs<TAgent, TInput, TRunner, TResult, TContext>,
     "runner"
   >,
 ): Promise<TRunner> {
@@ -1172,25 +1041,11 @@ async function resolveRunnerSource<
   return runner;
 }
 
-function isRunnerFactory<
-  TAgent,
-  TInput,
-  TMetadata extends HarnessMetadata,
-  TRunner,
-  TResult,
-  TContext,
->(
-  runner: RunnerSource<TAgent, TInput, TMetadata, TRunner, TResult, TContext>,
+function isRunnerFactory<TAgent, TInput, TRunner, TResult, TContext>(
+  runner: RunnerSource<TAgent, TInput, TRunner, TResult, TContext>,
 ): runner is (
   args: Omit<
-    OpenAiAgentsHarnessRunArgs<
-      TAgent,
-      TInput,
-      TMetadata,
-      TRunner,
-      TResult,
-      TContext
-    >,
+    OpenAiAgentsHarnessRunArgs<TAgent, TInput, TRunner, TResult, TContext>,
     "runner"
   >,
 ) => MaybePromise<TRunner> {
@@ -1200,7 +1055,6 @@ function isRunnerFactory<
 async function resolveRunOptions<
   TAgent,
   TInput,
-  TMetadata extends HarnessMetadata,
   TRunner,
   TResult,
   TContext,
@@ -1209,7 +1063,6 @@ async function resolveRunOptions<
   options: OpenAiAgentsHarnessOptions<
     TAgent,
     TInput,
-    TMetadata,
     TRunner,
     TResult,
     TContext,
@@ -1217,7 +1070,7 @@ async function resolveRunOptions<
   >,
   agent: TAgent,
   input: TInput,
-  context: HarnessContext<TMetadata>,
+  context: HarnessContext,
   defaultRuntimeContext: TContext,
 ): Promise<OpenAiAgentsRunOptions<TContext>> {
   const userOptions =
@@ -1247,7 +1100,6 @@ async function resolveRunOptions<
 async function runAgent<
   TAgent,
   TInput,
-  TMetadata extends HarnessMetadata,
   TRunner,
   TResult,
   TContext,
@@ -1256,20 +1108,12 @@ async function runAgent<
   options: OpenAiAgentsHarnessOptions<
     TAgent,
     TInput,
-    TMetadata,
     TRunner,
     TResult,
     TContext,
     TOutput
   >,
-  args: OpenAiAgentsHarnessRunArgs<
-    TAgent,
-    TInput,
-    TMetadata,
-    TRunner,
-    TResult,
-    TContext
-  >,
+  args: OpenAiAgentsHarnessRunArgs<TAgent, TInput, TRunner, TResult, TContext>,
 ): Promise<TResult | HarnessRun<TOutput>> {
   if (options.run) {
     return options.run(args);
@@ -1314,7 +1158,6 @@ async function settleRunResult(result: unknown) {
 function hasOutputSelector<
   TAgent,
   TInput,
-  TMetadata extends HarnessMetadata,
   TRunner,
   TResult,
   TContext,
@@ -1323,7 +1166,6 @@ function hasOutputSelector<
   options: OpenAiAgentsHarnessOptions<
     TAgent,
     TInput,
-    TMetadata,
     TRunner,
     TResult,
     TContext,
@@ -1533,25 +1375,20 @@ function usageNumberProperty(
   return numberProperty(value, camelKey) ?? numberProperty(value, snakeKey);
 }
 
-async function withInstrumentedAgentTools<
-  TAgent,
-  TInput,
-  TMetadata extends HarnessMetadata,
-  TResult,
->(
+async function withInstrumentedAgentTools<TAgent, TInput, TResult>(
   agent: TAgent,
   args: {
     input: TInput;
-    context: HarnessContext<TMetadata>;
+    context: HarnessContext;
     capture: RuntimeToolCapture;
-    toolReplay: OpenAiAgentsToolReplayPolicies<TInput, TMetadata> | undefined;
+    toolReplay: OpenAiAgentsToolReplayPolicies<TInput> | undefined;
   },
   callback: (
     agent: TAgent,
-    runtimeTools: OpenAiAgentsTool<TInput, TMetadata>[],
+    runtimeTools: OpenAiAgentsTool<TInput>[],
   ) => Promise<TResult>,
 ) {
-  const agentTools = getAgentTools<TInput, TMetadata>(agent) ?? [];
+  const agentTools = getAgentTools<TInput>(agent) ?? [];
   validateToolReplayPolicies(agentTools, args.toolReplay);
 
   if (agentTools.length === 0) {
@@ -1563,24 +1400,24 @@ async function withInstrumentedAgentTools<
   return callback(instrumentedAgent, runtimeTools);
 }
 
-function getAgentTools<TInput, TMetadata extends HarnessMetadata>(
+function getAgentTools<TInput>(
   agent: unknown,
-): OpenAiAgentsTool<TInput, TMetadata>[] | undefined {
+): OpenAiAgentsTool<TInput>[] | undefined {
   const tools = getObjectProperty(agent, "tools");
   return Array.isArray(tools)
-    ? (tools as OpenAiAgentsTool<TInput, TMetadata>[])
+    ? (tools as OpenAiAgentsTool<TInput>[])
     : undefined;
 }
 
-function instrumentTool<TInput, TMetadata extends HarnessMetadata>(
-  tool: OpenAiAgentsTool<TInput, TMetadata>,
+function instrumentTool<TInput>(
+  tool: OpenAiAgentsTool<TInput>,
   args: {
     input: TInput;
-    context: HarnessContext<TMetadata>;
+    context: HarnessContext;
     capture: RuntimeToolCapture;
-    toolReplay: OpenAiAgentsToolReplayPolicies<TInput, TMetadata> | undefined;
+    toolReplay: OpenAiAgentsToolReplayPolicies<TInput> | undefined;
   },
-): OpenAiAgentsTool<TInput, TMetadata> {
+): OpenAiAgentsTool<TInput> {
   const toolName = resolveToolName(tool);
   const replay = args.toolReplay?.[toolName];
 
@@ -1615,9 +1452,9 @@ function instrumentTool<TInput, TMetadata extends HarnessMetadata>(
   };
 }
 
-function validateToolReplayPolicies<TInput, TMetadata extends HarnessMetadata>(
-  tools: OpenAiAgentsTool<TInput, TMetadata>[],
-  toolReplay: OpenAiAgentsToolReplayPolicies<TInput, TMetadata> | undefined,
+function validateToolReplayPolicies<TInput>(
+  tools: OpenAiAgentsTool<TInput>[],
+  toolReplay: OpenAiAgentsToolReplayPolicies<TInput> | undefined,
 ) {
   const replayToolNames = Object.entries(toolReplay ?? {})
     .filter(([, replay]) => Boolean(replay))
@@ -1637,15 +1474,15 @@ function validateToolReplayPolicies<TInput, TMetadata extends HarnessMetadata>(
   }
 }
 
-function cloneAgentWithTools<TAgent, TInput, TMetadata extends HarnessMetadata>(
+function cloneAgentWithTools<TAgent, TInput>(
   agent: TAgent,
-  tools: OpenAiAgentsTool<TInput, TMetadata>[],
+  tools: OpenAiAgentsTool<TInput>[],
 ): TAgent {
   if (hasCallableMethod(agent, "clone")) {
     return (
       agent as {
         clone: (config: {
-          tools: OpenAiAgentsTool<TInput, TMetadata>[];
+          tools: OpenAiAgentsTool<TInput>[];
         }) => TAgent;
       }
     ).clone({ tools });
@@ -1658,10 +1495,7 @@ function cloneAgentWithTools<TAgent, TInput, TMetadata extends HarnessMetadata>(
   return Object.assign({}, agent, { tools }) as TAgent;
 }
 
-async function executeInstrumentedTool<
-  TInput,
-  TMetadata extends HarnessMetadata,
->({
+async function executeInstrumentedTool<TInput>({
   tool,
   toolName,
   replay,
@@ -1673,14 +1507,14 @@ async function executeInstrumentedTool<
   capture,
   execute,
 }: {
-  tool: OpenAiAgentsTool<TInput, TMetadata>;
+  tool: OpenAiAgentsTool<TInput>;
   toolName: string;
-  replay: OpenAiAgentsToolReplayPolicy<TInput, TMetadata> | undefined;
+  replay: OpenAiAgentsToolReplayPolicy<TInput> | undefined;
   rawInput: unknown;
   runContext: unknown;
   details: unknown;
   input: TInput;
-  context: HarnessContext<TMetadata>;
+  context: HarnessContext;
   capture: RuntimeToolCapture;
   execute: () => MaybePromise<unknown>;
 }) {
@@ -1689,13 +1523,12 @@ async function executeInstrumentedTool<
   const normalizedArgs = normalizeArguments(rawInput);
   const replayContext = {
     input,
-    metadata: context.metadata,
     signal: context.signal,
     setArtifact: context.setArtifact,
     runContext,
     details,
     tool,
-  } satisfies OpenAiAgentsToolContext<TInput, TMetadata>;
+  } satisfies OpenAiAgentsToolContext<TInput>;
 
   try {
     const execution = replay

--- a/packages/harness-openai-agents/src/judgeHarness.test.ts
+++ b/packages/harness-openai-agents/src/judgeHarness.test.ts
@@ -37,7 +37,6 @@ test("openaiAgentsJudgeHarness runs judge prompts through OpenAI Agents", async 
       },
     },
     {
-      metadata: {},
       signal,
       artifacts: {},
       setArtifact: () => {},
@@ -84,7 +83,6 @@ test("openaiAgentsJudgeHarness preserves null judge output", async () => {
       prompt: "Return null.",
     },
     {
-      metadata: {},
       artifacts: {},
       setArtifact: () => {},
     },

--- a/packages/harness-pi-ai/README.md
+++ b/packages/harness-pi-ai/README.md
@@ -17,7 +17,6 @@ import {
   createJudge,
   describeEval,
   toolCalls,
-  type JudgeContext,
 } from "vitest-evals";
 
 const harness = piAiHarness({
@@ -79,16 +78,15 @@ If the agent already implements `run(input, runtime)`, you can omit `run` and
 the harness will call that method automatically.
 
 `agent` can be an object or a per-run factory. The factory receives the per-run
-input and harness context before the adapter infers and instruments native
-agent tools. Use that for scenario-specific instructions, tool closures, or
-metadata without leaving the default replay path:
+input before the adapter infers and instruments native agent tools. Use that
+for scenario-specific instructions or tool closures without leaving the default
+replay path:
 
 ```ts
 const harness = piAiHarness({
-  agent: ({ input, context }) =>
+  agent: ({ input }) =>
     createRefundAgent({
       instructions: buildInstructions(input),
-      metadata: context.metadata,
     }),
   toolReplay: {
     lookupInvoice: true,

--- a/packages/harness-pi-ai/src/index.test.ts
+++ b/packages/harness-pi-ai/src/index.test.ts
@@ -10,9 +10,6 @@ import {
 import type { Harness, HarnessContext, JsonValue } from "vitest-evals/harness";
 import { piAiHarness, type PiAiRuntime, type PiAiToolset } from "./index";
 
-type DemoMetadata = {
-  scenario?: string;
-};
 type RefundDecision = {
   status: "approved" | "denied";
 };
@@ -22,7 +19,7 @@ type Equal<TActual, TExpected> = (<T>() => T extends TActual ? 1 : 2) extends <
   ? true
   : false;
 type Expect<T extends true> = T;
-type HarnessOutput<THarness> = THarness extends Harness<any, infer TOutput, any>
+type HarnessOutput<THarness> = THarness extends Harness<any, infer TOutput>
   ? TOutput
   : never;
 
@@ -114,9 +111,9 @@ const tools = {
       refundable: true,
     }),
   },
-} satisfies PiAiToolset<string, DemoMetadata>;
+} satisfies PiAiToolset<string>;
 
-type DemoRuntime = PiAiRuntime<typeof tools, string, DemoMetadata>;
+type DemoRuntime = PiAiRuntime<typeof tools, string>;
 
 let replayDir: string | undefined;
 
@@ -166,7 +163,7 @@ test("accepts agent as a factory", async () => {
       context,
     }: {
       input: string;
-      context: HarnessContext<DemoMetadata>;
+      context: HarnessContext;
     }) => {
       context.setArtifact("preparedInput", input);
       return {
@@ -181,7 +178,7 @@ test("accepts agent as a factory", async () => {
       runtime,
     }: {
       agent: { id: string };
-      context: HarnessContext<DemoMetadata>;
+      context: HarnessContext;
       runtime: DemoRuntime;
     }) => {
       context.setArtifact("agentId", agent.id);
@@ -204,7 +201,6 @@ test("accepts agent as a factory", async () => {
   });
 
   const result = await harness.run("Refund invoice inv_123", {
-    metadata: {},
     artifacts,
     setArtifact: vi.fn((name: string, value: JsonValue) => {
       artifacts[name] = value;
@@ -269,7 +265,6 @@ test("does not infer app output from arbitrary custom result shapes", async () =
     }),
   });
   const context = {
-    metadata: {},
     artifacts: {},
     setArtifact: vi.fn(),
   };
@@ -672,7 +667,7 @@ describeEval(
               refundable: true,
             }),
           },
-        } satisfies PiAiToolset<string, DemoMetadata>;
+        } satisfies PiAiToolset<string>;
 
         const nativeTools = [
           {
@@ -794,7 +789,7 @@ test("lets native Pi tools own replay when they delegate to a runtime tool of th
           lookupInvoice: {
             execute: lookupInvoice,
           },
-        } satisfies PiAiToolset<string, DemoMetadata>,
+        } satisfies PiAiToolset<string>,
         agent: {
           state: {
             tools: nativeTools,
@@ -819,7 +814,6 @@ test("lets native Pi tools own replay when they delegate to a runtime tool of th
   });
 
   const firstRun = await replayHarness.run("Refund invoice inv_123", {
-    metadata: {},
     artifacts: {},
     setArtifact: vi.fn(),
   });
@@ -870,7 +864,6 @@ test("lets native Pi tools own replay when they delegate to a runtime tool of th
   });
 
   const secondRun = await replayHarness.run("Refund invoice inv_123", {
-    metadata: {},
     artifacts: {},
     setArtifact: vi.fn(),
   });
@@ -900,7 +893,7 @@ describeEval(
               refundable: true,
             }),
           },
-        } satisfies PiAiToolset<string, DemoMetadata>;
+        } satisfies PiAiToolset<string>;
 
         return {
           toolset,
@@ -952,7 +945,7 @@ test("prefers inferred non-empty runtime toolsets over empty placeholders", asyn
         lookupInvoice: {
           execute: lookupInvoice,
         },
-      } satisfies PiAiToolset<string, DemoMetadata>;
+      } satisfies PiAiToolset<string>;
 
       return {
         toolset: {},
@@ -975,7 +968,6 @@ test("prefers inferred non-empty runtime toolsets over empty placeholders", asyn
   });
 
   const result = await harness.run("Refund invoice inv_123", {
-    metadata: {},
     artifacts: {},
     setArtifact: vi.fn(),
   });
@@ -1008,7 +1000,6 @@ test("supports a typed output selector", async () => {
   });
 
   const result = await normalizedHarness.run("Refund invoice inv_123", {
-    metadata: {},
     artifacts: {},
     setArtifact: vi.fn(),
   });
@@ -1052,7 +1043,6 @@ test("applies output selectors to HarnessRun-shaped results", async () => {
   });
 
   const result = await normalizedHarness.run("Refund invoice inv_123", {
-    metadata: {},
     artifacts: {},
     setArtifact: vi.fn(),
   });
@@ -1094,7 +1084,6 @@ test("moves provider-specific usage fields into metadata", async () => {
   });
 
   const result = await normalizedHarness.run("Refund invoice inv_123", {
-    metadata: {},
     artifacts: {},
     setArtifact: vi.fn(),
   });
@@ -1124,7 +1113,7 @@ test("attaches a partial run when the harness errors", async () => {
           throw new Error(`Invoice ${invoiceId} not found`);
         },
       },
-    } satisfies PiAiToolset<string, DemoMetadata>,
+    } satisfies PiAiToolset<string>,
     run: async ({ runtime }) => {
       await runtime.tools.lookupInvoice({
         invoiceId: "inv_missing",
@@ -1140,7 +1129,6 @@ test("attaches a partial run when the harness errors", async () => {
 
   const error = await erroringHarness
     .run("Refund invoice inv_missing", {
-      metadata: {},
       artifacts: {},
       setArtifact: vi.fn(),
     })
@@ -1202,7 +1190,6 @@ test("attaches a failed run when agent setup fails", async () => {
     }),
   });
   const context = {
-    metadata: {},
     artifacts: {} as Record<string, JsonValue>,
     setArtifact: vi.fn((name: string, value: JsonValue) => {
       context.artifacts[name] = value;
@@ -1298,7 +1285,6 @@ test("replays native agent tools without breaking the agent-facing result", asyn
   });
 
   const firstRun = await replayHarness.run("Refund invoice inv_123", {
-    metadata: {},
     artifacts: {},
     setArtifact: vi.fn(),
   });
@@ -1376,7 +1362,6 @@ test("replays native agent tools without breaking the agent-facing result", asyn
   ]);
 
   const secondRun = await replayHarness.run("Refund invoice inv_123", {
-    metadata: {},
     artifacts: {},
     setArtifact: vi.fn(),
   });
@@ -1458,7 +1443,6 @@ test("does not opt native agent tools into replay from tool objects", async () =
   });
 
   const run = await harness.run("Refund invoice inv_123", {
-    metadata: {},
     artifacts: {},
     setArtifact: vi.fn(),
   });
@@ -1478,10 +1462,10 @@ test("passes run input and context to agent factory before native tool instrumen
       context,
     }: {
       input: string;
-      context: HarnessContext<DemoMetadata>;
+      context: HarnessContext;
     }) => {
       context.setArtifact("preparedInput", input);
-      const scenario = context.metadata.scenario ?? "unknown";
+      const scenario = "refund";
       const nativeTools = [
         {
           name: "lookupInvoice",
@@ -1533,10 +1517,7 @@ test("passes run input and context to agent factory before native tool instrumen
     },
   });
   const artifacts: Record<string, JsonValue> = {};
-  const context: HarnessContext<DemoMetadata> = {
-    metadata: {
-      scenario: "refund",
-    },
+  const context: HarnessContext = {
     artifacts,
     setArtifact: vi.fn((name: string, value: JsonValue) => {
       artifacts[name] = value;
@@ -1549,8 +1530,8 @@ test("passes run input and context to agent factory before native tool instrumen
     expect.objectContaining({
       input: "Refund invoice inv_123",
       context: expect.objectContaining({
-        metadata: {
-          scenario: "refund",
+        artifacts: {
+          preparedInput: "Refund invoice inv_123",
         },
       }),
     }),
@@ -1599,7 +1580,7 @@ test("records and replays opt-in tools in auto mode", async () => {
       lookupInvoice: {
         execute,
       },
-    } satisfies PiAiToolset<string, DemoMetadata>,
+    } satisfies PiAiToolset<string>,
     run: async ({ runtime }) => {
       await runtime.tools.lookupInvoice({
         invoiceId: "inv_123",
@@ -1614,7 +1595,6 @@ test("records and replays opt-in tools in auto mode", async () => {
   });
 
   const firstRun = await replayHarness.run("Refund invoice inv_123", {
-    metadata: {},
     artifacts: {},
     setArtifact: vi.fn(),
   });
@@ -1648,7 +1628,6 @@ test("records and replays opt-in tools in auto mode", async () => {
   });
 
   const secondRun = await replayHarness.run("Refund invoice inv_123", {
-    metadata: {},
     artifacts: {},
     setArtifact: vi.fn(),
   });
@@ -1669,14 +1648,14 @@ test("does not opt runtime tools into replay from tool definitions", async () =>
     refundable: true,
   }));
 
-  const harness = piAiHarness<{ id: string }, string, DemoMetadata>({
+  const harness = piAiHarness<{ id: string }, string>({
     agent: () => ({ id: "refund-agent" }),
     tools: {
       lookupInvoice: {
         replay: true,
         execute,
       },
-    } as unknown as PiAiToolset<string, DemoMetadata>,
+    } as unknown as PiAiToolset<string>,
     run: async ({ runtime }) => {
       await runtime.tools.lookupInvoice({
         invoiceId: "inv_123",
@@ -1691,7 +1670,6 @@ test("does not opt runtime tools into replay from tool definitions", async () =>
   });
 
   const run = await harness.run("Refund invoice inv_123", {
-    metadata: {},
     artifacts: {},
     setArtifact: vi.fn(),
   });
@@ -1719,7 +1697,7 @@ test("errors when strict mode is missing a recording", async () => {
       lookupInvoice: {
         execute,
       },
-    } satisfies PiAiToolset<string, DemoMetadata>,
+    } satisfies PiAiToolset<string>,
     run: async ({ runtime }) => {
       await runtime.tools.lookupInvoice({
         invoiceId: "inv_123",
@@ -1735,7 +1713,6 @@ test("errors when strict mode is missing a recording", async () => {
 
   const error = await replayHarness
     .run("Refund invoice inv_123", {
-      metadata: {},
       artifacts: {},
       setArtifact: vi.fn(),
     })

--- a/packages/harness-pi-ai/src/index.ts
+++ b/packages/harness-pi-ai/src/index.ts
@@ -1,7 +1,6 @@
 import type {
   Harness,
   HarnessContext,
-  HarnessMetadata,
   HarnessRun,
   JsonValue,
   NormalizedMessage,
@@ -64,17 +63,13 @@ type ResultFieldOutput<
     ? JsonOutput<TResult[TKey]> | undefined
     : JsonOutput<TResult[TKey]>
   : undefined;
-type AgentSource<
-  TAgent,
-  TInput = string,
-  TMetadata extends HarnessMetadata = HarnessMetadata,
-> =
+type AgentSource<TAgent, TInput = string> =
   | TAgent
-  | ((args: PiAiCreateAgentArgs<TInput, TMetadata>) => MaybePromise<TAgent>);
-type AnyPiAiToolset<
-  TInput = string,
-  TMetadata extends HarnessMetadata = HarnessMetadata,
-> = Record<string, PiAiToolDefinition<any, any, TInput, TMetadata>>;
+  | ((args: PiAiCreateAgentArgs<TInput>) => MaybePromise<TAgent>);
+type AnyPiAiToolset<TInput = string> = Record<
+  string,
+  PiAiToolDefinition<any, any, TInput>
+>;
 
 let nextTraceId = 0;
 
@@ -193,18 +188,12 @@ function resolvePiAiJudgeText(message: AssistantMessage) {
     .trim();
 }
 
-type InferredPiAiToolset<
-  TInput = string,
-  TMetadata extends HarnessMetadata = HarnessMetadata,
-> = Record<
+type InferredPiAiToolset<TInput = string> = Record<
   string,
-  PiAiToolDefinition<Record<string, JsonValue>, JsonValue, TInput, TMetadata>
+  PiAiToolDefinition<Record<string, JsonValue>, JsonValue, TInput>
 >;
 
-type PiAgentToolLike<
-  TInput = string,
-  TMetadata extends HarnessMetadata = HarnessMetadata,
-> = {
+type PiAgentToolLike<TInput = string> = {
   name: string;
   execute: (toolCallId: string, args: Record<string, JsonValue>) => unknown;
 };
@@ -217,12 +206,11 @@ type PiAiResultOutput<TResult> = TResult extends HarnessRun<infer TOutput>
 type PiAiAgentResult<
   TAgent,
   TInput,
-  TMetadata extends HarnessMetadata,
-  TTools extends PiAiToolset<TInput, TMetadata>,
+  TTools extends PiAiToolset<TInput>,
 > = TAgent extends {
   run: (
     input: TInput,
-    runtime: PiAiRuntime<TTools, TInput, TMetadata>,
+    runtime: PiAiRuntime<TTools, TInput>,
   ) => MaybePromise<infer TResult>;
 }
   ? Awaited<TResult>
@@ -230,11 +218,8 @@ type PiAiAgentResult<
 
 const ORIGINAL_NATIVE_EXECUTE = Symbol("vitest-evals.originalNativeExecute");
 
-type NativeToolExecute<
-  TInput,
-  TMetadata extends HarnessMetadata,
-> = PiAgentToolLike<TInput, TMetadata>["execute"] & {
-  [ORIGINAL_NATIVE_EXECUTE]?: PiAgentToolLike<TInput, TMetadata>["execute"];
+type NativeToolExecute<TInput> = PiAgentToolLike<TInput>["execute"] & {
+  [ORIGINAL_NATIVE_EXECUTE]?: PiAgentToolLike<TInput>["execute"];
 };
 
 /** Replay mode alias used by the Pi AI harness package. */
@@ -254,14 +239,10 @@ export interface PiAiEventSink {
 }
 
 /** Context passed to instrumented Pi AI tool executions. */
-export interface PiAiToolContext<
-  TInput = string,
-  TMetadata extends HarnessMetadata = HarnessMetadata,
-> {
+export interface PiAiToolContext<TInput = string> {
   input: TInput;
-  metadata: HarnessContext<TMetadata>["metadata"];
   signal?: AbortSignal;
-  setArtifact: HarnessContext<TMetadata>["setArtifact"];
+  setArtifact: HarnessContext["setArtifact"];
 }
 
 /** Tool replay recording shape for Pi AI tools. */
@@ -275,53 +256,39 @@ export type PiAiToolReplayConfig<
   TArgs extends Record<string, JsonValue> = Record<string, JsonValue>,
   TResult extends JsonValue = JsonValue,
   TInput = string,
-  TMetadata extends HarnessMetadata = HarnessMetadata,
-> = ToolReplayConfig<TArgs, TResult, PiAiToolContext<TInput, TMetadata>>;
+> = ToolReplayConfig<TArgs, TResult, PiAiToolContext<TInput>>;
 
 /** Replay policy for one Pi AI tool. */
-export type PiAiToolReplayPolicy<
-  TInput = string,
-  TMetadata extends HarnessMetadata = HarnessMetadata,
-> =
+export type PiAiToolReplayPolicy<TInput = string> =
   | boolean
-  | PiAiToolReplayConfig<
-      Record<string, JsonValue>,
-      JsonValue,
-      TInput,
-      TMetadata
-    >;
+  | PiAiToolReplayConfig<Record<string, JsonValue>, JsonValue, TInput>;
 
 /** Replay policy map keyed by Pi AI tool name. */
-export type PiAiToolReplayPolicies<
-  TInput = string,
-  TMetadata extends HarnessMetadata = HarnessMetadata,
-> = Record<string, PiAiToolReplayPolicy<TInput, TMetadata>>;
+export type PiAiToolReplayPolicies<TInput = string> = Record<
+  string,
+  PiAiToolReplayPolicy<TInput>
+>;
 
 /** Tool definition accepted by the Pi AI harness runtime. */
 export interface PiAiToolDefinition<
   TArgs extends Record<string, JsonValue> = Record<string, JsonValue>,
   TResult extends JsonValue = JsonValue,
   TInput = string,
-  TMetadata extends HarnessMetadata = HarnessMetadata,
 > {
   description?: string;
   execute: (
     args: TArgs,
-    context: PiAiToolContext<TInput, TMetadata>,
+    context: PiAiToolContext<TInput>,
   ) => MaybePromise<TResult>;
 }
 
 /** Toolset shape accepted by the Pi AI harness. */
-export type PiAiToolset<
-  TInput = string,
-  TMetadata extends HarnessMetadata = HarnessMetadata,
-> = AnyPiAiToolset<TInput, TMetadata>;
+export type PiAiToolset<TInput = string> = AnyPiAiToolset<TInput>;
 
 type ToolArgs<TTool> = TTool extends PiAiToolDefinition<
   infer TArgs,
   infer _TResult,
-  infer _TInput,
-  infer _TMetadata
+  infer _TInput
 >
   ? TArgs
   : never;
@@ -329,18 +296,13 @@ type ToolArgs<TTool> = TTool extends PiAiToolDefinition<
 type ToolResult<TTool> = TTool extends PiAiToolDefinition<
   infer _TArgs,
   infer TResult,
-  infer _TInput,
-  infer _TMetadata
+  infer _TInput
 >
   ? TResult
   : never;
 
 /** Runtime object passed into Pi AI agent entrypoints. */
-export type PiAiRuntime<
-  TTools extends PiAiToolset<TInput, TMetadata>,
-  TInput = string,
-  TMetadata extends HarnessMetadata = HarnessMetadata,
-> = {
+export type PiAiRuntime<TTools extends PiAiToolset<TInput>, TInput = string> = {
   tools: {
     [K in keyof TTools]: (
       args: ToolArgs<TTools[K]>,
@@ -354,182 +316,105 @@ export type PiAiRuntime<
 export interface PiAiHarnessRunArgs<
   TAgent,
   TInput,
-  TMetadata extends HarnessMetadata,
-  TTools extends PiAiToolset<TInput, TMetadata>,
+  TTools extends PiAiToolset<TInput>,
 > {
   agent: TAgent;
   input: TInput;
-  context: HarnessContext<TMetadata>;
-  runtime: PiAiRuntime<TTools, TInput, TMetadata>;
+  context: HarnessContext;
+  runtime: PiAiRuntime<TTools, TInput>;
 }
 
 /** Arguments passed to Pi AI harness output selectors. */
 export interface PiAiHarnessResultArgs<
   TAgent,
   TInput,
-  TMetadata extends HarnessMetadata,
   TResult,
-  TTools extends PiAiToolset<TInput, TMetadata>,
-> extends PiAiHarnessRunArgs<TAgent, TInput, TMetadata, TTools> {
+  TTools extends PiAiToolset<TInput>,
+> extends PiAiHarnessRunArgs<TAgent, TInput, TTools> {
   result: TResult;
 }
 
 /** Arguments passed to per-run Pi AI agent factories. */
-export interface PiAiCreateAgentArgs<
-  TInput = string,
-  TMetadata extends HarnessMetadata = HarnessMetadata,
-> {
+export interface PiAiCreateAgentArgs<TInput = string> {
   input: TInput;
-  context: HarnessContext<TMetadata>;
+  context: HarnessContext;
 }
 
 interface PiAiHarnessBaseOptions<
   TAgent,
   TInput = string,
-  TMetadata extends HarnessMetadata = HarnessMetadata,
   TResult = unknown,
-  TTools extends PiAiToolset<TInput, TMetadata> = PiAiToolset<
-    TInput,
-    TMetadata
-  >,
+  TTools extends PiAiToolset<TInput> = PiAiToolset<TInput>,
   TOutput extends JsonValue | undefined = JsonValue | undefined,
 > {
-  agent: AgentSource<TAgent, TInput, TMetadata>;
-  toolReplay?: PiAiToolReplayPolicies<TInput, TMetadata>;
-  output?: PiAiHarnessOutputSelector<
-    TAgent,
-    TInput,
-    TMetadata,
-    TResult,
-    TTools,
-    TOutput
-  >;
+  agent: AgentSource<TAgent, TInput>;
+  toolReplay?: PiAiToolReplayPolicies<TInput>;
+  output?: PiAiHarnessOutputSelector<TAgent, TInput, TResult, TTools, TOutput>;
   name?: string;
 }
 
 interface PiAiHarnessWithToolsOptions<
   TAgent,
   TInput = string,
-  TMetadata extends HarnessMetadata = HarnessMetadata,
   TResult = unknown,
-  TTools extends PiAiToolset<TInput, TMetadata> = PiAiToolset<
-    TInput,
-    TMetadata
-  >,
+  TTools extends PiAiToolset<TInput> = PiAiToolset<TInput>,
   TOutput extends JsonValue | undefined = JsonValue | undefined,
-> extends PiAiHarnessBaseOptions<
-    TAgent,
-    TInput,
-    TMetadata,
-    TResult,
-    TTools,
-    TOutput
-  > {
+> extends PiAiHarnessBaseOptions<TAgent, TInput, TResult, TTools, TOutput> {
   tools: TTools;
   run?: (
-    args: PiAiHarnessRunArgs<TAgent, TInput, TMetadata, TTools>,
+    args: PiAiHarnessRunArgs<TAgent, TInput, TTools>,
   ) => MaybePromise<TResult | HarnessRun<TOutput>>;
 }
 
 interface PiAiHarnessInferredToolsOptions<
   TAgent,
   TInput = string,
-  TMetadata extends HarnessMetadata = HarnessMetadata,
   TResult = unknown,
   TOutput extends JsonValue | undefined = JsonValue | undefined,
 > extends PiAiHarnessBaseOptions<
     TAgent,
     TInput,
-    TMetadata,
     TResult,
-    InferredPiAiToolset<TInput, TMetadata>,
+    InferredPiAiToolset<TInput>,
     TOutput
   > {
   tools?: undefined;
   run?: (
-    args: PiAiHarnessRunArgs<
-      TAgent,
-      TInput,
-      TMetadata,
-      InferredPiAiToolset<TInput, TMetadata>
-    >,
+    args: PiAiHarnessRunArgs<TAgent, TInput, InferredPiAiToolset<TInput>>,
   ) => MaybePromise<TResult | HarnessRun<TOutput>>;
 }
 
 type PiAiHarnessOptions<
   TAgent,
   TInput = string,
-  TMetadata extends HarnessMetadata = HarnessMetadata,
   TResult = unknown,
-  TTools extends PiAiToolset<TInput, TMetadata> = PiAiToolset<
-    TInput,
-    TMetadata
-  >,
+  TTools extends PiAiToolset<TInput> = PiAiToolset<TInput>,
   TOutput extends JsonValue | undefined = JsonValue | undefined,
 > =
-  | PiAiHarnessWithToolsOptions<
-      TAgent,
-      TInput,
-      TMetadata,
-      TResult,
-      TTools,
-      TOutput
-    >
-  | PiAiHarnessInferredToolsOptions<
-      TAgent,
-      TInput,
-      TMetadata,
-      TResult,
-      TOutput
-    >;
+  | PiAiHarnessWithToolsOptions<TAgent, TInput, TResult, TTools, TOutput>
+  | PiAiHarnessInferredToolsOptions<TAgent, TInput, TResult, TOutput>;
 
 type PiAiHarnessWithToolsOptionsWithOutput<
   TAgent,
   TInput = string,
-  TMetadata extends HarnessMetadata = HarnessMetadata,
   TResult = unknown,
-  TTools extends PiAiToolset<TInput, TMetadata> = PiAiToolset<
-    TInput,
-    TMetadata
-  >,
+  TTools extends PiAiToolset<TInput> = PiAiToolset<TInput>,
   TOutput extends JsonValue | undefined = JsonValue | undefined,
-> = PiAiHarnessWithToolsOptions<
-  TAgent,
-  TInput,
-  TMetadata,
-  TResult,
-  TTools,
-  TOutput
-> & {
-  output: PiAiHarnessOutputSelector<
-    TAgent,
-    TInput,
-    TMetadata,
-    TResult,
-    TTools,
-    TOutput
-  >;
+> = PiAiHarnessWithToolsOptions<TAgent, TInput, TResult, TTools, TOutput> & {
+  output: PiAiHarnessOutputSelector<TAgent, TInput, TResult, TTools, TOutput>;
 };
 
 type PiAiHarnessInferredToolsOptionsWithOutput<
   TAgent,
   TInput = string,
-  TMetadata extends HarnessMetadata = HarnessMetadata,
   TResult = unknown,
   TOutput extends JsonValue | undefined = JsonValue | undefined,
-> = PiAiHarnessInferredToolsOptions<
-  TAgent,
-  TInput,
-  TMetadata,
-  TResult,
-  TOutput
-> & {
+> = PiAiHarnessInferredToolsOptions<TAgent, TInput, TResult, TOutput> & {
   output: PiAiHarnessOutputSelector<
     TAgent,
     TInput,
-    TMetadata,
     TResult,
-    InferredPiAiToolset<TInput, TMetadata>,
+    InferredPiAiToolset<TInput>,
     TOutput
   >;
 };
@@ -537,23 +422,18 @@ type PiAiHarnessInferredToolsOptionsWithOutput<
 type PiAiHarnessWithToolsRunOptionsWithoutOutput<
   TAgent,
   TInput = string,
-  TMetadata extends HarnessMetadata = HarnessMetadata,
   TResult = unknown,
-  TTools extends PiAiToolset<TInput, TMetadata> = PiAiToolset<
-    TInput,
-    TMetadata
-  >,
+  TTools extends PiAiToolset<TInput> = PiAiToolset<TInput>,
 > = PiAiHarnessBaseOptions<
   TAgent,
   TInput,
-  TMetadata,
   TResult,
   TTools,
   JsonValue | undefined
 > & {
   tools: TTools;
   run: (
-    args: PiAiHarnessRunArgs<TAgent, TInput, TMetadata, TTools>,
+    args: PiAiHarnessRunArgs<TAgent, TInput, TTools>,
   ) => MaybePromise<TResult>;
   output?: never;
 };
@@ -561,15 +441,10 @@ type PiAiHarnessWithToolsRunOptionsWithoutOutput<
 type PiAiHarnessWithToolsAgentOptionsWithoutOutput<
   TAgent,
   TInput = string,
-  TMetadata extends HarnessMetadata = HarnessMetadata,
-  TTools extends PiAiToolset<TInput, TMetadata> = PiAiToolset<
-    TInput,
-    TMetadata
-  >,
+  TTools extends PiAiToolset<TInput> = PiAiToolset<TInput>,
 > = PiAiHarnessBaseOptions<
   TAgent,
   TInput,
-  TMetadata,
   unknown,
   TTools,
   JsonValue | undefined
@@ -582,24 +457,17 @@ type PiAiHarnessWithToolsAgentOptionsWithoutOutput<
 type PiAiHarnessInferredToolsRunOptionsWithoutOutput<
   TAgent,
   TInput = string,
-  TMetadata extends HarnessMetadata = HarnessMetadata,
   TResult = unknown,
 > = PiAiHarnessBaseOptions<
   TAgent,
   TInput,
-  TMetadata,
   TResult,
-  InferredPiAiToolset<TInput, TMetadata>,
+  InferredPiAiToolset<TInput>,
   JsonValue | undefined
 > & {
   tools?: undefined;
   run: (
-    args: PiAiHarnessRunArgs<
-      TAgent,
-      TInput,
-      TMetadata,
-      InferredPiAiToolset<TInput, TMetadata>
-    >,
+    args: PiAiHarnessRunArgs<TAgent, TInput, InferredPiAiToolset<TInput>>,
   ) => MaybePromise<TResult>;
   output?: never;
 };
@@ -607,13 +475,11 @@ type PiAiHarnessInferredToolsRunOptionsWithoutOutput<
 type PiAiHarnessInferredToolsAgentOptionsWithoutOutput<
   TAgent,
   TInput = string,
-  TMetadata extends HarnessMetadata = HarnessMetadata,
 > = PiAiHarnessBaseOptions<
   TAgent,
   TInput,
-  TMetadata,
   unknown,
-  InferredPiAiToolset<TInput, TMetadata>,
+  InferredPiAiToolset<TInput>,
   JsonValue | undefined
 > & {
   tools?: undefined;
@@ -624,53 +490,40 @@ type PiAiHarnessInferredToolsAgentOptionsWithoutOutput<
 type PiAiHarnessRunOptions<
   TAgent,
   TInput,
-  TMetadata extends HarnessMetadata,
   TResult,
-  TTools extends PiAiToolset<TInput, TMetadata>,
+  TTools extends PiAiToolset<TInput>,
   TOutput extends JsonValue | undefined,
-> = PiAiHarnessBaseOptions<
-  TAgent,
-  TInput,
-  TMetadata,
-  TResult,
-  TTools,
-  TOutput
-> & {
+> = PiAiHarnessBaseOptions<TAgent, TInput, TResult, TTools, TOutput> & {
   run?: (
-    args: PiAiHarnessRunArgs<TAgent, TInput, TMetadata, TTools>,
+    args: PiAiHarnessRunArgs<TAgent, TInput, TTools>,
   ) => MaybePromise<TResult | HarnessRun<TOutput>>;
 };
 
 type PiAiRunnableAgent<
   TInput,
-  TMetadata extends HarnessMetadata,
   TResult,
   TOutput extends JsonValue | undefined,
-  TTools extends PiAiToolset<TInput, TMetadata>,
+  TTools extends PiAiToolset<TInput>,
 > = {
   run: (
     input: TInput,
-    runtime: PiAiRuntime<TTools, TInput, TMetadata>,
+    runtime: PiAiRuntime<TTools, TInput>,
   ) => MaybePromise<TResult | HarnessRun<TOutput>>;
 };
 
 type PiAiHarnessOutputSelector<
   TAgent,
   TInput = string,
-  TMetadata extends HarnessMetadata = HarnessMetadata,
   TResult = unknown,
-  TTools extends PiAiToolset<TInput, TMetadata> = PiAiToolset<
-    TInput,
-    TMetadata
-  >,
+  TTools extends PiAiToolset<TInput> = PiAiToolset<TInput>,
   TOutput extends JsonValue | undefined = JsonValue | undefined,
 > = (
-  args: PiAiHarnessResultArgs<TAgent, TInput, TMetadata, TResult, TTools>,
+  args: PiAiHarnessResultArgs<TAgent, TInput, TResult, TTools>,
 ) => MaybePromise<TOutput>;
 
-type InferredToolSurfaces<TInput, TMetadata extends HarnessMetadata> = {
-  runtimeTools?: InferredPiAiToolset<TInput, TMetadata>;
-  nativeToolsets?: Array<PiAgentToolLike<TInput, TMetadata>[]>;
+type InferredToolSurfaces<TInput> = {
+  runtimeTools?: InferredPiAiToolset<TInput>;
+  nativeToolsets?: Array<PiAgentToolLike<TInput>[]>;
 };
 
 type PiToolExecutionState = {
@@ -681,135 +534,81 @@ type PiToolExecutionState = {
 export function piAiHarness<
   TAgent,
   TInput = string,
-  TMetadata extends HarnessMetadata = HarnessMetadata,
   TResult = unknown,
-  TTools extends PiAiToolset<TInput, TMetadata> = PiAiToolset<
-    TInput,
-    TMetadata
-  >,
+  TTools extends PiAiToolset<TInput> = PiAiToolset<TInput>,
   TOutput extends JsonValue | undefined = JsonValue | undefined,
 >(
   options: PiAiHarnessWithToolsOptionsWithOutput<
     TAgent,
     TInput,
-    TMetadata,
     TResult,
     TTools,
     TOutput
   >,
-): Harness<TInput, TOutput, TMetadata>;
+): Harness<TInput, TOutput>;
 export function piAiHarness<
   TAgent,
   TInput = string,
-  TMetadata extends HarnessMetadata = HarnessMetadata,
   TResult = unknown,
   TOutput extends JsonValue | undefined = JsonValue | undefined,
 >(
   options: PiAiHarnessInferredToolsOptionsWithOutput<
     TAgent,
     TInput,
-    TMetadata,
     TResult,
     TOutput
   >,
-): Harness<TInput, TOutput, TMetadata>;
+): Harness<TInput, TOutput>;
 export function piAiHarness<
   TAgent,
   TInput = string,
-  TMetadata extends HarnessMetadata = HarnessMetadata,
   TResult = unknown,
-  TTools extends PiAiToolset<TInput, TMetadata> = PiAiToolset<
-    TInput,
-    TMetadata
-  >,
+  TTools extends PiAiToolset<TInput> = PiAiToolset<TInput>,
 >(
   options: PiAiHarnessWithToolsRunOptionsWithoutOutput<
     TAgent,
     TInput,
-    TMetadata,
     TResult,
     TTools
   >,
-): Harness<TInput, PiAiResultOutput<Awaited<TResult>>, TMetadata>;
+): Harness<TInput, PiAiResultOutput<Awaited<TResult>>>;
 export function piAiHarness<
   TAgent,
   TInput = string,
-  TMetadata extends HarnessMetadata = HarnessMetadata,
-  TTools extends PiAiToolset<TInput, TMetadata> = PiAiToolset<
-    TInput,
-    TMetadata
-  >,
+  TTools extends PiAiToolset<TInput> = PiAiToolset<TInput>,
 >(
   options: PiAiHarnessWithToolsAgentOptionsWithoutOutput<
     TAgent,
     TInput,
-    TMetadata,
     TTools
   >,
-): Harness<
-  TInput,
-  PiAiResultOutput<PiAiAgentResult<TAgent, TInput, TMetadata, TTools>>,
-  TMetadata
->;
-export function piAiHarness<
-  TAgent,
-  TInput = string,
-  TMetadata extends HarnessMetadata = HarnessMetadata,
-  TResult = unknown,
->(
+): Harness<TInput, PiAiResultOutput<PiAiAgentResult<TAgent, TInput, TTools>>>;
+export function piAiHarness<TAgent, TInput = string, TResult = unknown>(
   options: PiAiHarnessInferredToolsRunOptionsWithoutOutput<
     TAgent,
     TInput,
-    TMetadata,
     TResult
   >,
-): Harness<TInput, PiAiResultOutput<Awaited<TResult>>, TMetadata>;
-export function piAiHarness<
-  TAgent,
-  TInput = string,
-  TMetadata extends HarnessMetadata = HarnessMetadata,
->(
-  options: PiAiHarnessInferredToolsAgentOptionsWithoutOutput<
-    TAgent,
-    TInput,
-    TMetadata
-  >,
+): Harness<TInput, PiAiResultOutput<Awaited<TResult>>>;
+export function piAiHarness<TAgent, TInput = string>(
+  options: PiAiHarnessInferredToolsAgentOptionsWithoutOutput<TAgent, TInput>,
 ): Harness<
   TInput,
-  PiAiResultOutput<
-    PiAiAgentResult<
-      TAgent,
-      TInput,
-      TMetadata,
-      InferredPiAiToolset<TInput, TMetadata>
-    >
-  >,
-  TMetadata
+  PiAiResultOutput<PiAiAgentResult<TAgent, TInput, InferredPiAiToolset<TInput>>>
 >;
 export function piAiHarness<
   TAgent,
   TInput = string,
-  TMetadata extends HarnessMetadata = HarnessMetadata,
   TResult = unknown,
-  TTools extends PiAiToolset<TInput, TMetadata> = PiAiToolset<
-    TInput,
-    TMetadata
-  >,
+  TTools extends PiAiToolset<TInput> = PiAiToolset<TInput>,
   TOutput extends JsonValue | undefined = JsonValue | undefined,
 >(
-  options: PiAiHarnessOptions<
-    TAgent,
-    TInput,
-    TMetadata,
-    TResult,
-    TTools,
-    TOutput
-  >,
-): Harness<TInput, TOutput, TMetadata> {
+  options: PiAiHarnessOptions<TAgent, TInput, TResult, TTools, TOutput>,
+): Harness<TInput, TOutput> {
   validateOptions(options);
 
   const harnessName = options.name ?? "pi-ai";
-  const harness: Harness<TInput, TOutput, TMetadata> = {
+  const harness: Harness<TInput, TOutput> = {
     name: harnessName,
     run: async (input, context) => {
       const startedAt = new Date();
@@ -825,9 +624,7 @@ export function piAiHarness<
             content: normalizeContent(input),
           },
         ];
-        const inferredTools = resolveInferredToolSurfaces<TInput, TMetadata>(
-          agent,
-        );
+        const inferredTools = resolveInferredToolSurfaces<TInput>(agent);
 
         if (hasExplicitToolset(options)) {
           return await executePiHarnessRun(
@@ -866,9 +663,9 @@ export function piAiHarness<
   return harness;
 }
 
-function createFailedPiAiRun<TInput, TMetadata extends HarnessMetadata>(
+function createFailedPiAiRun<TInput>(
   input: TInput,
-  context: HarnessContext<TMetadata>,
+  context: HarnessContext,
   error: unknown,
   harnessName: string,
   startedAt: Date,
@@ -890,20 +687,10 @@ function createFailedPiAiRun<TInput, TMetadata extends HarnessMetadata>(
 function validateOptions<
   TAgent,
   TInput,
-  TMetadata extends HarnessMetadata,
   TResult,
-  TTools extends PiAiToolset<TInput, TMetadata>,
+  TTools extends PiAiToolset<TInput>,
   TOutput extends JsonValue | undefined,
->(
-  options: PiAiHarnessOptions<
-    TAgent,
-    TInput,
-    TMetadata,
-    TResult,
-    TTools,
-    TOutput
-  >,
-) {
+>(options: PiAiHarnessOptions<TAgent, TInput, TResult, TTools, TOutput>) {
   if (options.agent === undefined) {
     throw new Error(
       "piAiHarness requires agent. Pass an agent instance or an agent factory.",
@@ -914,25 +701,17 @@ function validateOptions<
 async function executePiHarnessRun<
   TAgent,
   TInput,
-  TMetadata extends HarnessMetadata,
   TResult,
-  TTools extends PiAiToolset<TInput, TMetadata>,
+  TTools extends PiAiToolset<TInput>,
   TOutput extends JsonValue | undefined,
 >(
-  options: PiAiHarnessRunOptions<
-    TAgent,
-    TInput,
-    TMetadata,
-    TResult,
-    TTools,
-    TOutput
-  >,
+  options: PiAiHarnessRunOptions<TAgent, TInput, TResult, TTools, TOutput>,
   agent: TAgent,
   input: TInput,
-  context: HarnessContext<TMetadata>,
+  context: HarnessContext,
   messages: NormalizedMessage[],
   runtimeTools: TTools | undefined,
-  nativeToolsets?: Array<PiAgentToolLike<TInput, TMetadata>[]>,
+  nativeToolsets?: Array<PiAgentToolLike<TInput>[]>,
 ): Promise<HarnessRun<TOutput>> {
   const trace = createTraceRecorder(options.name ?? "pi-ai");
   const executionState = createPiToolExecutionState();
@@ -981,13 +760,7 @@ async function executePiHarnessRun<
       context,
       runtime,
       result: normalizeResult,
-    } satisfies PiAiHarnessResultArgs<
-      TAgent,
-      TInput,
-      TMetadata,
-      TResult,
-      TTools
-    >;
+    } satisfies PiAiHarnessResultArgs<TAgent, TInput, TResult, TTools>;
 
     const output = options.output
       ? await options.output(resultArgs)
@@ -1046,31 +819,19 @@ async function executePiHarnessRun<
 async function resolveAgent<
   TAgent,
   TInput,
-  TMetadata extends HarnessMetadata,
   TResult,
-  TTools extends PiAiToolset<TInput, TMetadata>,
+  TTools extends PiAiToolset<TInput>,
   TOutput extends JsonValue | undefined,
 >(
-  options: PiAiHarnessOptions<
-    TAgent,
-    TInput,
-    TMetadata,
-    TResult,
-    TTools,
-    TOutput
-  >,
-  args: PiAiCreateAgentArgs<TInput, TMetadata>,
+  options: PiAiHarnessOptions<TAgent, TInput, TResult, TTools, TOutput>,
+  args: PiAiCreateAgentArgs<TInput>,
 ) {
   return resolveAgentSource(options.agent, args);
 }
 
-async function resolveAgentSource<
-  TAgent,
-  TInput,
-  TMetadata extends HarnessMetadata,
->(
-  agent: AgentSource<TAgent, TInput, TMetadata>,
-  args: PiAiCreateAgentArgs<TInput, TMetadata>,
+async function resolveAgentSource<TAgent, TInput>(
+  agent: AgentSource<TAgent, TInput>,
+  args: PiAiCreateAgentArgs<TInput>,
 ): Promise<TAgent> {
   if (isAgentFactory(agent)) {
     return agent(args);
@@ -1079,31 +840,19 @@ async function resolveAgentSource<
   return agent;
 }
 
-function isAgentFactory<TAgent, TInput, TMetadata extends HarnessMetadata>(
-  agent: AgentSource<TAgent, TInput, TMetadata>,
-): agent is (
-  args: PiAiCreateAgentArgs<TInput, TMetadata>,
-) => MaybePromise<TAgent> {
+function isAgentFactory<TAgent, TInput>(
+  agent: AgentSource<TAgent, TInput>,
+): agent is (args: PiAiCreateAgentArgs<TInput>) => MaybePromise<TAgent> {
   return typeof agent === "function" && !hasPiAiRunMethod(agent);
 }
 
 function hasOutputSelector<
   TAgent,
   TInput,
-  TMetadata extends HarnessMetadata,
   TResult,
-  TTools extends PiAiToolset<TInput, TMetadata>,
+  TTools extends PiAiToolset<TInput>,
   TOutput extends JsonValue | undefined,
->(
-  options: PiAiHarnessRunOptions<
-    TAgent,
-    TInput,
-    TMetadata,
-    TResult,
-    TTools,
-    TOutput
-  >,
-) {
+>(options: PiAiHarnessRunOptions<TAgent, TInput, TResult, TTools, TOutput>) {
   return Boolean(options.output);
 }
 
@@ -1216,15 +965,15 @@ function createUsageModelSpan(
   };
 }
 
-function resolveInferredToolSurfaces<TInput, TMetadata extends HarnessMetadata>(
+function resolveInferredToolSurfaces<TInput>(
   agent: unknown,
-): InferredToolSurfaces<TInput, TMetadata> {
-  let runtimeTools: InferredPiAiToolset<TInput, TMetadata> | undefined;
-  const nativeToolsets: Array<PiAgentToolLike<TInput, TMetadata>[]> = [];
-  const seenToolsets = new Set<PiAgentToolLike<TInput, TMetadata>[]>();
+): InferredToolSurfaces<TInput> {
+  let runtimeTools: InferredPiAiToolset<TInput> | undefined;
+  const nativeToolsets: Array<PiAgentToolLike<TInput>[]> = [];
+  const seenToolsets = new Set<PiAgentToolLike<TInput>[]>();
 
   for (const candidate of getAgentToolCandidates(agent)) {
-    const nextRuntimeTools = getRuntimeToolset<TInput, TMetadata>(candidate);
+    const nextRuntimeTools = getRuntimeToolset<TInput>(candidate);
     if (runtimeTools === undefined && nextRuntimeTools !== undefined) {
       runtimeTools = nextRuntimeTools;
     }
@@ -1285,23 +1034,23 @@ function getObjectProperty(value: unknown, key: string): unknown {
     : undefined;
 }
 
-function getRuntimeToolset<TInput, TMetadata extends HarnessMetadata>(
+function getRuntimeToolset<TInput>(
   value: object,
-): InferredPiAiToolset<TInput, TMetadata> | undefined {
+): InferredPiAiToolset<TInput> | undefined {
   const candidate =
     getObjectProperty(value, "tools") ?? getObjectProperty(value, "toolset");
 
   return isPiAiToolset(candidate)
-    ? (candidate as InferredPiAiToolset<TInput, TMetadata>)
+    ? (candidate as InferredPiAiToolset<TInput>)
     : undefined;
 }
 
-function getNativeToolArray<TInput, TMetadata extends HarnessMetadata>(
+function getNativeToolArray<TInput>(
   value: object,
-): PiAgentToolLike<TInput, TMetadata>[] | undefined {
+): PiAgentToolLike<TInput>[] | undefined {
   const candidate = getObjectProperty(value, "tools");
   if (isAgentToolArray(candidate)) {
-    return candidate as PiAgentToolLike<TInput, TMetadata>[];
+    return candidate as PiAgentToolLike<TInput>[];
   }
 
   return undefined;
@@ -1310,28 +1059,18 @@ function getNativeToolArray<TInput, TMetadata extends HarnessMetadata>(
 async function runAgent<
   TAgent,
   TInput,
-  TMetadata extends HarnessMetadata,
   TResult,
-  TTools extends PiAiToolset<TInput, TMetadata>,
+  TTools extends PiAiToolset<TInput>,
   TOutput extends JsonValue | undefined,
 >(
-  options: PiAiHarnessRunOptions<
-    TAgent,
-    TInput,
-    TMetadata,
-    TResult,
-    TTools,
-    TOutput
-  >,
-  args: PiAiHarnessRunArgs<TAgent, TInput, TMetadata, TTools>,
+  options: PiAiHarnessRunOptions<TAgent, TInput, TResult, TTools, TOutput>,
+  args: PiAiHarnessRunArgs<TAgent, TInput, TTools>,
 ): Promise<TResult | HarnessRun<TOutput>> {
   if (options.run) {
     return options.run(args);
   }
 
-  if (
-    hasPiAiRunMethod<TInput, TMetadata, TResult, TOutput, TTools>(args.agent)
-  ) {
+  if (hasPiAiRunMethod<TInput, TResult, TOutput, TTools>(args.agent)) {
     return args.agent.run(args.input, args.runtime);
   }
 
@@ -1343,23 +1082,14 @@ async function runAgent<
 function hasExplicitToolset<
   TAgent,
   TInput,
-  TMetadata extends HarnessMetadata,
   TResult,
-  TTools extends PiAiToolset<TInput, TMetadata>,
+  TTools extends PiAiToolset<TInput>,
   TOutput extends JsonValue | undefined,
 >(
-  options: PiAiHarnessOptions<
-    TAgent,
-    TInput,
-    TMetadata,
-    TResult,
-    TTools,
-    TOutput
-  >,
+  options: PiAiHarnessOptions<TAgent, TInput, TResult, TTools, TOutput>,
 ): options is PiAiHarnessWithToolsOptions<
   TAgent,
   TInput,
-  TMetadata,
   TResult,
   TTools,
   TOutput
@@ -1369,13 +1099,12 @@ function hasExplicitToolset<
 
 function hasPiAiRunMethod<
   TInput,
-  TMetadata extends HarnessMetadata,
   TResult,
   TOutput extends JsonValue | undefined,
-  TTools extends PiAiToolset<TInput, TMetadata>,
+  TTools extends PiAiToolset<TInput>,
 >(
   agent: unknown,
-): agent is PiAiRunnableAgent<TInput, TMetadata, TResult, TOutput, TTools> {
+): agent is PiAiRunnableAgent<TInput, TResult, TOutput, TTools> {
   if (!agent || (typeof agent !== "object" && typeof agent !== "function")) {
     return false;
   }
@@ -1420,19 +1149,15 @@ function isAgentToolArray(value: unknown): value is PiAgentToolLike[] {
   );
 }
 
-async function withInstrumentedAgentTools<
-  TResult,
-  TInput,
-  TMetadata extends HarnessMetadata,
->(
+async function withInstrumentedAgentTools<TResult, TInput>(
   agent: unknown,
-  toolsets: Array<PiAgentToolLike<TInput, TMetadata>[]> | undefined,
+  toolsets: Array<PiAgentToolLike<TInput>[]> | undefined,
   args: {
     input: TInput;
-    context: HarnessContext<TMetadata>;
+    context: HarnessContext;
     messages: NormalizedMessage[];
     toolCalls: ToolCallRecord[];
-    toolReplay: PiAiToolReplayPolicies<TInput, TMetadata> | undefined;
+    toolReplay: PiAiToolReplayPolicies<TInput> | undefined;
     executionState: PiToolExecutionState;
   },
   callback: () => Promise<TResult>,
@@ -1442,29 +1167,28 @@ async function withInstrumentedAgentTools<
   }
 
   const originalExecutions = new Map<
-    PiAgentToolLike<TInput, TMetadata>,
-    PiAgentToolLike<TInput, TMetadata>["execute"]
+    PiAgentToolLike<TInput>,
+    PiAgentToolLike<TInput>["execute"]
   >();
   const originalResets = new Map<ResettableAgent, ResettableAgent["reset"]>();
 
-  const patchTool = (tool: PiAgentToolLike<TInput, TMetadata>) => {
+  const patchTool = (tool: PiAgentToolLike<TInput>) => {
     if (originalExecutions.has(tool)) {
       return;
     }
 
     const originalExecute = getNativeToolExecuteOrigin(tool.execute);
     originalExecutions.set(tool, originalExecute);
-    const instrumentedExecute: NativeToolExecute<TInput, TMetadata> = async (
+    const instrumentedExecute: NativeToolExecute<TInput> = async (
       toolCallId: string,
       rawArgs: Record<string, JsonValue>,
     ) => {
       const startedAt = new Date();
       const toolContext = {
         input: args.input,
-        metadata: args.context.metadata,
         signal: args.context.signal,
         setArtifact: args.context.setArtifact,
-      } satisfies PiAiToolContext<TInput, TMetadata>;
+      } satisfies PiAiToolContext<TInput>;
       const leaveNativeTool = enterNativeToolExecution(
         args.executionState,
         tool.name,
@@ -1529,9 +1253,7 @@ async function withInstrumentedAgentTools<
     tool.execute = instrumentedExecute;
   };
 
-  const patchToolsets = (
-    nextToolsets: Array<PiAgentToolLike<TInput, TMetadata>[]>,
-  ) => {
+  const patchToolsets = (nextToolsets: Array<PiAgentToolLike<TInput>[]>) => {
     for (const toolset of nextToolsets) {
       for (const tool of toolset) {
         patchTool(tool);
@@ -1549,13 +1271,11 @@ async function withInstrumentedAgentTools<
 
       if (isPromiseLike(resetResult)) {
         return resetResult.finally(() => {
-          patchToolsets(
-            resolveInferredNativeToolsets<TInput, TMetadata>(agent),
-          );
+          patchToolsets(resolveInferredNativeToolsets<TInput>(agent));
         });
       }
 
-      patchToolsets(resolveInferredNativeToolsets<TInput, TMetadata>(agent));
+      patchToolsets(resolveInferredNativeToolsets<TInput>(agent));
       return resetResult;
     };
   }
@@ -1585,12 +1305,11 @@ function isResettableAgent(value: object): value is ResettableAgent {
   return "reset" in value && typeof value.reset === "function";
 }
 
-function resolveInferredNativeToolsets<
-  TInput,
-  TMetadata extends HarnessMetadata,
->(agent: unknown): Array<PiAgentToolLike<TInput, TMetadata>[]> {
-  const toolsets: Array<PiAgentToolLike<TInput, TMetadata>[]> = [];
-  const seenToolsets = new Set<PiAgentToolLike<TInput, TMetadata>[]>();
+function resolveInferredNativeToolsets<TInput>(
+  agent: unknown,
+): Array<PiAgentToolLike<TInput>[]> {
+  const toolsets: Array<PiAgentToolLike<TInput>[]> = [];
+  const seenToolsets = new Set<PiAgentToolLike<TInput>[]>();
 
   for (const candidate of getAgentToolCandidates(agent)) {
     const nativeTools = getNativeToolArray(candidate);
@@ -1622,10 +1341,10 @@ function serializeToolCallError(
   };
 }
 
-function getNativeToolExecuteOrigin<TInput, TMetadata extends HarnessMetadata>(
-  execute: PiAgentToolLike<TInput, TMetadata>["execute"],
+function getNativeToolExecuteOrigin<TInput>(
+  execute: PiAgentToolLike<TInput>["execute"],
 ) {
-  const nativeExecute = execute as NativeToolExecute<TInput, TMetadata>;
+  const nativeExecute = execute as NativeToolExecute<TInput>;
   return nativeExecute[ORIGINAL_NATIVE_EXECUTE] ?? nativeExecute;
 }
 
@@ -1662,10 +1381,7 @@ function hasActiveNativeToolExecution(
   return (state.activeNativeToolNames.get(toolName) ?? 0) > 0;
 }
 
-async function executeNativeToolWithReplay<
-  TInput,
-  TMetadata extends HarnessMetadata,
->({
+async function executeNativeToolWithReplay<TInput>({
   toolName,
   toolCallId,
   execute,
@@ -1675,10 +1391,10 @@ async function executeNativeToolWithReplay<
 }: {
   toolName: string;
   toolCallId: string;
-  execute: PiAgentToolLike<TInput, TMetadata>["execute"];
-  replay: PiAiToolReplayPolicy<TInput, TMetadata> | undefined;
+  execute: PiAgentToolLike<TInput>["execute"];
+  replay: PiAiToolReplayPolicy<TInput> | undefined;
   args: Record<string, JsonValue>;
-  context: PiAiToolContext<TInput, TMetadata>;
+  context: PiAiToolContext<TInput>;
 }) {
   let didExecute = false;
   let liveResult: unknown;
@@ -1713,11 +1429,7 @@ function createNativeReplayToolName(toolName: string) {
   return `${toolName}.native`;
 }
 
-function createRuntime<
-  TInput,
-  TMetadata extends HarnessMetadata,
-  TTools extends PiAiToolset<TInput, TMetadata>,
->({
+function createRuntime<TInput, TTools extends PiAiToolset<TInput>>({
   input,
   context,
   tools,
@@ -1726,12 +1438,12 @@ function createRuntime<
   messages,
 }: {
   input: TInput;
-  context: HarnessContext<TMetadata>;
+  context: HarnessContext;
   tools: TTools | undefined;
-  toolReplay: PiAiToolReplayPolicies<TInput, TMetadata> | undefined;
+  toolReplay: PiAiToolReplayPolicies<TInput> | undefined;
   executionState: PiToolExecutionState;
   messages: NormalizedMessage[];
-}): PiAiRuntime<TTools, TInput, TMetadata> & {
+}): PiAiRuntime<TTools, TInput> & {
   toolCalls: ToolCallRecord[];
 } {
   const toolCalls: ToolCallRecord[] = [];
@@ -1783,10 +1495,9 @@ function createRuntime<
         );
         const toolContext = {
           input,
-          metadata: context.metadata,
           signal: context.signal,
           setArtifact: context.setArtifact,
-        } satisfies PiAiToolContext<TInput, TMetadata>;
+        } satisfies PiAiToolContext<TInput>;
 
         try {
           const execution = await executeToolWithReplay({
@@ -1852,7 +1563,7 @@ function createRuntime<
         }
       },
     ]),
-  ) as unknown as PiAiRuntime<TTools, TInput, TMetadata>["tools"];
+  ) as unknown as PiAiRuntime<TTools, TInput>["tools"];
 
   return {
     tools: runtimeTools,
@@ -2198,7 +1909,6 @@ async function executeToolWithReplay<
   TArgs extends Record<string, JsonValue>,
   TResult extends JsonValue,
   TInput,
-  TMetadata extends HarnessMetadata,
 >({
   toolName,
   tool,
@@ -2207,15 +1917,15 @@ async function executeToolWithReplay<
   context,
 }: {
   toolName: string;
-  tool: PiAiToolDefinition<TArgs, TResult, TInput, TMetadata>;
-  replay: PiAiToolReplayPolicy<TInput, TMetadata> | undefined;
+  tool: PiAiToolDefinition<TArgs, TResult, TInput>;
+  replay: PiAiToolReplayPolicy<TInput> | undefined;
   args: TArgs;
-  context: PiAiToolContext<TInput, TMetadata>;
+  context: PiAiToolContext<TInput>;
 }) {
   return executeWithReplay<
     Record<string, JsonValue>,
     JsonValue,
-    PiAiToolContext<TInput, TMetadata>
+    PiAiToolContext<TInput>
   >({
     toolName,
     args,

--- a/packages/harness-pi-ai/src/judgeHarness.test.ts
+++ b/packages/harness-pi-ai/src/judgeHarness.test.ts
@@ -64,7 +64,6 @@ test("piAiJudgeHarness runs judge prompts through Pi AI", async () => {
       },
     },
     {
-      metadata: {},
       signal,
       artifacts: {},
       setArtifact: () => {},

--- a/packages/vitest-evals/README.md
+++ b/packages/vitest-evals/README.md
@@ -30,8 +30,8 @@ workflow.
 
 - `describeEval(...)` binds exactly one harness to a suite
 - the suite callback receives a fixture-backed Vitest `it`
-- `run(input, { metadata? })` executes the harness explicitly and returns a
-  normalized `HarnessRun`
+- `run(input)` executes the harness explicitly and returns a normalized
+  `HarnessRun`
 - the returned `result.output` is the app-facing value you assert on directly
 - the returned `result.session` is the canonical JSON-serializable transcript for
   reporting, replay, tool assertions, and judges
@@ -41,19 +41,18 @@ workflow.
   that do not return traces themselves. Span attributes include typed
   OpenTelemetry GenAI semantic keys while still allowing provider-specific
   metadata
-- scenario-specific judge criteria can live in `input`; use `metadata` for
-  per-run expectations or harness configuration that are not part of the
-  scenario payload
+- scenario-specific judge criteria should live in `input` or explicit matcher
+  options, depending on whether the app or only the judge needs them
 - suite-level `judges` are optional and run automatically after each `run(...)`
 - suite-level `judgeThreshold` controls fail-on-score for those automatic judges
 - every judge is a named object with `assess(ctx)`
 - every judge receives `JudgeContext` with typed `input`, typed `output`, the
-  normalized run/session, tool calls, and metadata; `output` is only optional
+  normalized run/session, and tool calls; `output` is only optional
   when the harness output type includes `undefined`
 - judges own their prompt, rubric, and parsing; LLM-backed judges use
   `ctx.runJudge(...)` from a configured `judgeHarness`
 - explicit judge assertions use
-  `await expect(result).toSatisfyJudge(judge, context)`
+  `await expect(result).toSatisfyJudge(judge, options)`
 
 ## Explicit Run Example
 
@@ -80,18 +79,16 @@ describeEval(
       agent: () => createRefundAgent(),
     }),
     judgeHarness,
-    judges: [FactualityJudge()],
+    judges: [
+      FactualityJudge({
+        expected: "The refund request is approved.",
+      }),
+    ],
     judgeThreshold: 0.6,
   },
   (it) => {
     it("approves a refundable invoice", async ({ run }) => {
-      const result = await run("Refund invoice inv_123", {
-        metadata: {
-          expected: "The refund request is approved.",
-          expectedStatus: "approved",
-          expectedTools: ["lookupInvoice", "createRefund"],
-        },
-      });
+      const result = await run("Refund invoice inv_123");
 
       expect(result.output).toMatchObject({ status: "approved" });
       expect(toolCalls(result.session).map((call) => call.name)).toEqual([
@@ -121,13 +118,11 @@ describeEval("refund agent", { harness }, (it) => {
       input: "Refund invoice inv_404",
       expectedStatus: "denied",
     },
-  ])("$name", async ({ input, ...metadata }, { run }) => {
-    const result = await run(input, {
-      metadata,
-    });
+  ])("$name", async ({ input, expectedStatus }, { run }) => {
+    const result = await run(input);
 
     expect(result.output).toMatchObject({
-      status: metadata.expectedStatus,
+      status: expectedStatus,
     });
   });
 });
@@ -213,7 +208,7 @@ First-party harness packages are conveniences, not the only supported path. If
 you need to test a full application flow, use `createHarness(...)` to run your
 app through its normal entrypoint and return the app-facing output. Judges own
 their prompt/rubric text separately from the system under test.
-When generics are needed, use `createHarness<Input, Output, Metadata>(...)`.
+When generics are needed, use `createHarness<Input, Output>(...)`.
 
 ```ts
 import {
@@ -221,7 +216,6 @@ import {
   createJudge,
   createJudgeHarness,
   describeEval,
-  type JudgeContext,
 } from "vitest-evals";
 
 type AppEvent = {
@@ -238,14 +232,12 @@ type AppEvalInput = {
   };
 };
 
-type AppEvalMetadata = Record<string, never>;
-
 type AppOutput = {
   replies: Array<{ text: string }>;
   sideEffects: string[];
 };
 
-const appHarness = createHarness<AppEvalInput, AppOutput, AppEvalMetadata>({
+const appHarness = createHarness<AppEvalInput, AppOutput>({
   name: "custom-app",
   run: async ({ input, signal }) => {
     const result = await replayAppEvents(input.events, {
@@ -271,9 +263,9 @@ const judgeHarness = createJudgeHarness({
     promptJudgeModel({ prompt, signal }),
 });
 
-const AppRubricJudge = createJudge(
+const AppRubricJudge = createJudge<AppEvalInput, AppOutput>(
   "AppRubricJudge",
-  async (ctx: JudgeContext<AppEvalInput, AppOutput, AppEvalMetadata>) => {
+  async (ctx) => {
     if (!ctx.runJudge) {
       throw new Error("AppRubricJudge requires a configured judgeHarness.");
     }
@@ -323,11 +315,11 @@ describeEval(
 Use `Harness.run(...)` for the application under test. Calling
 `ctx.harness.run(...)` from inside a judge runs the application a second time,
 so reserve that for judges that intentionally need a second execution. Put
-criteria on `input` when they are part of the scenario itself; use per-run
-`metadata` for harness configuration or expectations that are not part of the
-scenario payload. `createHarness(...)` builds a default user/assistant session
-from `input` and typed `output`; return a full `HarnessRun` only when you need
-exact session control.
+criteria on `input` when they are part of the scenario itself; pass
+case-specific judge criteria through matcher options, or configure suite-wide
+criteria on the judge instance. `createHarness(...)` builds a default
+user/assistant session from `input` and typed `output`; return a full
+`HarnessRun` only when you need exact session control.
 
 Provider setup and rubric parsing stay in your judge. The core
 package only requires the judge to return a `JudgeResult` with a score and
@@ -449,7 +441,7 @@ so use that only when a second run is intentional.
 
 For an `EvalHarnessRun` returned by fixture `run(...)`,
 `toSatisfyJudge(...)` uses the run's typed `output` and reuses the registered
-input and metadata. It requires any custom judge params and rejects judges whose
+input. It requires any custom judge params and rejects judges whose
 output type cannot assess the received value. Inside an eval test,
 matcher calls on registered output objects or session objects reuse that exact
 run context when the value can be registered by reference, so
@@ -457,10 +449,10 @@ run context when the value can be registered by reference, so
 outputs. Other raw values fall back to the current test's most recent
 `run(...)` context. For
 manually-created runs or values outside an eval context, pass any required
-`input`, `metadata`, or `harness` in matcher options. Structured or
+`input` or `harness` in matcher options. Structured or
 programmatic result checks should usually assert on `result.output` directly.
 When a judge needs richer normalized context or the configured suite harness,
-type it with `JudgeContext`.
+type it with `createJudge<Input, Output>(...)` or `JudgeContext<Input, Output>`.
 
 When you only need deterministic contract checks, built-ins such as
 `StructuredOutputJudge()` and `ToolCallJudge()` are still available.

--- a/packages/vitest-evals/src/harness.test.ts
+++ b/packages/vitest-evals/src/harness.test.ts
@@ -33,23 +33,13 @@ import {
   type SimpleHarnessResult,
 } from "./index";
 
-type RefundEvalMetadata = {
-  name: string;
-  expectedStatus: string;
-};
-
 type RefundOutput = {
   status: string;
 };
 
-type RefundHarness = Harness<string, RefundOutput, RefundEvalMetadata>;
+type RefundHarness = Harness<string, RefundOutput>;
 
-type RefundJudgeContext = JudgeContext<
-  string,
-  RefundOutput,
-  RefundEvalMetadata,
-  RefundHarness
->;
+type RefundJudgeContext = JudgeContext<string, RefundOutput, RefundHarness>;
 
 type Equal<TActual, TExpected> = (<T>() => T extends TActual ? 1 : 2) extends <
   T,
@@ -110,19 +100,17 @@ type _CreateHarnessUsesOutputAsSecondGeneric = Expect<
   >
 >;
 
-const requiredParamJudge = createJudge(
-  "RequiredParamJudge",
-  async ({
-    expectedStatus,
-    output,
-  }: JudgeOptions<{ expectedStatus: string }, unknown, RefundOutput>) => ({
-    score: output.status === expectedStatus ? 1 : 0,
-  }),
-);
+const requiredParamJudge = createJudge<
+  unknown,
+  RefundOutput,
+  { expectedStatus: string }
+>("RequiredParamJudge", async ({ expectedStatus, output }) => ({
+  score: output.status === expectedStatus ? 1 : 0,
+}));
 
-const stringOutputJudge = createJudge(
+const stringOutputJudge = createJudge<unknown, string>(
   "StringOutputJudge",
-  async ({ output }: JudgeContext<unknown, string>) => ({
+  async ({ output }) => ({
     score: output.length > 0 ? 1 : 0,
   }),
 );
@@ -135,13 +123,14 @@ const stringOutputJudgeWithHarness = {
   ...stringOutputJudge,
   judgeHarness: typedJudgeHarness,
 };
-const configObjectJudgeWithHarness = createJudge({
+const configObjectJudgeWithHarness = createJudge<
+  unknown,
+  RefundOutput,
+  { expectedStatus: string }
+>({
   name: "ConfigObjectJudge",
   judgeHarness: typedJudgeHarness,
-  async assess({
-    expectedStatus,
-    output,
-  }: JudgeOptions<{ expectedStatus: string }, unknown, RefundOutput>) {
+  async assess({ expectedStatus, output }) {
     return {
       score: output.status === expectedStatus ? 1 : 0,
     };
@@ -174,7 +163,7 @@ void assertMatcherTypes;
 const runSpy = vi.fn(
   async (
     input: string,
-    context: HarnessContext<RefundEvalMetadata>,
+    context: HarnessContext,
   ): Promise<HarnessRun<RefundOutput>> => {
     context.setArtifact("request", input);
 
@@ -228,7 +217,7 @@ const customHarness = {
 };
 
 const judgeSpy = vi.fn(async (opts: RefundJudgeContext) => ({
-  score: opts.metadata.expectedStatus === "approved" ? 1 : 0,
+  score: opts.output.status === "approved" ? 1 : 0,
 }));
 
 const judge = createJudge("RefundStatusJudge", judgeSpy);
@@ -272,7 +261,7 @@ beforeEach(() => {
 describeEval(
   "createHarness",
   {
-    harness: createHarness<string, RefundOutput, RefundEvalMetadata>({
+    harness: createHarness<string, RefundOutput>({
       name: "custom-app",
       run: async ({ input, setArtifact }) => {
         setArtifact("request", input);
@@ -307,12 +296,7 @@ describeEval(
   },
   (it) => {
     it("normalizes lightweight harness results", async ({ run }) => {
-      const result = await run("Refund invoice inv_123", {
-        metadata: {
-          name: "custom harness result",
-          expectedStatus: "approved",
-        },
-      });
+      const result = await run("Refund invoice inv_123");
 
       expect(result.output).toEqual({
         status: "approved",
@@ -374,7 +358,6 @@ test("createHarness drops non-normalized lightweight tool call fields", async ()
   });
 
   const result = await lightweightHarness.run("Refund invoice inv_123", {
-    metadata: {},
     artifacts: {},
     setArtifact: vi.fn(),
   });
@@ -407,7 +390,6 @@ test("createHarness attaches fallback traces to direct runs", async () => {
   });
 
   const result = await lightweightHarness.run("Refund invoice inv_123", {
-    metadata: {},
     artifacts: {},
     setArtifact: vi.fn(),
   });
@@ -447,7 +429,6 @@ test("createHarness attaches failed runs and traces to thrown errors", async () 
   let thrown: unknown;
   try {
     await lightweightHarness.run("Refund invoice inv_123", {
-      metadata: {},
       artifacts: {},
       setArtifact: vi.fn(),
     });
@@ -478,7 +459,6 @@ test("createHarness preserves typed lightweight output values", async () => {
   });
 
   const result = await lightweightHarness.run("Refund invoice inv_123", {
-    metadata: {},
     artifacts: {},
     setArtifact: vi.fn(),
   });
@@ -505,7 +485,6 @@ test("createHarness preserves null lightweight output in the session", async () 
   });
 
   const result = await lightweightHarness.run("Refund invoice inv_123", {
-    metadata: {},
     artifacts: {},
     setArtifact: vi.fn(),
   });
@@ -533,7 +512,6 @@ test("createHarness serializes Error objects in lightweight errors", async () =>
   });
 
   const result = await lightweightHarness.run("Refund invoice inv_123", {
-    metadata: {},
     artifacts: {},
     setArtifact: vi.fn(),
   });
@@ -594,7 +572,6 @@ test("createHarness normalizes lightweight traces", async () => {
   });
 
   const result = await lightweightHarness.run("Refund invoice inv_123", {
-    metadata: {},
     artifacts: {},
     setArtifact: vi.fn(),
   });
@@ -717,12 +694,7 @@ test("JSON normalization drops non-finite numbers and circular references", () =
 
 describeEval("harness mode", { harness }, (it) => {
   it("refund request", async ({ run, task }) => {
-    const result = await run("Refund invoice inv_123", {
-      metadata: {
-        name: "refund request",
-        expectedStatus: "approved",
-      },
-    });
+    const result = await run("Refund invoice inv_123");
 
     expect(result.output).toEqual({
       status: "approved",
@@ -764,9 +736,8 @@ describeEval("harness mode", { harness }, (it) => {
     expect(runSpy).toHaveBeenCalledWith(
       "Refund invoice inv_123",
       expect.objectContaining({
-        metadata: expect.objectContaining({
-          expectedStatus: "approved",
-          name: "refund request",
+        artifacts: expect.objectContaining({
+          request: "Refund invoice inv_123",
         }),
       }),
     );
@@ -781,12 +752,7 @@ describeEval(
   },
   (it) => {
     it("refund request with judge", async ({ run, task }) => {
-      const result = await run("Refund invoice inv_123", {
-        metadata: {
-          name: "refund request with judge",
-          expectedStatus: "approved",
-        },
-      });
+      const result = await run("Refund invoice inv_123");
 
       expect(result.output).toEqual({
         status: "approved",
@@ -800,9 +766,6 @@ describeEval(
           output: {
             status: "approved",
           },
-          metadata: expect.objectContaining({
-            expectedStatus: "approved",
-          }),
           run: expect.objectContaining({
             output: {
               status: "approved",
@@ -839,12 +802,7 @@ describeEval(
         "CustomHarnessJudge",
         async ({
           harness: configuredHarness,
-        }: JudgeContext<
-          string,
-          RefundOutput,
-          RefundEvalMetadata,
-          typeof customHarness
-        >) => {
+        }: JudgeContext<string, RefundOutput, typeof customHarness>) => {
           return {
             score: configuredHarness.label === "custom-harness" ? 1 : 0,
           };
@@ -856,12 +814,7 @@ describeEval(
     it("preserves the configured harness subtype for judges", async ({
       run,
     }) => {
-      await run("Refund invoice inv_123", {
-        metadata: {
-          name: "refund request with typed harness helper",
-          expectedStatus: "approved",
-        },
-      });
+      await run("Refund invoice inv_123");
     });
   },
 );
@@ -876,12 +829,7 @@ describeEval(
     it("curries run-scoped options into judge assessor calls", async ({
       run,
     }) => {
-      await run("Refund invoice inv_123", {
-        metadata: {
-          name: "refund request with bound judge harness",
-          expectedStatus: "approved",
-        },
-      });
+      await run("Refund invoice inv_123");
 
       expect(judgeAssessorAssessSpy).toHaveBeenCalledWith(
         "Judge refund request Refund invoice inv_123",
@@ -905,12 +853,7 @@ describeEval(
       run,
       task,
     }) => {
-      await run("Refund invoice inv_123", {
-        metadata: {
-          name: "refund request at threshold",
-          expectedStatus: "approved",
-        },
-      });
+      await run("Refund invoice inv_123");
 
       expect(thresholdJudgeSpy).toHaveBeenCalledTimes(1);
       expect(task.meta.eval).toEqual({
@@ -937,12 +880,7 @@ describeEval("harness mode with explicit judge matcher", { harness }, (it) => {
   it("curries run-scoped options into explicit judge assessor calls", async ({
     run,
   }) => {
-    const result = await run("Refund invoice inv_123", {
-      metadata: {
-        name: "refund request with explicit bound judge harness",
-        expectedStatus: "approved",
-      },
-    });
+    const result = await run("Refund invoice inv_123");
 
     await expect(result).toSatisfyJudge(boundAssessorJudge);
 
@@ -954,29 +892,29 @@ describeEval("harness mode with explicit judge matcher", { harness }, (it) => {
     );
   });
 
-  it("records explicit judge metadata on the task", async ({ run, task }) => {
-    const result = await run("Refund invoice inv_123", {
-      metadata: {
-        name: "refund request with explicit judge matcher",
-        expectedStatus: "approved",
-      },
-    });
-    const explicitJudgeSpy = vi.fn(async (opts: RefundJudgeContext) => ({
-      score:
-        opts.input === "Refund invoice inv_123" &&
-        opts.output.status === "approved" &&
-        opts.metadata.expectedStatus === "approved" &&
-        opts.toolCalls?.[0]?.name === "lookupInvoice"
-          ? 1
-          : 0,
-    }));
+  it("records explicit judge params on the task", async ({ run, task }) => {
+    type ExplicitRefundJudgeContext = JudgeOptions<
+      string,
+      RefundOutput,
+      { expectedStatus: string },
+      RefundHarness
+    >;
+    const result = await run("Refund invoice inv_123");
+    const explicitJudgeSpy = vi.fn(
+      async (opts: ExplicitRefundJudgeContext) => ({
+        score:
+          opts.input === "Refund invoice inv_123" &&
+          opts.output.status === "approved" &&
+          opts.expectedStatus === "approved" &&
+          opts.toolCalls?.[0]?.name === "lookupInvoice"
+            ? 1
+            : 0,
+      }),
+    );
     const explicitJudge = createJudge("ExplicitRefundJudge", explicitJudgeSpy);
 
     await expect(result).toSatisfyJudge(explicitJudge, {
-      metadata: {
-        expectedStatus: "approved",
-        name: "refund request with explicit judge matcher",
-      },
+      expectedStatus: "approved",
     });
 
     expect(explicitJudgeSpy).toHaveBeenCalledWith(
@@ -985,10 +923,7 @@ describeEval("harness mode with explicit judge matcher", { harness }, (it) => {
         output: {
           status: "approved",
         },
-        metadata: {
-          expectedStatus: "approved",
-          name: "refund request with explicit judge matcher",
-        },
+        expectedStatus: "approved",
       }),
     );
     expect(task.meta.eval).toEqual({
@@ -1009,23 +944,12 @@ describeEval("harness mode with explicit judge matcher", { harness }, (it) => {
     });
   });
 
-  it("reuses the suite harness and metadata for explicit judges", async ({
-    run,
-  }) => {
-    const result = await run("Refund invoice inv_123", {
-      metadata: {
-        name: "refund request with explicit typed harness judge",
-        expectedStatus: "approved",
-      },
-    });
+  it("reuses the suite harness for explicit judges", async ({ run }) => {
+    const result = await run("Refund invoice inv_123");
     const explicitJudgeSpy = vi.fn(
-      async ({ harness: configuredHarness, metadata }: RefundJudgeContext) => {
+      async ({ harness: configuredHarness }: RefundJudgeContext) => {
         return {
-          score:
-            configuredHarness === harness &&
-            metadata.expectedStatus === "approved"
-              ? 1
-              : 0,
+          score: configuredHarness === harness ? 1 : 0,
         };
       },
     );
@@ -1036,10 +960,6 @@ describeEval("harness mode with explicit judge matcher", { harness }, (it) => {
     expect(explicitJudgeSpy).toHaveBeenCalledWith(
       expect.objectContaining({
         harness,
-        metadata: {
-          expectedStatus: "approved",
-          name: "refund request with explicit typed harness judge",
-        },
       }),
     );
   });
@@ -1047,17 +967,11 @@ describeEval("harness mode with explicit judge matcher", { harness }, (it) => {
   it("uses the current test run context for raw explicit judge values", async ({
     run,
   }) => {
-    const result = await run("Refund invoice inv_123", {
-      metadata: {
-        name: "refund request with contextual raw judge",
-        expectedStatus: "approved",
-      },
-    });
+    const result = await run("Refund invoice inv_123");
     const explicitJudgeSpy = vi.fn(
       async ({
         harness: configuredHarness,
         input,
-        metadata,
         output,
         run: judgeRun,
         session,
@@ -1070,7 +984,6 @@ describeEval("harness mode with explicit judge matcher", { harness }, (it) => {
             judgeRun === result &&
             session === result.session &&
             judgeToolCalls[0]?.name === "lookupInvoice" &&
-            metadata.expectedStatus === "approved" &&
             input === "Refund invoice inv_123"
               ? 1
               : 0,
@@ -1101,10 +1014,6 @@ describeEval("harness mode with explicit judge matcher", { harness }, (it) => {
             },
           },
         ],
-        metadata: {
-          expectedStatus: "approved",
-          name: "refund request with contextual raw judge",
-        },
       }),
     );
   });
@@ -1112,28 +1021,13 @@ describeEval("harness mode with explicit judge matcher", { harness }, (it) => {
   it("prefers exact output object context over the latest run fallback", async ({
     run,
   }) => {
-    const first = await run("Refund invoice inv_123", {
-      metadata: {
-        name: "first raw judge context",
-        expectedStatus: "approved",
-      },
-    });
+    const first = await run("Refund invoice inv_123");
 
-    await run("Refund invoice inv_456", {
-      metadata: {
-        name: "second raw judge context",
-        expectedStatus: "rejected",
-      },
-    });
+    await run("Refund invoice inv_456");
 
     const explicitJudgeSpy = vi.fn(
-      async ({ input, metadata, run: judgeRun }: RefundJudgeContext) => ({
-        score:
-          input === "Refund invoice inv_123" &&
-          metadata.name === "first raw judge context" &&
-          judgeRun === first
-            ? 1
-            : 0,
+      async ({ input, run: judgeRun }: RefundJudgeContext) => ({
+        score: input === "Refund invoice inv_123" && judgeRun === first ? 1 : 0,
       }),
     );
     const explicitJudge = createJudge(
@@ -1146,10 +1040,6 @@ describeEval("harness mode with explicit judge matcher", { harness }, (it) => {
     expect(explicitJudgeSpy).toHaveBeenCalledWith(
       expect.objectContaining({
         input: "Refund invoice inv_123",
-        metadata: {
-          expectedStatus: "approved",
-          name: "first raw judge context",
-        },
         run: first,
       }),
     );
@@ -1224,10 +1114,6 @@ describeEval(
 
 test("toSatisfyJudge reuses normalized harness run data", async () => {
   const run = await harness.run("Refund invoice inv_123", {
-    metadata: {
-      expectedStatus: "approved",
-      name: "explicit judge",
-    },
     artifacts: {},
     setArtifact: vi.fn(),
   });
@@ -1244,10 +1130,6 @@ test("toSatisfyJudge reuses normalized harness run data", async () => {
 
   await expect(run).toSatisfyJudge(explicitJudge, {
     input: "Refund invoice inv_123",
-    metadata: {
-      expectedStatus: "approved",
-      name: "explicit judge",
-    },
     harness,
   });
 
@@ -1271,62 +1153,30 @@ test("toSatisfyJudge reuses normalized harness run data", async () => {
           },
         },
       ],
-      metadata: {
-        expectedStatus: "approved",
-        name: "explicit judge",
-      },
-    }),
-  );
-});
-
-test("automatic judges read per-run params from metadata", async () => {
-  const metadataJudgeSpy = vi.fn(async (opts: RefundJudgeContext) => ({
-    score: opts.metadata.expectedStatus === "approved" ? 1 : 0,
-  }));
-  const metadataJudge = createJudge("MetadataJudge", metadataJudgeSpy);
-
-  const run = await harness.run("Refund invoice inv_123", {
-    metadata: {
-      expectedStatus: "approved",
-      name: "compatibility judge",
-    },
-    artifacts: {},
-    setArtifact: vi.fn(),
-  });
-
-  await expect(run).toSatisfyJudge(metadataJudge, {
-    input: "Refund invoice inv_123",
-    metadata: {
-      expectedStatus: "approved",
-      name: "compatibility judge",
-    },
-    harness,
-  });
-
-  expect(metadataJudgeSpy).toHaveBeenCalledWith(
-    expect.objectContaining({
-      metadata: {
-        expectedStatus: "approved",
-        name: "compatibility judge",
-      },
     }),
   );
 });
 
 test("toSatisfyJudge accepts explicit harness context for raw values", async () => {
+  type RawHarnessContextJudgeOptions = JudgeOptions<
+    string,
+    RefundOutput,
+    { expectedStatus: string },
+    RefundHarness
+  >;
   const explicitJudgeSpy = vi.fn(
     async ({
       harness: configuredHarness,
       input,
-      metadata,
+      expectedStatus,
       output,
-    }: RefundJudgeContext) => {
+    }: RawHarnessContextJudgeOptions) => {
       return {
         score:
           configuredHarness === harness &&
           input === "Refund invoice inv_123" &&
           output.status === "approved" &&
-          metadata.expectedStatus === "approved"
+          expectedStatus === "approved"
             ? 1
             : 0,
       };
@@ -1338,10 +1188,7 @@ test("toSatisfyJudge accepts explicit harness context for raw values", async () 
     status: "approved",
   }).toSatisfyJudge(explicitJudge, {
     input: "Refund invoice inv_123",
-    metadata: {
-      expectedStatus: "approved",
-      name: "raw value with explicit harness context",
-    },
+    expectedStatus: "approved",
     harness,
   });
 
@@ -1352,10 +1199,7 @@ test("toSatisfyJudge accepts explicit harness context for raw values", async () 
       output: {
         status: "approved",
       },
-      metadata: {
-        expectedStatus: "approved",
-        name: "raw value with explicit harness context",
-      },
+      expectedStatus: "approved",
     }),
   );
 });
@@ -1681,7 +1525,6 @@ test("ToolCallJudge accepts string expected tools", async () => {
         name: "createRefund",
       },
     ],
-    metadata: {},
     run: {
       session: {
         messages: [],
@@ -1698,7 +1541,7 @@ test("ToolCallJudge accepts string expected tools", async () => {
   expect(result.score).toBe(1);
 });
 
-test("StructuredOutputJudge reads expected fields from metadata", async () => {
+test("StructuredOutputJudge reads expected fields from judge options", async () => {
   const judge = StructuredOutputJudge();
 
   const result = await judge.assess({
@@ -1719,10 +1562,8 @@ test("StructuredOutputJudge reads expected fields from metadata", async () => {
     session: {
       messages: [],
     },
-    metadata: {
-      expected: {
-        status: "approved",
-      },
+    expected: {
+      status: "approved",
     },
     harness: undefined,
   });

--- a/packages/vitest-evals/src/harness.ts
+++ b/packages/vitest-evals/src/harness.ts
@@ -94,7 +94,7 @@ export type EnsureRunTraceOptions = {
 type OutputField<TOutput extends JsonValue | undefined> =
   undefined extends TOutput ? { output?: TOutput } : { output: TOutput };
 
-/** Per-run metadata shape accepted by harnesses and eval tests. */
+/** Generic JSON-like metadata record used by normalized artifacts and reports. */
 export type HarnessMetadata = Record<string, unknown>;
 
 /**
@@ -117,11 +117,7 @@ export type HarnessMetadata = Record<string, unknown>;
  * };
  * ```
  */
-export type HarnessContext<
-  TMetadata extends HarnessMetadata = HarnessMetadata,
-> = {
-  /** Per-run metadata passed through `run(input, { metadata })`. */
-  metadata: Readonly<TMetadata>;
+export type HarnessContext = {
   /** Abort signal from Vitest when available. */
   signal?: AbortSignal;
   /** Mutable JSON-safe artifact bag shared with the harness. */
@@ -146,15 +142,11 @@ export type HarnessContext<
 export type Harness<
   TInput = unknown,
   TOutput extends JsonValue | undefined = JsonValue | undefined,
-  TMetadata extends HarnessMetadata = HarnessMetadata,
 > = {
   /** Stable harness name used in reports. */
   name: string;
   /** Executes the system under test and returns a normalized run. */
-  run: (
-    input: TInput,
-    context: HarnessContext<TMetadata>,
-  ) => Promise<HarnessRun<TOutput>>;
+  run: (input: TInput, context: HarnessContext) => Promise<HarnessRun<TOutput>>;
 };
 
 /** Value or promise accepted by lightweight harness callbacks. */
@@ -241,17 +233,15 @@ export type HarnessResultLike<
 > = HarnessRun<TOutput> | SimpleHarnessResult<TOutput>;
 
 /** Arguments passed to the `createHarness(...)` convenience callback. */
-export type CreateHarnessRunArgs<TInput, TMetadata extends HarnessMetadata> = {
+export type CreateHarnessRunArgs<TInput> = {
   /** Original input passed to `run(input)`. */
   input: TInput;
-  /** Read-only metadata passed to `run(input, { metadata })`. */
-  metadata: Readonly<TMetadata>;
   /** Abort signal from Vitest when available. */
   signal?: AbortSignal;
   /** Mutable run artifact bag. */
-  artifacts: HarnessContext<TMetadata>["artifacts"];
+  artifacts: HarnessContext["artifacts"];
   /** Stores one JSON-safe artifact on the current run. */
-  setArtifact: HarnessContext<TMetadata>["setArtifact"];
+  setArtifact: HarnessContext["setArtifact"];
 };
 
 /**
@@ -270,13 +260,12 @@ export type CreateHarnessRunArgs<TInput, TMetadata extends HarnessMetadata> = {
 export type CreateHarnessOptions<
   TInput = unknown,
   TOutput extends JsonValue | undefined = JsonValue | undefined,
-  TMetadata extends HarnessMetadata = HarnessMetadata,
 > = {
   /** Stable harness name used in reports. */
   name: string;
   /** Executes application code and returns either a lightweight result or full `HarnessRun`. */
   run: (
-    args: CreateHarnessRunArgs<TInput, TMetadata>,
+    args: CreateHarnessRunArgs<TInput>,
   ) => MaybePromise<HarnessResultLike<TOutput>>;
 };
 
@@ -407,15 +396,14 @@ export function normalizeContent(value: unknown): JsonValue {
  *
  * export const refundHarness = createHarness<
  *   string,
- *   { status: "approved" | "denied" },
- *   { expected: { status: "approved" | "denied" } }
+ *   { status: "approved" | "denied" }
  * >({
  *   name: "refund-agent",
- *   run: async ({ input, metadata, setArtifact }) => {
- *     const result = await runRefundFlow(input, metadata);
+ *   run: async ({ input, setArtifact }) => {
+ *     const result = await runRefundFlow(input);
  *     const output = { status: result.status };
  *
- *     setArtifact("case", { expected: metadata.expected.status });
+ *     setArtifact("case", { invoiceId: result.invoiceId });
  *
  *     return {
  *       output,
@@ -429,18 +417,12 @@ export function normalizeContent(value: unknown): JsonValue {
 export function createHarness<
   TInput = unknown,
   TOutput extends JsonValue | undefined = JsonValue | undefined,
-  TMetadata extends HarnessMetadata = HarnessMetadata,
->(
-  options: CreateHarnessOptions<TInput, TOutput, TMetadata>,
-): Harness<TInput, TOutput, TMetadata>;
+>(options: CreateHarnessOptions<TInput, TOutput>): Harness<TInput, TOutput>;
 export function createHarness<
   TInput = unknown,
   TOutput extends JsonValue | undefined = JsonValue | undefined,
-  TMetadata extends HarnessMetadata = HarnessMetadata,
->(
-  options: CreateHarnessOptions<TInput, TOutput, TMetadata>,
-): Harness<TInput, TOutput, TMetadata> {
-  const harness: Harness<TInput, TOutput, TMetadata> = {
+>(options: CreateHarnessOptions<TInput, TOutput>): Harness<TInput, TOutput> {
+  const harness: Harness<TInput, TOutput> = {
     name: options.name,
     run: async (input, context) => {
       const startedAt = new Date();
@@ -448,7 +430,6 @@ export function createHarness<
       try {
         const result = await options.run({
           input,
-          metadata: context.metadata,
           signal: context.signal,
           artifacts: context.artifacts,
           setArtifact: context.setArtifact,
@@ -515,12 +496,11 @@ export function createHarness<
  */
 export function normalizeHarnessRun<
   TInput = unknown,
-  TMetadata extends HarnessMetadata = HarnessMetadata,
   TOutput extends JsonValue | undefined = JsonValue | undefined,
 >(
   input: TInput,
   result: HarnessResultLike<TOutput>,
-  context?: HarnessContext<TMetadata>,
+  context?: HarnessContext,
 ): HarnessRun<TOutput> {
   if (isHarnessRun(result)) {
     if (

--- a/packages/vitest-evals/src/index.ts
+++ b/packages/vitest-evals/src/index.ts
@@ -3,7 +3,6 @@ import "vitest";
 import type {
   Harness,
   HarnessContext,
-  HarnessMetadata,
   HarnessRun,
   JsonValue,
   NormalizedSession,
@@ -52,43 +51,46 @@ type EvalTaskLike = {
 };
 
 type RegisteredJudgeRunContext = {
-  harness: Harness<any, any, any>;
+  harness: Harness<any, any>;
   input: unknown;
   judgeHarness?: JudgeHarness;
-  metadata: HarnessMetadata;
   run: HarnessRun;
   signal?: AbortSignal;
 };
 
 type InternalEvalFixtures = {
-  harness: Harness<any, any, any>;
-  automaticJudges: Array<Judge<JudgeContext<any, any, any, any>>>;
+  harness: Harness<any, any>;
+  automaticJudges: Array<Judge<JudgeContext<any, any, any>>>;
   judgeHarness?: JudgeHarness;
   judgeThreshold: number | null | undefined;
   explicitJudgeHarness?: JudgeHarness;
-  run: EvalRun<any, any, any>;
+  run: EvalRun<any, any>;
 };
 
-type HarnessInput<THarness extends Harness<any, any, any>> =
-  THarness extends Harness<infer TInput, any, any> ? TInput : unknown;
+type HarnessInput<THarness extends Harness<any, any>> =
+  THarness extends Harness<infer TInput, any> ? TInput : unknown;
 
-type HarnessMetadataFor<THarness extends Harness<any, any, any>> =
-  THarness extends Harness<any, any, infer TMetadata>
-    ? TMetadata
-    : HarnessMetadata;
-
-type HarnessOutput<THarness extends Harness<any, any, any>> =
-  THarness extends Harness<any, infer TOutput, any>
+type HarnessOutput<THarness extends Harness<any, any>> =
+  THarness extends Harness<any, infer TOutput>
     ? TOutput
     : JsonValue | undefined;
 
 type CreateJudgeConfig<
-  TOptions extends JudgeContext<any, any, any, any> = JudgeContext,
+  TOptions extends JudgeContext<any, any, any> = JudgeContext,
 > = {
   name: string;
   judgeHarness?: JudgeHarness;
   assess: JudgeAssessFn<TOptions>;
 };
+
+type CreateJudgeContext<
+  TInput,
+  TOutput extends JsonValue | undefined,
+  TOptions extends object,
+  THarness extends Harness<TInput, TOutput> | undefined =
+    | Harness<TInput, TOutput>
+    | undefined,
+> = JudgeOptions<TInput, TOutput, TOptions, THarness>;
 
 declare const evalHarnessRunBrand: unique symbol;
 
@@ -107,64 +109,28 @@ declare const evalHarnessRunBrand: unique symbol;
 export type EvalHarnessRun<
   TInput = unknown,
   TOutput extends JsonValue | undefined = JsonValue | undefined,
-  TMetadata extends HarnessMetadata = HarnessMetadata,
-  THarness extends Harness<TInput, TOutput, TMetadata> = Harness<
-    TInput,
-    TOutput,
-    TMetadata
-  >,
+  THarness extends Harness<TInput, TOutput> = Harness<TInput, TOutput>,
 > = HarnessRun<TOutput> & {
   readonly [evalHarnessRunBrand]: {
     readonly input: TInput;
-    readonly metadata: TMetadata;
     readonly output: TOutput;
     readonly harness: THarness;
   };
 };
 
 /**
- * Per-run metadata forwarded to the harness alongside the test input.
- *
- * @example
- * ```ts
- * await run("Refund invoice inv_123", {
- *   metadata: {
- *     expected: { status: "approved" },
- *     expectedTools: ["lookupInvoice", "createRefund"],
- *   },
- * });
- * ```
- */
-export interface EvalRunOptions<
-  TMetadata extends HarnessMetadata = HarnessMetadata,
-> {
-  /** Per-run expectations or configuration forwarded to harnesses and judges. */
-  metadata?: TMetadata;
-}
-
-/**
  * Explicit harness execution primitive exposed to each eval test.
  *
  * @example
  * ```ts
- * const result = await run("Refund invoice inv_123", {
- *   metadata: { expected: { status: "approved" } },
- * });
+ * const result = await run("Refund invoice inv_123");
  * ```
  */
 export type EvalRun<
   TInput = unknown,
   TOutput extends JsonValue | undefined = JsonValue | undefined,
-  TMetadata extends HarnessMetadata = HarnessMetadata,
-  THarness extends Harness<TInput, TOutput, TMetadata> = Harness<
-    TInput,
-    TOutput,
-    TMetadata
-  >,
-> = (
-  input: TInput,
-  options?: EvalRunOptions<TMetadata>,
-) => Promise<EvalHarnessRun<TInput, TOutput, TMetadata, THarness>>;
+  THarness extends Harness<TInput, TOutput> = Harness<TInput, TOutput>,
+> = (input: TInput) => Promise<EvalHarnessRun<TInput, TOutput, THarness>>;
 
 /**
  * Fixture-backed Vitest context exposed inside `describeEval(...)` tests.
@@ -183,27 +149,17 @@ export type EvalRun<
 export interface EvalTestContext<
   TInput = unknown,
   TOutput extends JsonValue | undefined = JsonValue | undefined,
-  TMetadata extends HarnessMetadata = HarnessMetadata,
-  THarness extends Harness<TInput, TOutput, TMetadata> = Harness<
-    TInput,
-    TOutput,
-    TMetadata
-  >,
+  THarness extends Harness<TInput, TOutput> = Harness<TInput, TOutput>,
 > {
-  run: EvalRun<TInput, TOutput, TMetadata, THarness>;
+  run: EvalRun<TInput, TOutput, THarness>;
 }
 
 /** Fixture-backed Vitest test API exposed inside `describeEval(...)`. */
 export type EvalTestAPI<
   TInput = unknown,
   TOutput extends JsonValue | undefined = JsonValue | undefined,
-  TMetadata extends HarnessMetadata = HarnessMetadata,
-  THarness extends Harness<TInput, TOutput, TMetadata> = Harness<
-    TInput,
-    TOutput,
-    TMetadata
-  >,
-> = TestAPI<EvalTestContext<TInput, TOutput, TMetadata, THarness>>;
+  THarness extends Harness<TInput, TOutput> = Harness<TInput, TOutput>,
+> = TestAPI<EvalTestContext<TInput, TOutput, THarness>>;
 
 /**
  * Suite-level configuration for a harness-backed eval block.
@@ -224,17 +180,12 @@ export type EvalTestAPI<
 export interface DescribeEvalOptions<
   TInput = unknown,
   TOutput extends JsonValue | undefined = JsonValue | undefined,
-  TMetadata extends HarnessMetadata = HarnessMetadata,
-  THarness extends Harness<TInput, TOutput, TMetadata> = Harness<
-    TInput,
-    TOutput,
-    TMetadata
-  >,
+  THarness extends Harness<TInput, TOutput> = Harness<TInput, TOutput>,
 > {
   /** Harness used for every explicit `run(...)` call in the suite. */
   harness: THarness;
   /** Automatic judges applied after each successful `run(...)`. */
-  judges?: Array<Judge<JudgeContext<TInput, TOutput, TMetadata, THarness>>>;
+  judges?: Array<Judge<JudgeContext<TInput, TOutput, THarness>>>;
   /** Optional judge-side harness used only by judges that call `ctx.runJudge(...)`. */
   judgeHarness?: JudgeHarness;
   /** Passing threshold for automatic suite-level judges. `null` disables fail-on-score. */
@@ -243,56 +194,43 @@ export interface DescribeEvalOptions<
   skipIf?: () => boolean;
 }
 
-type JudgeAssertionInput<
-  TJudgeOptions extends JudgeContext<any, any, any, any>,
-> = TJudgeOptions extends { input: infer TInput } ? TInput : unknown;
+type JudgeAssertionInput<TJudgeOptions extends JudgeContext<any, any, any>> =
+  TJudgeOptions extends { input: infer TInput } ? TInput : unknown;
 
-type JudgeAssertionOutput<
-  TJudgeOptions extends JudgeContext<any, any, any, any>,
-> = TJudgeOptions extends { output: infer TOutput }
-  ? TOutput
-  : JsonValue | undefined;
+type JudgeAssertionOutput<TJudgeOptions extends JudgeContext<any, any, any>> =
+  TJudgeOptions extends { output: infer TOutput }
+    ? TOutput
+    : JsonValue | undefined;
 
-type JudgeAssertionMetadata<
-  TJudgeOptions extends JudgeContext<any, any, any, any>,
-> = TJudgeOptions extends { metadata: infer TMetadata }
-  ? TMetadata
-  : HarnessMetadata;
-
-type JudgeAssertionHarness<
-  TJudgeOptions extends JudgeContext<any, any, any, any>,
-> = TJudgeOptions extends { harness: infer THarness }
-  ? Exclude<THarness, undefined>
-  : Harness<
-      JudgeAssertionInput<TJudgeOptions>,
-      JudgeAssertionOutput<TJudgeOptions>,
-      JudgeAssertionMetadata<TJudgeOptions>
-    >;
+type JudgeAssertionHarness<TJudgeOptions extends JudgeContext<any, any, any>> =
+  TJudgeOptions extends { harness: infer THarness }
+    ? Exclude<THarness, undefined>
+    : Harness<
+        JudgeAssertionInput<TJudgeOptions>,
+        JudgeAssertionOutput<TJudgeOptions>
+      >;
 
 type JudgeAssertionReservedKey =
-  | keyof JudgeContext<any, any, any, any>
+  | keyof JudgeContext<any, any, any>
   | "judgeHarness"
   | "signal"
   | "threshold";
 
-type JudgeAssertionParams<
-  TJudgeOptions extends JudgeContext<any, any, any, any>,
-> = Omit<TJudgeOptions, JudgeAssertionReservedKey>;
+type JudgeAssertionParams<TJudgeOptions extends JudgeContext<any, any, any>> =
+  Omit<TJudgeOptions, JudgeAssertionReservedKey>;
 
 type RequiredKeys<T> = {
   [K in keyof T]-?: Record<string, never> extends Pick<T, K> ? never : K;
 }[keyof T];
 
-type JudgeAssertionArgs<
-  TJudgeOptions extends JudgeContext<any, any, any, any>,
-> = RequiredKeys<JudgeAssertionParams<TJudgeOptions>> extends never
-  ? [options?: JudgeAssertionOptions<TJudgeOptions>]
-  : [options: JudgeAssertionOptions<TJudgeOptions>];
+type JudgeAssertionArgs<TJudgeOptions extends JudgeContext<any, any, any>> =
+  RequiredKeys<JudgeAssertionParams<TJudgeOptions>> extends never
+    ? [options?: JudgeAssertionOptions<TJudgeOptions>]
+    : [options: JudgeAssertionOptions<TJudgeOptions>];
 
 type MatcherOutput<TReceived> = TReceived extends EvalHarnessRun<
   any,
   infer TOutput,
-  any,
   any
 >
   ? TOutput
@@ -306,7 +244,7 @@ type MatcherOutput<TReceived> = TReceived extends EvalHarnessRun<
 
 type JudgeForReceived<
   TReceived,
-  TJudgeOptions extends JudgeContext<any, any, any, any>,
+  TJudgeOptions extends JudgeContext<any, any, any>,
 > = MatcherOutput<TReceived> extends JudgeAssertionOutput<TJudgeOptions>
   ? Judge<TJudgeOptions>
   : never;
@@ -322,14 +260,12 @@ type JudgeForReceived<
  * ```
  */
 export type JudgeAssertionOptions<
-  TJudgeOptions extends JudgeContext<any, any, any, any> = JudgeContext,
+  TJudgeOptions extends JudgeContext<any, any, any> = JudgeContext,
 > = JudgeAssertionParams<TJudgeOptions> & {
   /** Override or provide the original eval input for the judge. */
   input?: JudgeAssertionInput<TJudgeOptions>;
   /** Override or provide the app-facing output for the judge. */
   output?: JudgeAssertionOutput<TJudgeOptions>;
-  /** Override or provide per-run judge metadata. */
-  metadata?: JudgeAssertionMetadata<TJudgeOptions>;
   /** Override or provide flattened tool calls for the judge. */
   toolCalls?: ToolCallRecord[];
   /** Override or provide the complete normalized harness run. */
@@ -346,7 +282,7 @@ export type JudgeAssertionOptions<
 
 /** Function type installed as the `toSatisfyJudge(...)` matcher. */
 export type ToSatisfyJudge<TReceived = unknown> = <
-  TJudgeOptions extends JudgeContext<any, any, any, any> = JudgeContext,
+  TJudgeOptions extends JudgeContext<any, any, any> = JudgeContext,
 >(
   judge: JudgeForReceived<TReceived, TJudgeOptions>,
   ...args: JudgeAssertionArgs<TJudgeOptions>
@@ -382,10 +318,7 @@ const evalTest = test
       "describeEval must override the harness fixture before running tests.",
     );
   })
-  .extend(
-    "automaticJudges",
-    [] as Array<Judge<JudgeContext<any, any, any, any>>>,
-  )
+  .extend("automaticJudges", [] as Array<Judge<JudgeContext<any, any, any>>>)
   .extend("judgeThreshold", undefined as number | null | undefined)
   .extend("judgeHarness", undefined as JudgeHarness | undefined)
   .extend("explicitJudgeHarness", undefined as JudgeHarness | undefined)
@@ -400,16 +333,13 @@ const evalTest = test
       signal,
       task,
     }) => {
-      return async (input: unknown, options?: EvalRunOptions) => {
+      return async (input: unknown) => {
         const resolvedHarness = harness as Harness<
           unknown,
-          JsonValue | undefined,
-          HarnessMetadata
+          JsonValue | undefined
         >;
-        const metadata = createMetadata(options?.metadata);
         const artifacts: HarnessContext["artifacts"] = {};
-        const context: HarnessContext<HarnessMetadata> = {
-          metadata,
+        const context: HarnessContext = {
           signal,
           artifacts,
           setArtifact: (artifactName, value) => {
@@ -442,7 +372,6 @@ const evalTest = test
               resolvedHarness,
               input,
               explicitJudgeHarness,
-              metadata,
               signal,
             );
           }
@@ -462,7 +391,6 @@ const evalTest = test
               resolvedHarness,
               input,
               explicitJudgeHarness,
-              metadata,
               signal,
             );
           }
@@ -485,7 +413,6 @@ const evalTest = test
           resolvedHarness,
           input,
           explicitJudgeHarness,
-          metadata,
           signal,
         );
 
@@ -497,7 +424,6 @@ const evalTest = test
             resolvedHarness,
             input,
             judgeHarness,
-            metadata,
             run,
             signal,
           );
@@ -506,7 +432,6 @@ const evalTest = test
         return run as EvalHarnessRun<
           unknown,
           JsonValue | undefined,
-          HarnessMetadata,
           typeof resolvedHarness
         >;
       };
@@ -515,7 +440,7 @@ const evalTest = test
 
 expect.extend({
   toSatisfyJudge: async function toSatisfyJudge<
-    TJudgeOptions extends JudgeContext<any, any, any, any> = JudgeContext,
+    TJudgeOptions extends JudgeContext<any, any, any> = JudgeContext,
   >(
     received: unknown,
     judge: Judge<TJudgeOptions>,
@@ -608,43 +533,34 @@ function formatJudgeOutputForMessage(output: JsonValue | undefined) {
  *   judges: [ToolCallJudge()],
  * }, (it) => {
  *   it("approves a refundable invoice", async ({ run }) => {
- *     const result = await run("Refund invoice inv_123", {
- *       metadata: {
- *         expected: "Invoice inv_123 should be refunded.",
- *       },
- *     });
+ *     const result = await run("Refund invoice inv_123");
  *
  *     expect(result.output).toMatchObject({ status: "approved" });
  *     expect(toolCalls(result.session)).toHaveLength(2);
  *     await expect(result).toSatisfyJudge(FactualityJudge(), {
+ *       expected: "Invoice inv_123 should be refunded.",
  *       threshold: 0.6,
  *     });
  *   });
  * });
  * ```
  */
-export function describeEval<THarness extends Harness<any, any, any>>(
+export function describeEval<THarness extends Harness<any, any>>(
   name: string,
   options: DescribeEvalOptions<
     HarnessInput<THarness>,
     HarnessOutput<THarness>,
-    HarnessMetadataFor<THarness>,
     THarness
   >,
   define: (
-    it: EvalTestAPI<
-      HarnessInput<THarness>,
-      HarnessOutput<THarness>,
-      HarnessMetadataFor<THarness>,
-      THarness
-    >,
+    it: EvalTestAPI<HarnessInput<THarness>, HarnessOutput<THarness>, THarness>,
   ) => void,
 ) {
   const suite = options.skipIf ? describe.skipIf(options.skipIf()) : describe;
 
   return suite(name, () => {
     const automaticJudges = (options.judges ?? []) as Array<
-      Judge<JudgeContext<any, any, any, any>>
+      Judge<JudgeContext<any, any, any>>
     >;
     const explicitJudgeHarness =
       options.judgeHarness ?? resolveDefaultJudgeHarness(automaticJudges);
@@ -657,7 +573,6 @@ export function describeEval<THarness extends Harness<any, any, any>>(
     }) as unknown as EvalTestAPI<
       HarnessInput<THarness>,
       HarnessOutput<THarness>,
-      HarnessMetadataFor<THarness>,
       THarness
     >;
 
@@ -665,25 +580,17 @@ export function describeEval<THarness extends Harness<any, any, any>>(
   });
 }
 
-function createMetadata<TMetadata extends HarnessMetadata>(
-  metadata: EvalRunOptions<TMetadata>["metadata"],
-) {
-  return { ...(metadata ?? {}) } as TMetadata;
-}
-
 async function applyAutomaticJudges<
   TInput,
   TOutput extends JsonValue | undefined,
-  TMetadata extends HarnessMetadata,
-  THarness extends Harness<TInput, TOutput, TMetadata>,
+  THarness extends Harness<TInput, TOutput>,
 >(
   task: EvalTaskLike,
-  judges: Array<Judge<JudgeContext<TInput, TOutput, TMetadata, THarness>>>,
+  judges: Array<Judge<JudgeContext<TInput, TOutput, THarness>>>,
   threshold: number | null | undefined,
   harness: THarness,
   input: TInput,
   judgeHarness: JudgeHarness | undefined,
-  metadata: TMetadata,
   run: HarnessRun<TOutput>,
   signal?: AbortSignal,
 ) {
@@ -698,13 +605,12 @@ async function applyAutomaticJudges<
         input,
         output: run.output,
         toolCalls: runToolCalls,
-        metadata,
         run,
         session: run.session,
         signal,
         harness,
         runJudge,
-      } as unknown as JudgeContext<TInput, TOutput, TMetadata, THarness>;
+      } as unknown as JudgeContext<TInput, TOutput, THarness>;
 
       return Promise.resolve(judge.assess(judgeOptions));
     }),
@@ -751,23 +657,17 @@ function setHarnessMeta(task: EvalTaskLike, name: string, run: HarnessRun) {
   };
 }
 
-function recordJudgeRunContext<
-  TInput,
-  TMetadata extends HarnessMetadata,
-  TOutput extends JsonValue | undefined,
->(
+function recordJudgeRunContext<TInput, TOutput extends JsonValue | undefined>(
   run: HarnessRun<TOutput>,
-  harness: Harness<TInput, TOutput, TMetadata>,
+  harness: Harness<TInput, TOutput>,
   input: TInput,
   judgeHarness: JudgeHarness | undefined,
-  metadata: TMetadata,
   signal?: AbortSignal,
 ) {
   const context = {
     harness,
     input,
     judgeHarness,
-    metadata,
     run,
     signal,
   };
@@ -862,7 +762,7 @@ function formatJudgeTextOutput(run: HarnessRun) {
 }
 
 function buildJudgeAssertionOptions<
-  TJudgeOptions extends JudgeContext<any, any, any, any> = JudgeContext,
+  TJudgeOptions extends JudgeContext<any, any, any> = JudgeContext,
 >(
   received: unknown,
   judge: Judge<TJudgeOptions>,
@@ -880,9 +780,6 @@ function buildJudgeAssertionOptions<
     resolveJudgeHarnessForJudge(judge, registeredContext?.judgeHarness);
   const runJudge = createRunJudge(judgeHarness, registeredContext?.signal);
   const signal = registeredContext?.signal;
-  const metadata = (options.metadata ??
-    registeredContext?.metadata ??
-    {}) as JudgeAssertionMetadata<TJudgeOptions>;
   const input =
     options.input ??
     (registeredContext?.input as
@@ -920,7 +817,6 @@ function buildJudgeAssertionOptions<
     ...judgeParams,
     input: resolvedInput,
     output,
-    metadata,
     run,
     session: options.session ?? run.session,
     signal,
@@ -955,7 +851,7 @@ function resolveDefaultJudgeHarness(
 }
 
 function resolveRegisteredJudgeRunContext<
-  TJudgeOptions extends JudgeContext<any, any, any, any> = JudgeContext,
+  TJudgeOptions extends JudgeContext<any, any, any> = JudgeContext,
 >(
   received: unknown,
   options: Omit<JudgeAssertionOptions<TJudgeOptions>, "threshold">,
@@ -988,7 +884,7 @@ function isWeakMapKey(value: unknown): value is object {
 }
 
 function resolveJudgeRun<
-  TJudgeOptions extends JudgeContext<any, any, any, any> = JudgeContext,
+  TJudgeOptions extends JudgeContext<any, any, any> = JudgeContext,
 >(
   received: unknown,
   options: Omit<JudgeAssertionOptions<TJudgeOptions>, "threshold">,
@@ -1037,7 +933,7 @@ function resolveJudgeRun<
 }
 
 function resolveJudgeAssertionOutput<
-  TJudgeOptions extends JudgeContext<any, any, any, any> = JudgeContext,
+  TJudgeOptions extends JudgeContext<any, any, any> = JudgeContext,
 >(
   received: unknown,
   run: HarnessRun,
@@ -1063,7 +959,7 @@ function resolveJudgeAssertionOutput<
 }
 
 function createSyntheticJudgeSession<
-  TJudgeOptions extends JudgeContext<any, any, any, any> = JudgeContext,
+  TJudgeOptions extends JudgeContext<any, any, any> = JudgeContext,
 >(
   received: unknown,
   options: Omit<JudgeAssertionOptions<TJudgeOptions>, "threshold">,
@@ -1177,17 +1073,20 @@ export function formatScores(scores: (JudgeResult & { name: string })[]) {
  *
  * @example
  * ```ts
- * import { createJudge, type JudgeContext } from "vitest-evals";
+ * import { createJudge } from "vitest-evals";
  *
  * type RefundOutput = { status: "approved" | "denied" };
- * type RefundMetadata = { expected: { status: RefundOutput["status"] } };
  *
- * export const RefundStatusJudge = createJudge(
+ * export const RefundStatusJudge = createJudge<
+ *   string,
+ *   RefundOutput,
+ *   { expectedStatus: RefundOutput["status"] }
+ * >(
  *   "RefundStatusJudge",
- *   async ({ output, metadata }: JudgeContext<string, RefundOutput, RefundMetadata>) => ({
- *     score: output.status === metadata.expected.status ? 1 : 0,
+ *   async ({ output, expectedStatus }) => ({
+ *     score: output.status === expectedStatus ? 1 : 0,
  *     metadata: {
- *       rationale: `Expected ${metadata.expected.status}, got ${output.status}`,
+ *       rationale: `Expected ${expectedStatus}, got ${output.status}`,
  *     },
  *   }),
  * );
@@ -1196,19 +1095,44 @@ export function formatScores(scores: (JudgeResult & { name: string })[]) {
  * For LLM-backed judges, prefer the object form with `ctx.runJudge(...)` so
  * provider-specific model configuration stays in the judge harness.
  */
-export function createJudge<TOptions extends JudgeContext<any, any, any, any>>(
+export function createJudge<TOptions extends JudgeContext<any, any, any>>(
   name: string,
   assess: JudgeAssessFn<TOptions>,
 ): Judge<TOptions>;
-export function createJudge<TOptions extends JudgeContext<any, any, any, any>>(
+export function createJudge<TOptions extends JudgeContext<any, any, any>>(
   config: CreateJudgeConfig<TOptions>,
 ): Judge<TOptions>;
+export function createJudge<
+  TInput,
+  TOutput extends JsonValue | undefined,
+  TOptions extends object = Record<never, never>,
+  THarness extends Harness<TInput, TOutput> | undefined =
+    | Harness<TInput, TOutput>
+    | undefined,
+>(
+  name: string,
+  assess: JudgeAssessFn<
+    CreateJudgeContext<TInput, TOutput, TOptions, THarness>
+  >,
+): Judge<CreateJudgeContext<TInput, TOutput, TOptions, THarness>>;
+export function createJudge<
+  TInput,
+  TOutput extends JsonValue | undefined,
+  TOptions extends object = Record<never, never>,
+  THarness extends Harness<TInput, TOutput> | undefined =
+    | Harness<TInput, TOutput>
+    | undefined,
+>(
+  config: CreateJudgeConfig<
+    CreateJudgeContext<TInput, TOutput, TOptions, THarness>
+  >,
+): Judge<CreateJudgeContext<TInput, TOutput, TOptions, THarness>>;
 /**
  * @deprecated Prefer `createJudge({ name, judgeHarness, assess })` and call
  * `ctx.runJudge(...)` from LLM-backed judges.
  */
 export function createJudge<
-  TOptions extends JudgeContext<any, any, any, any>,
+  TOptions extends JudgeContext<any, any, any>,
   TInput,
   TOutput,
 >(
@@ -1217,7 +1141,7 @@ export function createJudge<
   assess: JudgeAssessWithAssessorFn<TOptions, TInput, TOutput>,
 ): Judge<TOptions>;
 export function createJudge<
-  TOptions extends JudgeContext<any, any, any, any>,
+  TOptions extends JudgeContext<any, any, any>,
   TInput,
   TOutput,
 >(

--- a/packages/vitest-evals/src/judges/factualityJudge.test.ts
+++ b/packages/vitest-evals/src/judges/factualityJudge.test.ts
@@ -11,7 +11,7 @@ import {
   type RunJudge,
 } from "../index";
 
-const factualityHarness = createHarness<string, string, { expected?: string }>({
+const factualityHarness = createHarness<string, string>({
   name: "qa-harness",
   run: async () => ({
     output: "Paris is the capital of France.",
@@ -79,18 +79,14 @@ describeEval(
   {
     harness: factualityHarness,
     judgeHarness: automaticJudgeHarness,
-    judges: [FactualityJudge()],
+    judges: [FactualityJudge({ expected: "Paris is the capital of France." })],
   },
   (it) => {
-    it("uses metadata expected values with any harness output", async ({
+    it("uses configured expected values with any harness output", async ({
       run,
       task,
     }) => {
-      await run("What is the capital of France?", {
-        metadata: {
-          expected: "Paris is the capital of France.",
-        },
-      });
+      await run("What is the capital of France?");
 
       expect(automaticJudgeHarnessRun).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -125,17 +121,18 @@ describeEval(
   "factuality judge configured harness",
   {
     harness: factualityHarness,
-    judges: [FactualityJudge({ judgeHarness: configuredJudgeHarness })],
+    judges: [
+      FactualityJudge({
+        expected: "Paris is the capital of France.",
+        judgeHarness: configuredJudgeHarness,
+      }),
+    ],
   },
   (it) => {
     it("uses a judge-level judge harness for automatic assertions", async ({
       run,
     }) => {
-      await run("What is the capital of France?", {
-        metadata: {
-          expected: "Paris is the capital of France.",
-        },
-      });
+      await run("What is the capital of France?");
 
       expect(configuredJudgeHarnessRun).toHaveBeenCalledTimes(1);
     });
@@ -147,17 +144,18 @@ describeEval(
   {
     harness: factualityHarness,
     judgeHarness: suiteDefaultJudgeHarness,
-    judges: [FactualityJudge({ judgeHarness: judgeOverrideHarness })],
+    judges: [
+      FactualityJudge({
+        expected: "Paris is the capital of France.",
+        judgeHarness: judgeOverrideHarness,
+      }),
+    ],
   },
   (it) => {
     it("uses a judge-level judge harness before the suite default", async ({
       run,
     }) => {
-      await run("What is the capital of France?", {
-        metadata: {
-          expected: "Paris is the capital of France.",
-        },
-      });
+      await run("What is the capital of France?");
 
       expect(judgeOverrideHarnessRun).toHaveBeenCalledTimes(1);
       expect(suiteDefaultJudgeHarnessRun).not.toHaveBeenCalled();
@@ -170,7 +168,10 @@ describeEval(
   {
     harness: factualityHarness,
     judges: [
-      FactualityJudge({ judgeHarness: inferredSuiteJudgeHarness }),
+      FactualityJudge({
+        expected: "Paris is the capital of France.",
+        judgeHarness: inferredSuiteJudgeHarness,
+      }),
       createJudge("NoInferredAutomaticJudgeHarness", (ctx) => {
         leakedAutomaticJudgeRunJudge(ctx.runJudge);
 
@@ -189,11 +190,7 @@ describeEval(
       run,
       task,
     }) => {
-      const result = await run("What is the capital of France?", {
-        metadata: {
-          expected: "Paris is the capital of France.",
-        },
-      });
+      const result = await run("What is the capital of France?");
 
       await expect(result).toSatisfyJudge(FactualityJudge(), {
         expected: "Paris is the capital of France.",
@@ -320,7 +317,6 @@ test("FactualityJudge requires a judge harness when expected values are present"
       input: "What is the capital of France?",
       output: run.output,
       expected: "Paris is the capital of France.",
-      metadata: {},
       run,
       session: run.session,
       toolCalls: [],
@@ -342,7 +338,6 @@ test("FactualityJudge uses a configured judge harness when assess is called dire
     input: "What is the capital of France?",
     output: run.output,
     expected: "Paris is the capital of France.",
-    metadata: {},
     run,
     session: run.session,
     toolCalls: [],
@@ -363,27 +358,23 @@ test("FactualityJudge can be shared across different app harnesses and judge har
     rationale: "The submitted answer is a supported superset.",
   }));
   const factualityJudge = FactualityJudge();
-  const objectHarness = createHarness<
-    { question: string },
-    { answer: string },
-    { expected?: string }
-  >({
-    name: "object-qa-harness",
-    run: async () => ({
-      output: {
-        answer: "Paris",
-      },
-    }),
-  });
+  const objectHarness = createHarness<{ question: string }, { answer: string }>(
+    {
+      name: "object-qa-harness",
+      run: async () => ({
+        output: {
+          answer: "Paris",
+        },
+      }),
+    },
+  );
   const textRun = createRun("Paris is the capital of France.");
   const objectRun = createRun({ answer: "Paris" });
 
   const textResult = await factualityJudge.assess({
     input: "What is the capital of France?",
     output: textRun.output,
-    metadata: {
-      expected: "Paris is the capital of France.",
-    },
+    expected: "Paris is the capital of France.",
     run: textRun,
     session: textRun.session,
     toolCalls: [],
@@ -395,9 +386,7 @@ test("FactualityJudge can be shared across different app harnesses and judge har
       question: "What is the capital of France?",
     },
     output: objectRun.output,
-    metadata: {
-      expected: "Paris is the capital of France.",
-    },
+    expected: "Paris is the capital of France.",
     run: objectRun,
     session: objectRun.session,
     toolCalls: [],
@@ -422,7 +411,6 @@ test("FactualityJudge parses JSON text returned by the judge harness", async () 
     input: "What is the capital of France?",
     output: run.output,
     expected: "Paris is the capital of France.",
-    metadata: {},
     run,
     session: run.session,
     toolCalls: [],
@@ -470,7 +458,6 @@ test("FactualityJudge skips blank assistant transcript output", async () => {
     input: "What is the capital of France?",
     output: run.output,
     expected: "Paris is the capital of France.",
-    metadata: {},
     run,
     session: run.session,
     toolCalls: [],
@@ -495,7 +482,6 @@ test("FactualityJudge fails closed when no expected value is provided", async ()
   const result = await FactualityJudge().assess({
     input: "What is the capital of France?",
     output: run.output,
-    metadata: {},
     run,
     session: run.session,
     toolCalls: [],
@@ -506,7 +492,7 @@ test("FactualityJudge fails closed when no expected value is provided", async ()
     score: 0,
     metadata: {
       rationale:
-        "FactualityJudge requires a non-empty expert answer in `expected` or `metadata.expected`.",
+        "FactualityJudge requires a non-empty expert answer in `expected` or FactualityJudge(...) config.",
     },
   });
 });
@@ -517,9 +503,7 @@ test("FactualityJudge fails closed when expected is null", async () => {
   const result = await FactualityJudge().assess({
     input: "What is the capital of France?",
     output: run.output,
-    metadata: {
-      expected: null,
-    },
+    expected: null,
     run,
     session: run.session,
     toolCalls: [],
@@ -530,7 +514,7 @@ test("FactualityJudge fails closed when expected is null", async () => {
     score: 0,
     metadata: {
       rationale:
-        "FactualityJudge requires a non-empty expert answer in `expected` or `metadata.expected`.",
+        "FactualityJudge requires a non-empty expert answer in `expected` or FactualityJudge(...) config.",
     },
   });
 });
@@ -538,15 +522,11 @@ test("FactualityJudge fails closed when expected is null", async () => {
 test("FactualityJudge treats explicit null expected as missing", async () => {
   const runJudge = vi.fn();
   const run = createRun("Paris");
-  const metadata = {
-    expected: "Paris is the capital of France.",
-  };
 
   const result = await FactualityJudge().assess({
     input: "What is the capital of France?",
     output: run.output,
     expected: null,
-    metadata,
     run,
     session: run.session,
     toolCalls: [],
@@ -558,7 +538,7 @@ test("FactualityJudge treats explicit null expected as missing", async () => {
     score: 0,
     metadata: {
       rationale:
-        "FactualityJudge requires a non-empty expert answer in `expected` or `metadata.expected`.",
+        "FactualityJudge requires a non-empty expert answer in `expected` or FactualityJudge(...) config.",
     },
   });
   expect(runJudge).not.toHaveBeenCalled();
@@ -572,7 +552,6 @@ test("FactualityJudge fails closed when expected is blank", async () => {
     input: "What is the capital of France?",
     output: run.output,
     expected: "   ",
-    metadata: {},
     run,
     session: run.session,
     toolCalls: [],
@@ -584,7 +563,7 @@ test("FactualityJudge fails closed when expected is blank", async () => {
     score: 0,
     metadata: {
       rationale:
-        "FactualityJudge requires a non-empty expert answer in `expected` or `metadata.expected`.",
+        "FactualityJudge requires a non-empty expert answer in `expected` or FactualityJudge(...) config.",
     },
   });
   expect(runJudge).not.toHaveBeenCalled();

--- a/packages/vitest-evals/src/judges/factualityJudge.ts
+++ b/packages/vitest-evals/src/judges/factualityJudge.ts
@@ -1,8 +1,4 @@
-import {
-  type Harness,
-  type HarnessMetadata,
-  latestAssistantMessageContent,
-} from "../harness";
+import { type Harness, latestAssistantMessageContent } from "../harness";
 import type { JsonValue } from "../harness";
 import { createRunJudge } from "./judgeHarness";
 import type { JudgeHarness } from "./judgeHarness";
@@ -119,9 +115,7 @@ export type FactualityJudgeConfig = {
   name?: string;
   /** Default judge-side harness used when matcher options do not provide one. */
   judgeHarness?: JudgeHarness;
-};
-
-type FactualityJudgeMetadata = HarnessMetadata & {
+  /** Expert answer or reference facts used by this judge instance. */
   expected?: FactualityJudgeExpected;
 };
 
@@ -147,23 +141,20 @@ type FactualityJudgeMetadata = HarnessMetadata & {
  */
 export type FactualityJudgeOptions<
   TInput = any,
-  TOutput extends JsonValue | undefined = JsonValue | undefined,
-  TMetadata extends HarnessMetadata = HarnessMetadata,
-  THarness extends Harness<TInput, TOutput, TMetadata> | undefined =
-    | Harness<TInput, TOutput, TMetadata>
-    | undefined,
-> = JudgeContext<TInput, TOutput, TMetadata, THarness> & {
-  /** Expert answer or reference facts. Defaults to `metadata.expected`. */
+  TOutput extends JsonValue | undefined = any,
+  THarness extends Harness<TInput, TOutput> | undefined = any,
+> = JudgeContext<TInput, TOutput, THarness> & {
+  /** Expert answer or reference facts. Overrides the judge config default. */
   expected?: FactualityJudgeExpected;
 };
 
 /**
  * Creates a factuality judge over normalized harness output.
  *
- * `FactualityJudge()` compares `input`, `output`, and `expected` from the
- * current `JudgeContext`, so the same judge can run against any application
- * harness. Configure the LLM used for grading with `judgeHarness` on the
- * judge, suite, or matcher options.
+ * `FactualityJudge()` compares `input`, `output`, and an expert answer. Bind a
+ * suite-wide expert answer on the judge config, or pass a case-specific
+ * `expected` value to `toSatisfyJudge(...)`. Configure the LLM used for grading
+ * with `judgeHarness` on the judge, suite, or matcher options.
  *
  * @param config - Optional judge name and reusable judge harness default.
  *
@@ -178,18 +169,17 @@ export type FactualityJudgeOptions<
  *   model: anthropic("claude-sonnet-4-5"),
  *   temperature: 0,
  * });
- * const factualityJudge = FactualityJudge({ judgeHarness });
+ * const factualityJudge = FactualityJudge({
+ *   judgeHarness,
+ *   expected: "Paris is the capital of France.",
+ * });
  *
  * describeEval("qa agent", {
  *   harness: qaHarness,
  *   judges: [factualityJudge],
  * }, (it) => {
  *   it("answers a geography question", async ({ run }) => {
- *     await run("What is the capital of France?", {
- *       metadata: {
- *         expected: "Paris is the capital of France.",
- *       },
- *     });
+ *     await run("What is the capital of France?");
  *   });
  * });
  * ```
@@ -202,24 +192,29 @@ export function FactualityJudge(
   return {
     name: config.name ?? "FactualityJudge",
     judgeHarness,
-    assess: (opts) => assessFactuality(opts, judgeHarness),
+    assess: (opts) =>
+      assessFactuality(opts, {
+        expected: config.expected,
+        judgeHarness,
+      }),
   };
 }
 
 async function assessFactuality(
   opts: FactualityJudgeOptions,
-  configuredJudgeHarness: JudgeHarness | undefined,
+  config: {
+    expected: FactualityJudgeExpected | undefined;
+    judgeHarness: JudgeHarness | undefined;
+  },
 ) {
-  const metadata = opts.metadata as FactualityJudgeMetadata;
-  const expected =
-    opts.expected === undefined ? metadata.expected : opts.expected;
+  const expected = opts.expected ?? config.expected;
 
   if (isMissingExpectedAnswer(expected)) {
     return {
       score: 0,
       metadata: {
         rationale:
-          "FactualityJudge requires a non-empty expert answer in `expected` or `metadata.expected`.",
+          "FactualityJudge requires a non-empty expert answer in `expected` or FactualityJudge(...) config.",
       },
     };
   }
@@ -227,7 +222,7 @@ async function assessFactuality(
   const runJudge =
     opts.runJudge ??
     createRunJudge(
-      configuredJudgeHarness,
+      config.judgeHarness,
       (opts as { signal?: AbortSignal }).signal,
     );
 

--- a/packages/vitest-evals/src/judges/judgeHarness.ts
+++ b/packages/vitest-evals/src/judges/judgeHarness.ts
@@ -2,7 +2,6 @@ import {
   createHarness,
   type Harness,
   type HarnessContext,
-  type HarnessMetadata,
   type HarnessResultLike,
   type HarnessRun,
   isHarnessRun,
@@ -58,16 +57,12 @@ export type JudgeHarnessOutput = JsonValue | undefined;
  * });
  * ```
  */
-export type JudgeHarness = Harness<
-  JudgeHarnessInput,
-  JudgeHarnessOutput,
-  HarnessMetadata
->;
+export type JudgeHarness = Harness<JudgeHarnessInput, JudgeHarnessOutput>;
 
 /** Runtime options supplied when a judge calls `runJudge(...)`. */
 export type RunJudgeOptions = {
-  /** Optional metadata forwarded to the judge harness run. */
-  metadata?: HarnessMetadata;
+  /** Abort signal from the current eval run when available. */
+  signal?: AbortSignal;
 };
 
 /**
@@ -90,8 +85,6 @@ export type RunJudge = (
 export type CreateJudgeHarnessRunOptions = {
   /** Abort signal from the current eval run when available. */
   signal?: AbortSignal;
-  /** Metadata for this judge-harness run. */
-  metadata: Readonly<HarnessMetadata>;
 };
 
 /**
@@ -139,10 +132,8 @@ export function createJudgeHarness(
 ): JudgeHarness {
   return createHarness({
     name: options.name ?? "judge-harness",
-    run: async ({ input, signal, metadata }) => {
-      return normalizeJudgeHarnessResult(
-        await options.run(input, { signal, metadata }),
-      );
+    run: async ({ input, signal }) => {
+      return normalizeJudgeHarnessResult(await options.run(input, { signal }));
     },
   });
 }
@@ -152,16 +143,15 @@ export function createJudgeHarness(
  *
  * @param judgeHarness - Judge-side harness configured on the matcher, judge, or suite.
  * @param input - Provider-neutral judge prompt request.
- * @param options - Run-scoped metadata and abort signal.
+ * @param options - Run-scoped abort signal.
  */
 export async function runJudgeHarness(
   judgeHarness: JudgeHarness,
   input: JudgeHarnessInput,
-  options: RunJudgeOptions & { signal?: AbortSignal } = {},
+  options: RunJudgeOptions = {},
 ): Promise<JudgeHarnessOutput> {
   const artifacts: HarnessContext["artifacts"] = {};
   const run = await judgeHarness.run(input, {
-    metadata: options.metadata ?? {},
     signal: options.signal,
     artifacts,
     setArtifact: (name, value) => {
@@ -185,8 +175,7 @@ export function createRunJudge(
 
   return (input, options) =>
     runJudgeHarness(judgeHarness, input, {
-      metadata: options?.metadata,
-      signal,
+      signal: options?.signal ?? signal,
     });
 }
 

--- a/packages/vitest-evals/src/judges/structuredOutputJudge.ts
+++ b/packages/vitest-evals/src/judges/structuredOutputJudge.ts
@@ -4,7 +4,6 @@ import {
   type StructuredOutputScorerConfig,
   type StructuredOutputScorerOptions,
 } from "../internal/structuredOutputScorer";
-import type { HarnessMetadata } from "../harness";
 
 /**
  * Expected structured fields accepted by `StructuredOutputJudge()`.
@@ -19,10 +18,6 @@ import type { HarnessMetadata } from "../harness";
  */
 export type StructuredOutputJudgeExpected = Record<string, unknown>;
 
-type StructuredOutputJudgeMetadata = HarnessMetadata & {
-  expected?: StructuredOutputJudgeExpected;
-};
-
 /**
  * Matcher context accepted by `StructuredOutputJudge()`.
  *
@@ -34,7 +29,7 @@ type StructuredOutputJudgeMetadata = HarnessMetadata & {
  * ```
  */
 export interface StructuredOutputJudgeOptions
-  extends JudgeContext<any, any, HarnessMetadata, any>,
+  extends JudgeContext<any, any, any>,
     Omit<StructuredOutputScorerOptions, "input" | "output" | "toolCalls"> {
   expected?: StructuredOutputJudgeExpected;
 }
@@ -51,7 +46,10 @@ export interface StructuredOutputJudgeOptions
  * ```
  */
 export interface StructuredOutputJudgeConfig
-  extends StructuredOutputScorerConfig {}
+  extends StructuredOutputScorerConfig {
+  /** Expected structured fields used by this judge instance. */
+  expected?: StructuredOutputJudgeExpected;
+}
 
 /**
  * Creates a deterministic judge that compares structured output fields.
@@ -62,14 +60,10 @@ export interface StructuredOutputJudgeConfig
  * ```ts
  * describeEval("refund agent", {
  *   harness: refundHarness,
- *   judges: [StructuredOutputJudge()],
+ *   judges: [StructuredOutputJudge({ expected: { status: "approved" } })],
  * }, (it) => {
  *   it("returns the expected decision", async ({ run }) => {
- *     await run("Refund invoice inv_123", {
- *       metadata: {
- *         expected: { status: "approved" },
- *       },
- *     });
+ *     await run("Refund invoice inv_123");
  *   });
  * });
  * ```
@@ -77,25 +71,22 @@ export interface StructuredOutputJudgeConfig
 export function StructuredOutputJudge(
   config: StructuredOutputJudgeConfig = {},
 ): Judge<StructuredOutputJudgeOptions> {
-  const scorer = StructuredOutputScorer(config);
+  const { expected, ...scorerConfig } = config;
+  const scorer = StructuredOutputScorer(scorerConfig);
   return {
     name: "StructuredOutputJudge",
     assess: (opts: StructuredOutputJudgeOptions) => {
-      const metadata = opts.metadata as StructuredOutputJudgeMetadata;
-
       return scorer({
         ...opts,
         input: formatStructuredOutput(opts.input),
-        expected: opts.expected ?? metadata.expected,
+        expected: opts.expected ?? expected,
         output: formatStructuredOutput(opts.output),
       });
     },
   };
 }
 
-function formatStructuredOutput(
-  output: StructuredOutputJudgeOptions["run"]["output"],
-) {
+function formatStructuredOutput(output: unknown) {
   if (typeof output === "string") {
     return output;
   }

--- a/packages/vitest-evals/src/judges/toolCallJudge.ts
+++ b/packages/vitest-evals/src/judges/toolCallJudge.ts
@@ -4,7 +4,6 @@ import {
   type ToolCallScorerConfig,
   type ToolCallScorerOptions,
 } from "../internal/toolCallScorer";
-import type { HarnessMetadata } from "../harness";
 
 /**
  * Expected tool-call shape accepted by `ToolCallJudge()`.
@@ -35,11 +34,10 @@ export type ToolCallJudgeExpectedTool =
  * });
  * ```
  */
-export interface ToolCallJudgeConfig extends ToolCallScorerConfig {}
-
-type ToolCallJudgeMetadata = HarnessMetadata & {
+export interface ToolCallJudgeConfig extends ToolCallScorerConfig {
+  /** Expected tool calls used by this judge instance. */
   expectedTools?: ToolCallJudgeExpectedTool[];
-};
+}
 
 /**
  * Matcher context accepted by `ToolCallJudge()`.
@@ -52,7 +50,7 @@ type ToolCallJudgeMetadata = HarnessMetadata & {
  * ```
  */
 export interface ToolCallJudgeOptions
-  extends JudgeContext<any, any, HarnessMetadata, any>,
+  extends JudgeContext<any, any, any>,
     Omit<
       ToolCallScorerOptions,
       "input" | "output" | "toolCalls" | "expectedTools"
@@ -69,14 +67,15 @@ export interface ToolCallJudgeOptions
  * ```ts
  * describeEval("refund agent", {
  *   harness: refundHarness,
- *   judges: [ToolCallJudge({ ordered: true })],
+ *   judges: [
+ *     ToolCallJudge({
+ *       ordered: true,
+ *       expectedTools: ["lookupInvoice", "createRefund"],
+ *     }),
+ *   ],
  * }, (it) => {
  *   it("creates a refund after lookup", async ({ run }) => {
- *     await run("Refund invoice inv_123", {
- *       metadata: {
- *         expectedTools: ["lookupInvoice", "createRefund"],
- *       },
- *     });
+ *     await run("Refund invoice inv_123");
  *   });
  * });
  * ```
@@ -84,18 +83,17 @@ export interface ToolCallJudgeOptions
 export function ToolCallJudge(
   config: ToolCallJudgeConfig = {},
 ): Judge<ToolCallJudgeOptions> {
-  const scorer = ToolCallScorer(config);
+  const { expectedTools, ...scorerConfig } = config;
+  const scorer = ToolCallScorer(scorerConfig);
   return {
     name: "ToolCallJudge",
     assess: (opts: ToolCallJudgeOptions) => {
-      const metadata = opts.metadata as ToolCallJudgeMetadata;
-
       return scorer({
         ...opts,
         input: formatJudgeValue(opts.input),
         output: formatJudgeValue(opts.output),
         expectedTools: normalizeExpectedTools(
-          opts.expectedTools ?? metadata.expectedTools,
+          opts.expectedTools ?? expectedTools,
         ),
       });
     },

--- a/packages/vitest-evals/src/judges/types.ts
+++ b/packages/vitest-evals/src/judges/types.ts
@@ -1,6 +1,5 @@
 import type {
   Harness,
-  HarnessMetadata,
   HarnessRun,
   JsonValue,
   ToolCallRecord,
@@ -35,32 +34,23 @@ export type JudgeResult = {
 /**
  * Full normalized context passed to every judge.
  *
- * Scenario-owned judge criteria should live on `input`. Use `metadata` for
- * per-run expectations or harness configuration that are not part of the
- * scenario payload.
- *
  * @example
  * ```ts
- * type RefundContext = JudgeContext<
- *   string,
- *   { status: "approved" | "denied" },
- *   { expected: { status: "approved" | "denied" } }
- * >;
+ * type RefundOutput = { status: "approved" | "denied" };
  *
- * const RefundStatusJudge = createJudge(
+ * const RefundStatusJudge = createJudge<string, RefundOutput>(
  *   "RefundStatusJudge",
- *   ({ output, metadata }: RefundContext) => ({
- *     score: output.status === metadata.expected.status ? 1 : 0,
+ *   ({ output }) => ({
+ *     score: output.status === "approved" ? 1 : 0,
  *   }),
  * );
  * ```
  */
 export interface JudgeContext<
-  TInput = unknown,
+  TInput = any,
   TOutput extends JsonValue | undefined = JsonValue | undefined,
-  TMetadata extends HarnessMetadata = HarnessMetadata,
-  THarness extends Harness<TInput, TOutput, TMetadata> | undefined =
-    | Harness<TInput, TOutput, TMetadata>
+  THarness extends Harness<TInput, TOutput> | undefined =
+    | Harness<TInput, TOutput>
     | undefined,
 > {
   /** Original eval input passed to the harness. */
@@ -69,8 +59,6 @@ export interface JudgeContext<
   output: TOutput;
   /** Flattened tool calls observed in the normalized session. */
   toolCalls: ToolCallRecord[];
-  /** Per-run expectations or configuration passed to `run(input, { metadata })`. */
-  metadata: Readonly<TMetadata>;
   /** Complete normalized harness run being judged. */
   run: HarnessRun<TOutput>;
   /** Normalized transcript associated with the harness run. */
@@ -83,18 +71,17 @@ export interface JudgeContext<
 
 /** Convenience helper for judges that accept explicit per-call params. */
 export type JudgeOptions<
-  TParams extends Record<string, unknown> = Record<string, never>,
-  TInput = unknown,
+  TInput = any,
   TOutput extends JsonValue | undefined = JsonValue | undefined,
-  TMetadata extends HarnessMetadata = HarnessMetadata,
-  THarness extends Harness<TInput, TOutput, TMetadata> | undefined =
-    | Harness<TInput, TOutput, TMetadata>
+  TParams extends object = Record<never, never>,
+  THarness extends Harness<TInput, TOutput> | undefined =
+    | Harness<TInput, TOutput>
     | undefined,
-> = JudgeContext<TInput, TOutput, TMetadata, THarness> & TParams;
+> = JudgeContext<TInput, TOutput, THarness> & TParams;
 
 /** Function that assesses a normalized judge context. */
 export type JudgeAssessFn<
-  TOptions extends JudgeContext<any, any, any, any> = JudgeContext,
+  TOptions extends JudgeContext<any, any, any> = JudgeContext,
 > = (opts: TOptions) => Promise<JudgeResult> | JudgeResult;
 
 /**
@@ -151,7 +138,7 @@ export type BoundJudgeAssessor<TInput = string, TOutput = string> = {
  * @deprecated Prefer `JudgeAssessFn` with `ctx.runJudge(...)`.
  */
 export type JudgeAssessWithAssessorFn<
-  TOptions extends JudgeContext<any, any, any, any> = JudgeContext,
+  TOptions extends JudgeContext<any, any, any> = JudgeContext,
   TInput = string,
   TOutput = string,
 > = (
@@ -165,18 +152,17 @@ export type JudgeAssessWithAssessorFn<
  * @example
  * ```ts
  * type RefundOutput = { status: "approved" | "denied" };
- * type RefundMetadata = { expected: { status: RefundOutput["status"] } };
  *
- * const judge: Judge<JudgeContext<string, RefundOutput, RefundMetadata>> = {
+ * const judge: Judge<JudgeContext<string, RefundOutput>> = {
  *   name: "RefundStatusJudge",
- *   assess: ({ output, metadata }) => ({
- *     score: output.status === metadata.expected.status ? 1 : 0,
+ *   assess: ({ output }) => ({
+ *     score: output.status === "approved" ? 1 : 0,
  *   }),
  * };
  * ```
  */
 export interface Judge<
-  TOptions extends JudgeContext<any, any, any, any> = JudgeContext,
+  TOptions extends JudgeContext<any, any, any> = JudgeContext,
 > {
   /** Stable judge name used in assertion messages and reports. */
   name: string;

--- a/scripts/check-public-docs.mjs
+++ b/scripts/check-public-docs.mjs
@@ -284,7 +284,12 @@ function collectStructuredDocsErrors() {
       label: "harness",
       dir: join(root, "packages/docs/src/content/docs/docs/harnesses"),
       template: "_TEMPLATE.md",
-      requiredHeadings: ["Install", "App Shape", "Configure Harness", "Eval"],
+      requiredHeadings: [
+        "Install",
+        "App Shape",
+        "Configure Harness",
+        "Writing Evals",
+      ],
     },
     {
       label: "judge",

--- a/skills/vitest-evals/SKILL.md
+++ b/skills/vitest-evals/SKILL.md
@@ -22,6 +22,7 @@ Use the harness-backed API as the only authoring model.
 | Integrate AI SDK `generateText`, `generateObject`, tools, or an AI SDK-style agent | `references/harness-ai-sdk.md` |
 | Integrate a Pi AI or Pi Mono-style agent | `references/harness-pi-ai.md` |
 | Add custom judges, suite judges, built-in judges, or `toSatisfyJudge(...)` assertions | `references/judges-and-assertions.md` |
+| Assert on message, tool-call, or span history | `references/utilities.md` |
 | Configure tool recording or replay | `references/tool-replay.md` |
 | Diagnose failures, missing traces, odd output, or choose verification commands | `references/troubleshooting.md` |
 
@@ -29,14 +30,17 @@ Use the harness-backed API as the only authoring model.
 
 - Import `describeEval(...)`, judges, and helpers from `vitest-evals`.
 - Bind exactly one `harness` to a suite.
-- Call `run(input, { metadata? })` where the test should execute the system.
+- Call `run(input)` where the test should execute the system.
 - Assert on `result.output` for app-facing behavior.
 - Use `result.session` and helpers such as `toolCalls(session)` for trace assertions.
+- Use `spans(result)`, `spansByKind(result, kind)`, and `failedSpans(result)` for trace assertions.
 - Keep `HarnessRun`, `NormalizedSession`, usage, artifacts, and tool records JSON-serializable.
 - Keep judge model calls on judges. Use `createJudge("Name", assess)` for
   custom judges; use the provider-helper overload only when multiple judges
   reuse setup and need curried run options.
-- Put scenario-owned criteria on the input value; put per-run expectations or harness settings in `metadata`.
+- Put scenario-owned criteria on the input value. Put direct-check expected
+  values in Vitest case rows. Pass per-case judge criteria through explicit
+  matcher options, and suite-wide criteria through judge config.
 - Custom judges should use `createJudge(...)` for stable reporter labels.
 
 ## Verification

--- a/skills/vitest-evals/SOURCES.md
+++ b/skills/vitest-evals/SOURCES.md
@@ -21,7 +21,7 @@
 | `packages/vitest-evals/README.md` | high | high | install, core model, custom harnesses, judge matcher behavior | Use the core, custom harness, and matcher sections only. |
 | `packages/vitest-evals/src/index.ts` | high | high | `describeEval`, `run(...)`, automatic judges, matcher context behavior | Runtime API source of truth. |
 | `packages/vitest-evals/src/harness.ts` | high | high | `Harness`, `HarnessRun`, normalization helpers, session helpers | Runtime type source of truth. |
-| `packages/vitest-evals/src/judges/*` | high | high | judge context, built-in judge options, metadata behavior | Keep examples judge-first. |
+| `packages/vitest-evals/src/judges/*` | high | high | judge context, built-in judge options, judge result metadata behavior | Keep examples judge-first. |
 | `packages/vitest-evals/src/replay.ts` | high | high | replay modes, env vars, recording shape, cache key behavior | Use for shared replay guidance. |
 | `packages/harness-ai-sdk/README.md` and `src/index.ts` | high | high | AI SDK harness options, output selection, replay constraints | Keep option names exact. |
 | `packages/harness-ai-sdk/src/index.test.ts` | high | high | edge cases for agent/run entrypoints, partial runs, output and tool normalization, replay errors | Use as failure/workaround evidence. |
@@ -38,7 +38,7 @@
 | Put skill under `skills/vitest-evals` | adopted | User requested this path; no existing repo skill tree conflicted. |
 | Use reference-backed layout | adopted | First-party harnesses have distinct options and failure modes. |
 | Add one reference per supported harness path | adopted | Supported paths are custom `Harness`, AI SDK harness, and Pi AI harness. |
-| Add shared judge and replay references | adopted | Both first-party harnesses feed the same judge and reporter APIs; replay is implemented centrally. |
+| Add shared judge, utilities, and replay references | adopted | First-party harnesses feed the same judge, helper, and reporter APIs; replay is implemented centrally. |
 | Omit install scripts | deferred | A self-contained skill directory is enough now; no repo skill catalog or installer exists. |
 | Avoid alternate suite API guidance | adopted | User asked for the skill to stay purely harness-backed. |
 
@@ -46,10 +46,10 @@
 
 | Dimension | Status | Coverage |
 |-----------|--------|----------|
-| API surface and behavior contracts | covered | `describeEval`, `run`, `Harness`, `HarnessRun`, `JudgeContext`, first-party harness options, replay. |
+| API surface and behavior contracts | covered | `describeEval`, `run`, `Harness`, `HarnessRun`, `JudgeContext`, first-party harness options, utilities, replay. |
 | Config/runtime options | covered | suite options, harness options, replay env vars, package peer ranges. |
-| Downstream use cases | covered | new eval suite, table-driven cases, custom app harness, AI SDK `generateText`, AI SDK agent entrypoint, Pi agent default run, Pi custom run, native Pi tools, LLM-backed judge, deterministic tool/output judge, replayed tools. |
-| Issues and workarounds | covered | troubleshooting reference includes missing harness, duplicate executions, missing tool traces, non-JSON data, replay misses, provider-executed tools, async iterable replay outputs, hidden Pi tools, reset behavior, blank judge output, stale metadata, missing provider keys. |
+| Downstream use cases | covered | new eval suite, table-driven cases, custom app harness, AI SDK `generateText`, AI SDK agent entrypoint, Pi agent default run, Pi custom run, native Pi tools, LLM-backed judge, deterministic tool/output judge, session helpers, trace helpers, replayed tools. |
+| Issues and workarounds | covered | troubleshooting reference includes missing harness, duplicate executions, missing tool traces, non-JSON data, replay misses, provider-executed tools, async iterable replay outputs, hidden Pi tools, reset behavior, blank judge output, and missing provider keys. |
 | Version variance | partial | Peer ranges are captured from package manifests; future package releases should refresh option tables before release-sensitive edits. |
 | Reference discoverability | covered | Every runtime reference is directly routed from `SKILL.md`. |
 

--- a/skills/vitest-evals/references/custom-harness.md
+++ b/skills/vitest-evals/references/custom-harness.md
@@ -13,12 +13,11 @@ import {
   type HarnessRun,
 } from "vitest-evals/harness";
 
-const appHarness: Harness<AppInput, AppOutput, AppMetadata> = {
+const appHarness: Harness<AppInput, AppOutput> = {
   name: "app",
   run: async (input, context): Promise<HarnessRun<AppOutput>> => {
     const appResult = await runApp(input, {
       signal: context.signal,
-      metadata: context.metadata,
     });
 
     const output = toJsonValue(appResult.decision);
@@ -56,7 +55,7 @@ const appHarness: Harness<AppInput, AppOutput, AppMetadata> = {
 ## Implementation Rules
 
 - Run the app through its normal entrypoint.
-- Inject `context.signal`, `context.metadata`, and test doubles where the app supports them.
+- Inject `context.signal` and test doubles where the app supports them.
 - Use `context.setArtifact(name, value)` for JSON-safe diagnostics that should appear on the run.
 - Convert unknown values with `toJsonValue(...)`, `normalizeContent(...)`, or `normalizeMetadata(...)`.
 - Attach a partial run to thrown errors with `attachHarnessRunToError(...)` when meaningful trace data exists.

--- a/skills/vitest-evals/references/harness-ai-sdk.md
+++ b/skills/vitest-evals/references/harness-ai-sdk.md
@@ -42,7 +42,7 @@ const harness = aiSdkHarness({
 | `name` | Optional reporter label; defaults to `ai-sdk`. |
 
 Agent factories receive `{ input, context }` before execution so apps can
-derive instructions, metadata, or seeded state without side-channel setup.
+derive instructions or seeded state without side-channel setup.
 
 When LLM-backed judges need shared provider setup, keep that helper in the
 judge module. Do not put judge-model calls on the app harness:

--- a/skills/vitest-evals/references/harness-pi-ai.md
+++ b/skills/vitest-evals/references/harness-pi-ai.md
@@ -22,7 +22,7 @@ const harness = piAiHarness({
 
 `agent` can be an existing agent instance or a per-run factory. Factories
 receive `{ input, context }` when per-run instructions, native tool closures,
-metadata, or seeded artifacts are needed before instrumentation.
+or seeded artifacts are needed before instrumentation.
 
 If the agent needs a custom entrypoint:
 

--- a/skills/vitest-evals/references/judges-and-assertions.md
+++ b/skills/vitest-evals/references/judges-and-assertions.md
@@ -10,7 +10,6 @@ Every judge receives:
 |-------|---------|
 | `input` | Original typed eval input. |
 | `output` | Typed app output returned by the harness. |
-| `metadata` | Readonly per-run metadata. |
 | `toolCalls` | Flattened calls from `run.session`. |
 | `run` | Full normalized `HarnessRun`. |
 | `session` | Normalized session from the run. |
@@ -21,17 +20,20 @@ Every judge receives:
 ```ts
 import {
   createJudge,
-  type JudgeContext,
 } from "vitest-evals";
 
-const RefundRubricJudge = createJudge(
+const RefundRubricJudge = createJudge<
+  string,
+  RefundOutput,
+  { expectedStatus: string }
+>(
   "RefundRubricJudge",
-  async (ctx: JudgeContext<string, RefundOutput, CaseMeta>) => {
+  async (ctx) => {
     const verdict = await callJudgeModel({
       prompt: formatRubric({
         input: ctx.input,
         output: ctx.output,
-        expectedStatus: ctx.metadata.expectedStatus,
+        expectedStatus: ctx.expectedStatus,
       }),
     });
 
@@ -56,15 +58,16 @@ const RefundRubricJudge = createJudge(
 
 | Judge | Use |
 |-------|-----|
-| `FactualityJudge({ model })` | Model-grade normalized output against `metadata.expected` or explicit `expected`. |
-| `ToolCallJudge()` | Check expected tool names or arguments from `metadata.expectedTools` or explicit options. |
-| `StructuredOutputJudge()` | Check expected fields from `metadata.expected` or explicit options against `run.output`. |
+| `FactualityJudge({ judgeHarness, expected })` | Model-grade normalized output against suite-wide expected text. |
+| `ToolCallJudge({ expectedTools })` | Check suite-wide expected tool names or arguments. |
+| `StructuredOutputJudge({ expected })` | Check suite-wide expected fields against `run.output`. |
 
 ## Matcher Context Rules
 
 - `expect(result).toSatisfyJudge(...)` reuses the fixture-backed run context.
 - `expect(result.output).toSatisfyJudge(...)` can reuse the exact run when the output object came from that run.
-- Raw values outside an eval context need explicit `input`, `metadata`, `session`, `run`, or `harness` when the judge depends on them.
+- Raw values outside an eval context need explicit `input`, `session`, `run`,
+  `harness`, or custom judge params when the judge depends on them.
 - Normalized sessions infer output from the latest assistant message content.
 - Calling `ctx.harness.run(...)` inside a judge executes the app again; only do this when the judge intentionally needs a second run.
 

--- a/skills/vitest-evals/references/suite-authoring.md
+++ b/skills/vitest-evals/references/suite-authoring.md
@@ -10,12 +10,7 @@ import { describeEval, toolCalls } from "vitest-evals";
 
 describeEval("refund agent", { harness }, (it) => {
   it("approves a refundable invoice", async ({ run }) => {
-    const result = await run("Refund invoice inv_123", {
-      metadata: {
-        expectedStatus: "approved",
-        expectedTools: ["lookupInvoice", "createRefund"],
-      },
-    });
+    const result = await run("Refund invoice inv_123");
 
     expect(result.output).toMatchObject({ status: "approved" });
     expect(toolCalls(result.session).map((call) => call.name)).toEqual([
@@ -34,7 +29,7 @@ describeEval("refund agent", { harness }, (it) => {
 | Call `run(...)` inside the test body. | The test controls when the system under test executes. |
 | Assert domain behavior on `result.output`. | Harnesses preserve app-facing results separately from trace data. |
 | Assert trace behavior on `result.session`. | Reporter, replay, tools, and judges consume normalized sessions. |
-| Use `metadata` for per-run expectations or harness settings. | Judges receive it without polluting the scenario input. |
+| Keep expected values in the Vitest row or matcher options. | Case criteria stays close to the assertion that uses it. |
 | Use `it.for(...)` for case tables. | Keep table-driven suites idiomatic Vitest. |
 
 ## Core Options

--- a/skills/vitest-evals/references/tool-replay.md
+++ b/skills/vitest-evals/references/tool-replay.md
@@ -58,9 +58,9 @@ Use an object when the default cache key or recording needs adjustment:
 ```ts
 replay: {
   version: "v2",
-  key: (args, context) => ({
+  key: (args) => ({
     args,
-    tenant: context.metadata.tenant,
+    tenant: args.tenant,
   }),
   sanitize: (recording) => ({
     ...recording,

--- a/skills/vitest-evals/references/utilities.md
+++ b/skills/vitest-evals/references/utilities.md
@@ -1,0 +1,44 @@
+# Utilities
+
+Open this when assertions need normalized message, tool-call, or span history.
+
+## Session Helpers
+
+Use these helpers with `result.session` or `ctx.session`:
+
+| Helper | Use |
+|--------|-----|
+| `toolCalls(session)` | Flatten tool calls from normalized messages. |
+| `assistantMessages(session)` | Read assistant transcript turns. |
+| `userMessages(session)` | Read user transcript turns. |
+| `systemMessages(session)` | Read system transcript turns. |
+| `toolMessages(session)` | Read tool transcript turns. |
+| `messagesByRole(session, role)` | Read messages for any normalized role. |
+| `latestAssistantMessageContent(session)` | Read the latest non-empty assistant content. |
+
+```ts
+const calls = toolCalls(result.session);
+
+expect(calls.map((call) => call.name)).toEqual([
+  "lookupInvoice",
+  "createRefund",
+]);
+expect(latestAssistantMessageContent(result.session)).toContain("approved");
+```
+
+## Trace Helpers
+
+Use these helpers with a `HarnessRun` when behavior is represented by spans:
+
+| Helper | Use |
+|--------|-----|
+| `spans(result)` | Flatten every span from a harness run. |
+| `spansByKind(result, kind)` | Filter spans by `run`, `model`, `tool`, or another span kind. |
+| `failedSpans(result)` | Read spans with error status or normalized errors. |
+
+```ts
+expect(spansByKind(result, "tool").map((span) => span.name)).toContain(
+  "lookupInvoice",
+);
+expect(failedSpans(result)).toHaveLength(0);
+```


### PR DESCRIPTION
Remove input-side run metadata from the eval authoring API and docs. Expected criteria now live in case rows, explicit matcher options, or judge configuration, while normalized output/session/tool/replay metadata remains available for reports and diagnostics.

The docs IA now treats Getting Started as the primary onboarding path, keeps Harnesses and Judges as top-level reference areas, adds Reporting and Utilities sections, and updates the bundled vitest-evals skill with short session/trace utility guidance. The adapter public type surfaces also drop stale metadata generics so the TypeScript API matches the cleaned-up model.

Validated with pnpm typecheck, pnpm docs:check, pnpm docs:build, focused judge harness tests, core harness/factuality tests, adapter index tests, and git diff --check.