### PR TITLE
feat(core): Accept harness runs in helper APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ describeEval(
       expect(result.output).toMatchObject({
         status: expected.expectedStatus,
       });
-      expect(toolCalls(result.session).map((call) => call.name)).toEqual(
+      expect(toolCalls(result).map((call) => call.name)).toEqual(
         expected.expectedTools,
       );
       await expect(result).toSatisfyJudge(factualityJudge, {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -51,7 +51,8 @@ from `packages/core`:
 - `ToolCallRecord`
 - `UsageSummary`
 - `NormalizedTrace` and `NormalizedSpan`
-- helper accessors such as `toolCalls(session)` and `assistantMessages(session)`
+- helper accessors such as `toolCalls(result)`, `assistantMessages(result)`,
+  and `spansByKind(result, "tool")`
 
 The normalized session model lives in `packages/core` and is intentionally
 JSON-serializable so it can be persisted, attached to errors, and emitted by

--- a/docs/harness-first-rfc.md
+++ b/docs/harness-first-rfc.md
@@ -142,7 +142,7 @@ describeEval(
       const result = await run("Refund invoice inv_123");
 
       expect(result.output).toMatchObject({ status: "approved" });
-      expect(toolCalls(result.session)).toContainEqual(
+      expect(toolCalls(result)).toContainEqual(
         expect.objectContaining({ name: "lookupInvoice" }),
       );
     });

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -116,7 +116,7 @@ describeEval(
       const result = await run("Refund invoice inv_123");
 
       expect(result.output).toMatchObject({ status: "approved" });
-      expect(toolCalls(result.session).map((call) => call.name)).toEqual([
+      expect(toolCalls(result).map((call) => call.name)).toEqual([
         "lookupInvoice",
         "createRefund",
       ]);

--- a/packages/core/src/harness/helpers.ts
+++ b/packages/core/src/harness/helpers.ts
@@ -3,68 +3,102 @@ import type {
   NormalizedMessage,
   NormalizedSession,
   NormalizedSpan,
+  NormalizedTrace,
   ToolCallRecord,
 } from "./index";
+import type { JsonValue } from "../json";
 
 /**
- * Flattens every recorded tool call from a normalized session.
+ * Flattens every recorded tool call from a normalized run or session.
  *
- * @param session - Normalized session produced by a harness run.
+ * @param source - Normalized run or session produced by a harness.
  *
  * @example
  * ```ts
- * const names = toolCalls(result.session).map((call) => call.name);
+ * const names = toolCalls(result).map((call) => call.name);
  *
  * expect(names).toEqual(["lookupInvoice", "createRefund"]);
  * ```
  */
-export function toolCalls(session: NormalizedSession): ToolCallRecord[] {
-  return session.messages.flatMap((message) => message.toolCalls ?? []);
+export function toolCalls(run: HarnessRun): ToolCallRecord[];
+export function toolCalls(session: NormalizedSession): ToolCallRecord[];
+export function toolCalls(
+  source: HarnessRun | NormalizedSession,
+): ToolCallRecord[] {
+  return sessionFrom(source).messages.flatMap(
+    (message) => message.toolCalls ?? [],
+  );
 }
 
 /**
- * Flattens every recorded span from a normalized harness run.
+ * Flattens every recorded span from a normalized harness run or trace list.
  *
- * @param run - Normalized harness run produced by a harness.
+ * @param source - Normalized run or trace list produced by a harness.
  *
  * @example
  * ```ts
  * const modelSpans = spans(result).filter((span) => span.kind === "model");
  * ```
  */
-export function spans(run: HarnessRun): NormalizedSpan[] {
-  return (run.traces ?? []).flatMap((trace) => trace.spans);
+export function spans(run: HarnessRun): NormalizedSpan[];
+export function spans(
+  traces: readonly NormalizedTrace[] | undefined,
+): NormalizedSpan[];
+export function spans(
+  source: HarnessRun | readonly NormalizedTrace[] | undefined,
+): NormalizedSpan[] {
+  return spansFrom(source);
 }
 
 /**
  * Alias for `spans(...)` for consumers that prefer trace-oriented naming.
  *
- * @param run - Normalized harness run produced by a harness.
+ * @param source - Normalized run or trace list produced by a harness.
  */
-export function traceSpans(run: HarnessRun): NormalizedSpan[] {
-  return spans(run);
+export function traceSpans(run: HarnessRun): NormalizedSpan[];
+export function traceSpans(
+  traces: readonly NormalizedTrace[] | undefined,
+): NormalizedSpan[];
+export function traceSpans(
+  source: HarnessRun | readonly NormalizedTrace[] | undefined,
+): NormalizedSpan[] {
+  return spansFrom(source);
 }
 
 /**
- * Returns spans of one coarse operation kind from a normalized run.
+ * Returns spans of one coarse operation kind from a normalized run or trace list.
  *
- * @param run - Normalized harness run produced by a harness.
+ * @param source - Normalized run or trace list produced by a harness.
  * @param kind - Span kind to keep.
  */
 export function spansByKind(
   run: HarnessRun,
   kind: NonNullable<NormalizedSpan["kind"]>,
+): NormalizedSpan[];
+export function spansByKind(
+  traces: readonly NormalizedTrace[] | undefined,
+  kind: NonNullable<NormalizedSpan["kind"]>,
+): NormalizedSpan[];
+export function spansByKind(
+  source: HarnessRun | readonly NormalizedTrace[] | undefined,
+  kind: NonNullable<NormalizedSpan["kind"]>,
 ): NormalizedSpan[] {
-  return spans(run).filter((span) => span.kind === kind);
+  return spansFrom(source).filter((span) => span.kind === kind);
 }
 
 /**
  * Returns every span that explicitly failed or carries a normalized error.
  *
- * @param run - Normalized harness run produced by a harness.
+ * @param source - Normalized run or trace list produced by a harness.
  */
-export function failedSpans(run: HarnessRun): NormalizedSpan[] {
-  return spans(run).filter(
+export function failedSpans(run: HarnessRun): NormalizedSpan[];
+export function failedSpans(
+  traces: readonly NormalizedTrace[] | undefined,
+): NormalizedSpan[];
+export function failedSpans(
+  source: HarnessRun | readonly NormalizedTrace[] | undefined,
+): NormalizedSpan[] {
+  return spansFrom(source).filter(
     (span) => span.status === "error" || span.error !== undefined,
   );
 }
@@ -72,79 +106,109 @@ export function failedSpans(run: HarnessRun): NormalizedSpan[] {
 /**
  * Filters normalized session messages by role.
  *
- * @param session - Normalized session produced by a harness run.
+ * @param source - Normalized run or session produced by a harness.
  * @param role - Message role to keep.
  *
  * @example
  * ```ts
- * const assistantText = messagesByRole(result.session, "assistant")
+ * const assistantText = messagesByRole(result, "assistant")
  *   .map((message) => message.content)
  *   .join("\n");
  * ```
  */
 export function messagesByRole(
+  run: HarnessRun,
+  role: NormalizedMessage["role"],
+): NormalizedMessage[];
+export function messagesByRole(
   session: NormalizedSession,
   role: NormalizedMessage["role"],
+): NormalizedMessage[];
+export function messagesByRole(
+  source: HarnessRun | NormalizedSession,
+  role: NormalizedMessage["role"],
 ): NormalizedMessage[] {
-  return session.messages.filter((message) => message.role === role);
+  return sessionFrom(source).messages.filter(
+    (message) => message.role === role,
+  );
 }
 
 /**
  * Returns every normalized system message from a session.
  *
- * @param session - Normalized session produced by a harness run.
+ * @param source - Normalized run or session produced by a harness.
  *
  * @example
  * ```ts
- * const systemPrompts = systemMessages(result.session);
+ * const systemPrompts = systemMessages(result);
  * ```
  */
-export function systemMessages(session: NormalizedSession) {
-  return messagesByRole(session, "system");
+export function systemMessages(run: HarnessRun): NormalizedMessage[];
+export function systemMessages(session: NormalizedSession): NormalizedMessage[];
+export function systemMessages(
+  source: HarnessRun | NormalizedSession,
+): NormalizedMessage[] {
+  return messagesByRoleFromSource(source, "system");
 }
 
 /**
  * Returns every normalized user message from a session.
  *
- * @param session - Normalized session produced by a harness run.
+ * @param source - Normalized run or session produced by a harness.
  *
  * @example
  * ```ts
- * const firstPrompt = userMessages(result.session)[0]?.content;
+ * const firstPrompt = userMessages(result)[0]?.content;
  * ```
  */
-export function userMessages(session: NormalizedSession) {
-  return messagesByRole(session, "user");
+export function userMessages(run: HarnessRun): NormalizedMessage[];
+export function userMessages(session: NormalizedSession): NormalizedMessage[];
+export function userMessages(
+  source: HarnessRun | NormalizedSession,
+): NormalizedMessage[] {
+  return messagesByRoleFromSource(source, "user");
 }
 
 /**
  * Returns every normalized assistant message from a session.
  *
- * @param session - Normalized session produced by a harness run.
+ * @param source - Normalized run or session produced by a harness.
  *
  * @example
  * ```ts
- * const finalAnswer = assistantMessages(session).at(-1)?.content;
+ * const finalAnswer = assistantMessages(result).at(-1)?.content;
  * ```
  */
+export function assistantMessages(run: HarnessRun): NormalizedMessage[];
 export function assistantMessages(
   session: NormalizedSession,
+): NormalizedMessage[];
+export function assistantMessages(
+  source: HarnessRun | NormalizedSession,
 ): NormalizedMessage[] {
-  return messagesByRole(session, "assistant");
+  return messagesByRoleFromSource(source, "assistant");
 }
 
 /**
  * Returns the latest assistant message content, ignoring empty text messages.
  *
- * @param session - Normalized session produced by a harness run.
+ * @param source - Normalized run or session produced by a harness.
  *
  * @example
  * ```ts
- * const finalAnswer = latestAssistantMessageContent(result.session);
+ * const finalAnswer = latestAssistantMessageContent(result);
  * ```
  */
-export function latestAssistantMessageContent(session: NormalizedSession) {
-  return [...assistantMessages(session)]
+export function latestAssistantMessageContent(
+  run: HarnessRun,
+): JsonValue | undefined;
+export function latestAssistantMessageContent(
+  session: NormalizedSession,
+): JsonValue | undefined;
+export function latestAssistantMessageContent(
+  source: HarnessRun | NormalizedSession,
+) {
+  return [...messagesByRoleFromSource(source, "assistant")]
     .reverse()
     .find(hasNonEmptyMessageContent)?.content;
 }
@@ -152,15 +216,56 @@ export function latestAssistantMessageContent(session: NormalizedSession) {
 /**
  * Returns every normalized tool message from a session.
  *
- * @param session - Normalized session produced by a harness run.
+ * @param source - Normalized run or session produced by a harness.
  *
  * @example
  * ```ts
- * const toolOutputs = toolMessages(session).map((message) => message.content);
+ * const toolOutputs = toolMessages(result).map((message) => message.content);
  * ```
  */
-export function toolMessages(session: NormalizedSession) {
-  return messagesByRole(session, "tool");
+export function toolMessages(run: HarnessRun): NormalizedMessage[];
+export function toolMessages(session: NormalizedSession): NormalizedMessage[];
+export function toolMessages(
+  source: HarnessRun | NormalizedSession,
+): NormalizedMessage[] {
+  return messagesByRoleFromSource(source, "tool");
+}
+
+function sessionFrom(source: HarnessRun | NormalizedSession) {
+  return "session" in source ? source.session : source;
+}
+
+function tracesFrom(
+  source: HarnessRun | readonly NormalizedTrace[] | undefined,
+): readonly NormalizedTrace[] {
+  if (source === undefined) {
+    return [];
+  }
+  if (isTraceList(source)) {
+    return source;
+  }
+  return source.traces ?? [];
+}
+
+function spansFrom(
+  source: HarnessRun | readonly NormalizedTrace[] | undefined,
+): NormalizedSpan[] {
+  return tracesFrom(source).flatMap((trace) => trace.spans);
+}
+
+function isTraceList(
+  source: HarnessRun | readonly NormalizedTrace[],
+): source is readonly NormalizedTrace[] {
+  return Array.isArray(source);
+}
+
+function messagesByRoleFromSource(
+  source: HarnessRun | NormalizedSession,
+  role: NormalizedMessage["role"],
+) {
+  return sessionFrom(source).messages.filter(
+    (message) => message.role === role,
+  );
 }
 
 function hasNonEmptyMessageContent(message: NormalizedMessage) {

--- a/packages/core/src/index.test.ts
+++ b/packages/core/src/index.test.ts
@@ -572,22 +572,23 @@ describe("normalized run helpers", () => {
     const workspace = collectReportWorkspace(sampleJson);
     const run = workspace.cases[0]!.harness!.run!;
 
+    expect(toolCalls(run).map((call) => call.name)).toEqual(["lookupInvoice"]);
     expect(toolCalls(run.session).map((call) => call.name)).toEqual([
       "lookupInvoice",
     ]);
-    expect(
-      assistantMessages(run.session).map((message) => message.role),
-    ).toEqual(["assistant"]);
-    expect(userMessages(run.session).map((message) => message.role)).toEqual([
-      "user",
+    expect(assistantMessages(run).map((message) => message.role)).toEqual([
+      "assistant",
     ]);
-    expect(systemMessages(run.session)).toEqual([]);
-    expect(toolMessages(run.session)).toEqual([]);
-    expect(messagesByRole(run.session, "assistant")).toEqual(
-      assistantMessages(run.session),
-    );
-    expect(latestAssistantMessageContent(run.session)).toBe("denied");
+    expect(userMessages(run).map((message) => message.role)).toEqual(["user"]);
+    expect(systemMessages(run)).toEqual([]);
+    expect(toolMessages(run)).toEqual([]);
+    expect(messagesByRole(run, "assistant")).toEqual(assistantMessages(run));
+    expect(latestAssistantMessageContent(run)).toBe("denied");
     expect(spans(run).map((span) => span.id)).toEqual([
+      "trace_1:run",
+      "trace_1:tool:1",
+    ]);
+    expect(spans(run.traces).map((span) => span.id)).toEqual([
       "trace_1:run",
       "trace_1:tool:1",
     ]);
@@ -598,6 +599,10 @@ describe("normalized run helpers", () => {
     expect(spansByKind(run, "tool").map((span) => span.name)).toEqual([
       "lookupInvoice",
     ]);
+    expect(spansByKind(run.traces, "tool").map((span) => span.name)).toEqual([
+      "lookupInvoice",
+    ]);
     expect(failedSpans(run)).toEqual([]);
+    expect(failedSpans(run.traces)).toEqual([]);
   });
 });

--- a/packages/docs/public/llms.txt
+++ b/packages/docs/public/llms.txt
@@ -203,10 +203,10 @@ Import from `vitest-evals` for new suites.
 - `ToolCallJudge(config?)`: deterministic tool-call judge.
 - `StructuredOutputJudge(config?)`: deterministic structured-output judge.
 - `formatScores(...)`: format judge results for assertions and reporters.
-- `toolCalls(session)`: flatten tool calls from a normalized session.
-- `assistantMessages(session)`, `userMessages(session)`, `systemMessages(session)`,
-  `toolMessages(session)`, `messagesByRole(session, role)`: filter normalized
-  messages.
+- `toolCalls(result)`: flatten tool calls from a normalized run.
+- `assistantMessages(result)`, `userMessages(result)`, `systemMessages(result)`,
+  `toolMessages(result)`, `messagesByRole(result, role)`: filter normalized
+  messages from a run.
 - `createHarness(...)`, `normalizeHarnessRun(...)`: custom harness helpers.
 
 Important root types include:

--- a/packages/docs/src/content/docs/docs.mdx
+++ b/packages/docs/src/content/docs/docs.mdx
@@ -91,7 +91,7 @@ describeEval("refund agent", { harness: refundHarness }, (it) => {
     const result = await run("Refund invoice inv_123");
 
     expect(result.output).toMatchObject({ status: "approved" });
-    expect(toolCalls(result.session).map((call) => call.name)).toEqual([
+    expect(toolCalls(result).map((call) => call.name)).toEqual([
       "lookupInvoice",
       "createRefund",
     ]);
@@ -138,7 +138,7 @@ it.for([
   const result = await run(input);
 
   expect(result.output).toMatchObject({ status: expectedStatus });
-  expect(toolCalls(result.session).map((call) => call.name)).toEqual(
+  expect(toolCalls(result).map((call) => call.name)).toEqual(
     expectedTools,
   );
   await expect(result).toSatisfyJudge(factualityJudge, {

--- a/packages/docs/src/content/docs/docs/utilities.mdx
+++ b/packages/docs/src/content/docs/docs/utilities.mdx
@@ -12,11 +12,11 @@ They are most useful in direct Vitest checks and custom judges.
 <div class="api-link-grid">
   <a class="api-link-card" href="/docs/utilities/session-helpers/">
     <strong>Session Helpers</strong>
-    <span>Read messages and flattened tool calls from <code>result.session</code>.</span>
+    <span>Read messages and flattened tool calls from <code>result</code>.</span>
   </a>
   <a class="api-link-card" href="/docs/utilities/trace-helpers/">
     <strong>Trace Helpers</strong>
-    <span>Read spans and failures from <code>result.traces</code>.</span>
+    <span>Read spans and failures from <code>result</code>.</span>
   </a>
 </div>
 

--- a/packages/docs/src/content/docs/docs/utilities/session-helpers.mdx
+++ b/packages/docs/src/content/docs/docs/utilities/session-helpers.mdx
@@ -1,22 +1,22 @@
 ---
 title: Session Helpers
-description: Read normalized messages and tool calls from a harness session.
+description: Read normalized messages and tool calls from a harness run.
 editUrl: false
 ---
 
-Session helpers read `result.session`, the JSON-serializable transcript returned
-by every harness run. Use them in direct Vitest checks or inside custom judges
-through `ctx.session` and `ctx.toolCalls`.
+Session helpers read a harness run. Use them in direct Vitest checks or inside
+custom judges through `ctx.session` and `ctx.toolCalls`.
 
 ## Tool Calls
 
-Use `toolCalls(session)` for the flattened tool history.
+Use `toolCalls(result)` for the flattened tool history. The helpers also accept
+a normalized session when that is the only value available.
 
 ```ts title="evals/refund.eval.ts"
 import { expect } from "vitest";
 import { toolCalls } from "vitest-evals";
 
-const calls = toolCalls(result.session);
+const calls = toolCalls(result);
 
 expect(calls.map((call) => call.name)).toEqual([
   "lookupInvoice",
@@ -43,12 +43,12 @@ import {
   userMessages,
 } from "vitest-evals";
 
-expect(userMessages(result.session)[0]?.content).toBe("Refund invoice inv_123");
-expect(latestAssistantMessageContent(result.session)).toContain("approved");
-expect(assistantMessages(result.session).length).toBeGreaterThan(0);
-expect(toolMessages(result.session)).toHaveLength(1);
-expect(messagesByRole(result.session, "assistant")).toEqual(
-  assistantMessages(result.session),
+expect(userMessages(result)[0]?.content).toBe("Refund invoice inv_123");
+expect(latestAssistantMessageContent(result)).toContain("approved");
+expect(assistantMessages(result).length).toBeGreaterThan(0);
+expect(toolMessages(result)).toHaveLength(1);
+expect(messagesByRole(result, "assistant")).toEqual(
+  assistantMessages(result),
 );
 ```
 
@@ -67,7 +67,7 @@ expect(result.session.messages.map((message) => message.role)).toEqual([
 
 | Helper | Use |
 | --- | --- |
-| [`toolCalls`](/api/functions/toolcalls/) | Flatten tool calls from a session. |
+| [`toolCalls`](/api/functions/toolcalls/) | Flatten tool calls from a run. |
 | [`assistantMessages`](/api/functions/assistantmessages/) | Read assistant transcript turns. |
 | [`userMessages`](/api/functions/usermessages/) | Read user transcript turns. |
 | [`systemMessages`](/api/functions/systemmessages/) | Read system transcript turns. |

--- a/packages/docs/src/content/docs/docs/utilities/trace-helpers.mdx
+++ b/packages/docs/src/content/docs/docs/utilities/trace-helpers.mdx
@@ -4,10 +4,10 @@ description: Read normalized operation spans from a harness run.
 editUrl: false
 ---
 
-Trace helpers read `result.traces`, the normalized operation spans attached to a
-harness run. First-party harnesses attach native run, model, and tool spans when
-they observe them. Custom harnesses created with `createHarness()` get fallback
-run and tool spans unless they return their own traces.
+Trace helpers read a harness run. First-party harnesses attach native run,
+model, and tool spans when they observe them. Custom harnesses created with
+`createHarness()` get fallback run and tool spans unless they return their own
+traces.
 
 ## Span Checks
 
@@ -28,7 +28,8 @@ expect(spansByKind(result, "tool").map((span) => span.name)).toContain(
 expect(failedSpans(result)).toHaveLength(0);
 ```
 
-Use `spans(result)` when you need the full flattened span list.
+Use `spans(result)` when you need the full flattened span list. The helpers also
+accept a normalized trace array when that is the only value available.
 
 ```ts title="evals/refund.eval.ts"
 import { spans } from "vitest-evals";
@@ -40,6 +41,6 @@ expect(spans(result).some((span) => span.status === "error")).toBe(false);
 
 | Helper | Use |
 | --- | --- |
-| [`spans`](/api/functions/spans/) | Flatten every span from a harness run. |
+| [`spans`](/api/functions/spans/) | Flatten every span from a run. |
 | [`spansByKind`](/api/functions/spansbykind/) | Filter spans by `run`, `model`, `tool`, or another span kind. |
 | [`failedSpans`](/api/functions/failedspans/) | Read spans with error status or normalized errors. |

--- a/packages/harness-ai-sdk/README.md
+++ b/packages/harness-ai-sdk/README.md
@@ -50,7 +50,7 @@ describeEval("refund agent", { harness }, (it) => {
     expect(result.output).toMatchObject({
       status: "approved",
     });
-    expect(toolCalls(result.session).map((call) => call.name)).toContain(
+    expect(toolCalls(result).map((call) => call.name)).toContain(
       "lookupInvoice",
     );
   });

--- a/packages/harness-openai-agents/README.md
+++ b/packages/harness-openai-agents/README.md
@@ -36,7 +36,7 @@ describeEval("classifier agent", { harness }, (it) => {
     expect(result.output).toMatchObject({
       label: "bourbon",
     });
-    expect(toolCalls(result.session).map((call) => call.name)).toContain(
+    expect(toolCalls(result).map((call) => call.name)).toContain(
       "lookup_bottle",
     );
   });

--- a/packages/harness-pi-ai/README.md
+++ b/packages/harness-pi-ai/README.md
@@ -33,7 +33,7 @@ describeEval("refund agent", { harness }, (it) => {
     expect(result.output).toMatchObject({
       status: "approved",
     });
-    expect(toolCalls(result.session).map((call) => call.name)).toEqual([
+    expect(toolCalls(result).map((call) => call.name)).toEqual([
       "lookupInvoice",
       "createRefund",
     ]);

--- a/packages/vitest-evals/README.md
+++ b/packages/vitest-evals/README.md
@@ -33,9 +33,11 @@ workflow.
 - `run(input)` executes the harness explicitly and returns a normalized
   `HarnessRun`
 - the returned `result.output` is the app-facing value you assert on directly
-- the returned `result.session` is the canonical JSON-serializable transcript for
-  reporting, replay, tool assertions, and judges
-- the returned `result.traces` contains JSON-serializable operation spans; the
+- helper assertions usually read the returned `result`, for example
+  `toolCalls(result)` or `spansByKind(result, "tool")`
+- `result.session` is the canonical JSON-serializable transcript for reporting,
+  replay, tool assertions, and judges
+- `result.traces` contains JSON-serializable operation spans; the
   first-party harnesses attach run, model, and tool spans automatically, while
   `createHarness(...)` attaches fallback run and tool spans for custom harnesses
   that do not return traces themselves. Span attributes include typed
@@ -91,7 +93,7 @@ describeEval(
       const result = await run("Refund invoice inv_123");
 
       expect(result.output).toMatchObject({ status: "approved" });
-      expect(toolCalls(result.session).map((call) => call.name)).toEqual([
+      expect(toolCalls(result).map((call) => call.name)).toEqual([
         "lookupInvoice",
         "createRefund",
       ]);

--- a/packages/vitest-evals/src/harness.ts
+++ b/packages/vitest-evals/src/harness.ts
@@ -491,7 +491,7 @@ export function createHarness<
  *   usage: { provider: "openai", model: "gpt-4o-mini" },
  * });
  *
- * expect(toolCalls(run.session)).toHaveLength(1);
+ * expect(toolCalls(run)).toHaveLength(1);
  * ```
  */
 export function normalizeHarnessRun<

--- a/packages/vitest-evals/src/index.ts
+++ b/packages/vitest-evals/src/index.ts
@@ -536,7 +536,7 @@ function formatJudgeOutputForMessage(output: JsonValue | undefined) {
  *     const result = await run("Refund invoice inv_123");
  *
  *     expect(result.output).toMatchObject({ status: "approved" });
- *     expect(toolCalls(result.session)).toHaveLength(2);
+ *     expect(toolCalls(result)).toHaveLength(2);
  *     await expect(result).toSatisfyJudge(FactualityJudge(), {
  *       expected: "Invoice inv_123 should be refunded.",
  *       threshold: 0.6,

--- a/skills/vitest-evals/SKILL.md
+++ b/skills/vitest-evals/SKILL.md
@@ -32,8 +32,8 @@ Use the harness-backed API as the only authoring model.
 - Bind exactly one `harness` to a suite.
 - Call `run(input)` where the test should execute the system.
 - Assert on `result.output` for app-facing behavior.
-- Use `result.session` and helpers such as `toolCalls(session)` for trace assertions.
-- Use `spans(result)`, `spansByKind(result, kind)`, and `failedSpans(result)` for trace assertions.
+- Use `toolCalls(result)` and message helpers for normalized session assertions.
+- Use `spans(result)`, `spansByKind(result, kind)`, and `failedSpans(result)` for span assertions.
 - Keep `HarnessRun`, `NormalizedSession`, usage, artifacts, and tool records JSON-serializable.
 - Keep judge model calls on judges. Use `createJudge("Name", assess)` for
   custom judges; use the provider-helper overload only when multiple judges

--- a/skills/vitest-evals/references/judges-and-assertions.md
+++ b/skills/vitest-evals/references/judges-and-assertions.md
@@ -10,7 +10,7 @@ Every judge receives:
 |-------|---------|
 | `input` | Original typed eval input. |
 | `output` | Typed app output returned by the harness. |
-| `toolCalls` | Flattened calls from `run.session`. |
+| `toolCalls` | Flattened calls from the run. |
 | `run` | Full normalized `HarnessRun`. |
 | `session` | Normalized session from the run. |
 | `harness` | Suite harness for intentional second runs. |

--- a/skills/vitest-evals/references/suite-authoring.md
+++ b/skills/vitest-evals/references/suite-authoring.md
@@ -13,7 +13,7 @@ describeEval("refund agent", { harness }, (it) => {
     const result = await run("Refund invoice inv_123");
 
     expect(result.output).toMatchObject({ status: "approved" });
-    expect(toolCalls(result.session).map((call) => call.name)).toEqual([
+    expect(toolCalls(result).map((call) => call.name)).toEqual([
       "lookupInvoice",
       "createRefund",
     ]);
@@ -28,7 +28,7 @@ describeEval("refund agent", { harness }, (it) => {
 | Use one `harness` per `describeEval(...)` suite. | Core stores one normalized run per explicit execution. |
 | Call `run(...)` inside the test body. | The test controls when the system under test executes. |
 | Assert domain behavior on `result.output`. | Harnesses preserve app-facing results separately from trace data. |
-| Assert trace behavior on `result.session`. | Reporter, replay, tools, and judges consume normalized sessions. |
+| Assert trace behavior with helpers such as `toolCalls(result)` and `spansByKind(result, "tool")`. | Reporter, replay, tools, spans, and judges consume normalized run data. |
 | Keep expected values in the Vitest row or matcher options. | Case criteria stays close to the assertion that uses it. |
 | Use `it.for(...)` for case tables. | Keep table-driven suites idiomatic Vitest. |
 

--- a/skills/vitest-evals/references/utilities.md
+++ b/skills/vitest-evals/references/utilities.md
@@ -4,35 +4,38 @@ Open this when assertions need normalized message, tool-call, or span history.
 
 ## Session Helpers
 
-Use these helpers with `result.session` or `ctx.session`:
+Use these helpers with a `HarnessRun` such as `result`. They also accept a
+normalized session when that is the only value available.
 
 | Helper | Use |
 |--------|-----|
-| `toolCalls(session)` | Flatten tool calls from normalized messages. |
-| `assistantMessages(session)` | Read assistant transcript turns. |
-| `userMessages(session)` | Read user transcript turns. |
-| `systemMessages(session)` | Read system transcript turns. |
-| `toolMessages(session)` | Read tool transcript turns. |
-| `messagesByRole(session, role)` | Read messages for any normalized role. |
-| `latestAssistantMessageContent(session)` | Read the latest non-empty assistant content. |
+| `toolCalls(result)` | Flatten tool calls from normalized messages. |
+| `assistantMessages(result)` | Read assistant transcript turns. |
+| `userMessages(result)` | Read user transcript turns. |
+| `systemMessages(result)` | Read system transcript turns. |
+| `toolMessages(result)` | Read tool transcript turns. |
+| `messagesByRole(result, role)` | Read messages for any normalized role. |
+| `latestAssistantMessageContent(result)` | Read the latest non-empty assistant content. |
 
 ```ts
-const calls = toolCalls(result.session);
+const calls = toolCalls(result);
 
 expect(calls.map((call) => call.name)).toEqual([
   "lookupInvoice",
   "createRefund",
 ]);
-expect(latestAssistantMessageContent(result.session)).toContain("approved");
+expect(latestAssistantMessageContent(result)).toContain("approved");
 ```
 
 ## Trace Helpers
 
-Use these helpers with a `HarnessRun` when behavior is represented by spans:
+Use these helpers with a `HarnessRun` such as `result` when behavior is
+represented by spans. They also accept a normalized trace array when that is
+the only value available.
 
 | Helper | Use |
 |--------|-----|
-| `spans(result)` | Flatten every span from a harness run. |
+| `spans(result)` | Flatten every span from a run. |
 | `spansByKind(result, kind)` | Filter spans by `run`, `model`, `tool`, or another span kind. |
 | `failedSpans(result)` | Read spans with error status or normalized errors. |
 


### PR DESCRIPTION
Helper APIs now accept the full HarnessRun that eval tests already receive, so examples can consistently use result-first calls such as toolCalls(result), assistantMessages(result), and spansByKind(result, "tool"). The lower-level session and trace-array inputs remain supported for callers that only have normalized data.

The docs, README examples, API JSDoc, and local skill guidance now focus on that single common result-first spelling. Validated with the focused core test, typecheck, docs check, Biome lint on touched TypeScript files, and git diff --check.